### PR TITLE
Make big screenshots fit in a small window

### DIFF
--- a/lib/static/components/state/screenshot.js
+++ b/lib/static/components/state/screenshot.js
@@ -17,7 +17,10 @@ export default class Screenshot extends Component {
 
         return (
             <LazyLoad offsetVertical={800}>
-                <img src={url}/>
+                <img
+                    src={url}
+                    className="image-box__screenshot"
+                />
             </LazyLoad>
         );
     }

--- a/lib/static/styles.css
+++ b/lib/static/styles.css
@@ -51,6 +51,7 @@
 
 .image-box__exp-with-act {
     display: inline-block;
+    max-width: 100%;
 }
 
 .report_show-only-diff .image-box__exp-with-act,
@@ -63,6 +64,8 @@
     padding:  0 5px;
     display: inline-block;
     vertical-align: top;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .section__title {
@@ -73,6 +76,10 @@
     -webkit-user-select: none;
     -ms-user-select: none;
     user-select: none;
+}
+
+.image-box__screenshot {
+    width: 100%;
 }
 
 .section__title_skipped {


### PR DESCRIPTION
Hi!
I tried to use this reporper for screenshots with Retina-display, so I got really big screenshots (because they have size twice bigger that I set in the settings) and they weren't fit in a window:
https://pp.userapi.com/c841227/v841227183/5da4e/sN88XePETyI.jpg

It seems not so useful, so I fixed the styles to make screenshots fit:
https://pp.userapi.com/c841227/v841227183/5da44/zxNM5M13Xvc.jpg

What do you think about it?