### PR TITLE
Do not try to show image if screenshot has not been made

### DIFF
--- a/lib/report-builder-factory/report-builder.js
+++ b/lib/report-builder-factory/report-builder.js
@@ -63,7 +63,8 @@ module.exports = class ReportBuilder {
         this._addTestResult(result, {
             status,
             actualPath: getCurrentPath(formattedResult),
-            expectedPath: getReferencePath(formattedResult)
+            expectedPath: getReferencePath(formattedResult),
+            image: formattedResult.hasImageForSuccess
         });
     }
 
@@ -90,7 +91,7 @@ module.exports = class ReportBuilder {
         this._addTestResult(result, {
             actualPath: formattedResult.state ? getCurrentPath(formattedResult) : '',
             status: ERROR,
-            image: !!formattedResult.imagePath || !!formattedResult.currentPath || !!formattedResult.screenshot,
+            image: formattedResult.hasImageForError,
             reason: formattedResult.error
         });
     }

--- a/lib/static/components/state/index.js
+++ b/lib/static/components/state/index.js
@@ -31,14 +31,13 @@ export default class State extends Component {
         let elem = null;
 
         if (isErroredStatus(status)) {
-            elem = <StateError image={Boolean(image)} actual={actualPath} reason={reason}/>;
+            elem = <StateError image={image} actual={actualPath} reason={reason}/>;
         } else if (isSuccessStatus(status) || isUpdatedStatus(status)) {
-            elem = <StateSuccess expected={expectedPath}/>;
+            elem = <StateSuccess image={image} expected={expectedPath}/>;
         } else if (isFailStatus(status)) {
             elem = reason
                 ? <StateError image={true} actual={actualPath} reason={reason}/>
                 : <StateFail expected={expectedPath} actual={actualPath} diff={diffPath}/>;
-        }
 
         return (
             <Fragment>

--- a/lib/static/components/state/state-error.js
+++ b/lib/static/components/state/state-error.js
@@ -23,8 +23,8 @@ export default class StateError extends Component {
         );
     }
 
-    _drawImage(image, actual) {
-        return image ? <Screenshot imagePath={actual}/> : null;
+    _drawImage(image, path) {
+        return image ? <Screenshot imagePath={path}/> : null;
     }
 }
 

--- a/lib/static/components/state/state-success.js
+++ b/lib/static/components/state/state-success.js
@@ -6,14 +6,21 @@ import Screenshot from './screenshot';
 
 export default class StateSuccess extends Component {
     static propTypes = {
-        expected: PropTypes.string.isRequired
-    }
+        expected: PropTypes.string.isRequired,
+        image: PropTypes.bool.isRequired
+    };
 
     render() {
+        const {expected, image} = this.props;
+
         return (
             <div className="image-box__image">
-                <Screenshot imagePath={this.props.expected}/>
+                {this._drawImage(image, expected)}
             </div>
         );
+    }
+
+    _drawImage(image, path) {
+        return image ? <Screenshot imagePath={path}/> : null;
     }
 }

--- a/lib/test-adapter/gemini-test-adapter.js
+++ b/lib/test-adapter/gemini-test-adapter.js
@@ -52,4 +52,12 @@ module.exports = class GeminiTestResultAdapter extends TestAdapter {
     get imagePath() {
         return this._testResult.imagePath;
     }
+
+    get hasImageForError() {
+        return !!this.imagePath || !!this.currentPath;
+    }
+
+    get hasImageForSuccess() {
+        return true;
+    }
 };

--- a/lib/test-adapter/hermione-test-adapter.js
+++ b/lib/test-adapter/hermione-test-adapter.js
@@ -55,4 +55,12 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
     get description() {
         return this._testResult.description;
     }
+
+    get hasImageForError() {
+        return !!this.currentPath || !!this.screenshot;
+    }
+
+    get hasImageForSuccess() {
+        return false;
+    }
 };


### PR DESCRIPTION
Теперь все ок
![image](https://user-images.githubusercontent.com/25789153/36975061-ea3677c4-2089-11e8-90d1-db0009aa62ee.png)

Логика про поле `image` уже была при событии `ERROR`, я дублировал ее на событие `SUCCESS`. При событии `FAIL` скриншоты есть всегда.

Как раньше html-reporter не работал c `assertView`, так не работает и сейчас.