### PR TITLE
Render only affected parts of page

### DIFF
--- a/lib/static/components/section/section-base.js
+++ b/lib/static/components/section/section-base.js
@@ -7,7 +7,8 @@ import {isFailStatus, isSkippedStatus} from '../../../common-utils';
 
 export default class Base extends Component {
     static propTypes = {
-        view: PropTypes.object
+        expand: PropTypes.string,
+        showRetries: PropTypes.bool
     }
 
     constructor(props) {
@@ -20,7 +21,7 @@ export default class Base extends Component {
     }
 
     _shouldBeCollapsed({failed, retried, updated}) {
-        const {expand, showRetries} = this.props.view;
+        const {expand, showRetries} = this.props;
 
         if (expand === 'errors' && failed || updated) {
             return false;

--- a/lib/static/components/section/section-browser.js
+++ b/lib/static/components/section/section-browser.js
@@ -59,5 +59,5 @@ export class SectionBrowser extends SectionBase {
 }
 
 export default connect(
-    (state) => ({view: state.view})
+    ({view: {expand, showRetries}}) => ({expand, showRetries})
 )(SectionBrowser);

--- a/lib/static/components/section/section-common.js
+++ b/lib/static/components/section/section-common.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import {uniqueId} from 'lodash';
 import SectionBase from './section-base';
-import {SectionBrowser} from './section-browser';
+import SectionBrowser from './section-browser';
 import {allSkipped, allUpdated, hasFails, hasRetries} from '../../modules/utils';
 import Title from './title/simple';
 
@@ -36,7 +36,7 @@ export class SectionCommon extends SectionBase {
     }
 
     render() {
-        const {suite, view} = this.props;
+        const {suite, expand, showRetries} = this.props;
         const {
             name,
             suitePath,
@@ -55,10 +55,10 @@ export class SectionCommon extends SectionBase {
 
         const childrenTmpl = children.map((child) => {
             const key = uniqueId(`${suite.suitePath}-${suite.name}`);
-            return <SectionCommon key={key} suite={child} view={view}/>;
+            return <SectionCommon key={key} suite={child} expand={expand} showRetries={showRetries}/>;
         });
         const browserTmpl = browsers.map((browser) => {
-            return <SectionBrowser key={browser.name} browser={browser} suite={suite} view={view}/>;
+            return <SectionBrowser key={browser.name} browser={browser} suite={suite}/>;
         });
 
         return (
@@ -74,7 +74,5 @@ export class SectionCommon extends SectionBase {
 }
 
 export default connect(
-    (state) => ({
-        view: state.view
-    })
+    ({view: {expand, showRetries}}) => ({expand, showRetries})
 )(SectionCommon);

--- a/lib/static/components/suites.js
+++ b/lib/static/components/suites.js
@@ -11,7 +11,7 @@ import {initial, suiteBegin, testBegin, testResult, updateResult, testsEnd} from
 class Suites extends Component {
     static propTypes = {
         viewMode: PropTypes.string.isRequired,
-        skips: PropTypes.array
+        expand: PropTypes.string
     }
 
     componentDidMount() {
@@ -58,13 +58,13 @@ class Suites extends Component {
     }
 
     render() {
-        const {suites, viewMode} = this.props;
+        const {suites, viewMode, expand} = this.props;
 
         return (
             <div className="sections">
                 {suites[viewMode].map((suite) => {
                     const key = uniqueId(`${suite.suitePath}-${suite.name}`);
-                    return <SectionCommon key={key} suite={suite}/>;
+                    return <SectionCommon key={key} suite={suite} expand={expand}/>;
                 })}
             </div>
         );
@@ -76,6 +76,7 @@ const actions = {initial, testBegin, suiteBegin, testResult, updateResult, tests
 export default connect(
     (state) => ({
         viewMode: state.view.viewMode,
+        expand: state.view.expand,
         suites: state.suites,
         gui: state.gui
     }),

--- a/lib/static/modules/reducer.js
+++ b/lib/static/modules/reducer.js
@@ -3,7 +3,7 @@
 import url from 'url';
 import actionNames from './action-names';
 import defaultState from './default-state';
-import {assign, merge, filter, flatMap, cloneDeep, set} from 'lodash';
+import {assign, merge, filter, flatMap, cloneDeep, set, clone} from 'lodash';
 import {hasFails, isSuiteFailed, setStatusToAll, findNode, setStatusForBranch} from './utils';
 
 const compiledData = window.data || defaultState;
@@ -38,7 +38,7 @@ export default function reducer(state = getInitialState(compiledData), action) {
             return merge({}, state, {running: true, suites: {all: suites}}); // TODO: rewrite store on run all tests
         }
         case actionNames.RUN_FAILED_TESTS: {
-            return merge({}, state, {running: true});
+            return assign(clone(state), {running: true});
         }
         case actionNames.VIEW_INITIAL: {
             const {gui, suites, skips} = action.payload;
@@ -73,7 +73,7 @@ export default function reducer(state = getInitialState(compiledData), action) {
             return merge({}, state, {suites: {all: suites}});
         }
         case actionNames.TESTS_END: {
-            return merge({}, state, {running: false});
+            return assign(clone(state), {running: false});
         }
         case actionNames.TEST_RESULT: {
             return addTestResult(state, action);
@@ -82,38 +82,34 @@ export default function reducer(state = getInitialState(compiledData), action) {
             return addTestResult(state, action);
         }
         case actionNames.VIEW_EXPAND_ALL: {
-            return merge({}, state, {view: {expand: 'all'}});
+            return _mutateStateView(state, {expand: 'all'});
         }
         case actionNames.VIEW_EXPAND_ERRORS: {
-            return merge({}, state, {view: {expand: 'errors'}});
+            return _mutateStateView(state, {expand: 'errors'});
         }
         case actionNames.VIEW_COLLAPSE_ALL: {
-            return merge({}, state, {view: {expand: 'none'}});
+            return _mutateStateView(state, {expand: 'none'});
         }
         case actionNames.VIEW_SHOW_ALL: {
-            return merge({}, state, {view: {viewMode: 'all', expand: 'errors'}});
+            return _mutateStateView(state, {viewMode: 'all', expand: 'errors'});
         }
         case actionNames.VIEW_SHOW_FAILED: {
-            return merge({}, state, {view: {viewMode: 'failed', expand: 'errors'}});
+            return _mutateStateView(state, {viewMode: 'failed', expand: 'errors'});
         }
         case actionNames.VIEW_TOGGLE_SKIPPED: {
-            return merge({}, state, {view: {showSkipped: !state.view.showSkipped}});
+            return _mutateStateView(state, {showSkipped: !state.view.showSkipped});
         }
         case actionNames.VIEW_TOGGLE_RETRIES: {
-            return merge({}, state, {view: {showRetries: !state.view.showRetries}});
+            return _mutateStateView(state, {showRetries: !state.view.showRetries});
         }
         case actionNames.VIEW_TOGGLE_ONLY_DIFF: {
-            return merge({}, state, {view: {showOnlyDiff: !state.view.showOnlyDiff}});
+            return _mutateStateView(state, {showOnlyDiff: !state.view.showOnlyDiff});
         }
         case actionNames.VIEW_UPDATE_BASE_HOST: {
             const baseHost = action.host;
+            const parsedHost = _parseHost(baseHost);
 
-            return merge({}, state, {
-                view: {
-                    baseHost,
-                    parsedHost: _parseHost(baseHost)
-                }
-            });
+            return _mutateStateView(state, {baseHost, parsedHost});
         }
         default:
             return state;
@@ -137,6 +133,13 @@ function addTestResult(state, action) {
     const failed = filterFailedSuites(cloneDeep(suites));
 
     return assign({}, state, {suites: {all: suites, failed}});
+}
+
+function _mutateStateView(state, mutation) {
+    const newView = clone(state.view);
+    assign(newView, mutation);
+
+    return assign(clone(state), {view: newView});
 }
 
 function _loadBaseHost(configuredHost, storage) {


### PR DESCRIPTION
Наверное, замечали, что если в html-reporter нажимать на следующие кнопки и вводить данные в поля:
![image](https://user-images.githubusercontent.com/25789153/36900698-61d84084-1e35-11e8-9f78-c5e0be10de59.png)
заново раскрываются все сьюты, а на больших тестах отчет начинает тормозить. Так вот, это поведение было вызвано тем, что на каждое это действие заново рендерилось все дерево сьютов. Это поведение исправлено.

### P.S.
В ходе работы были найдены 2 проблемы:
1. Кнопка `ExpandRetries` работает некорректно.
![image](https://user-images.githubusercontent.com/25789153/37033791-318fe7f8-2158-11e8-9c62-5bbbfa269050.png)
В самом коде:
    ```js
    if (expand === 'errors' && failed || updated) {
        return false;
    } else if (showRetries && retried) {
        return false;
    }
    ```
    явно прописано, что она имеет меньшее значение, чем `Expand errors`. Это очень путает, не логично, и приводит к неправильному поведению. А самое главное, кнопка свою функцию не выполняет.
2. При клике на `ExpandAll`, `Collapse All` и `Expand Errors` дерево сьютов заново полностью рендерится. Это поведение не получилось исправить в рамках этой задачи, так как придется делать структурные изменения (не понятно какие пока), чтобы оптимизировать рендер.