### PR TITLE
Remove no-image icon after hermione success test

### DIFF
--- a/lib/report-builder-factory/report-builder.js
+++ b/lib/report-builder-factory/report-builder.js
@@ -60,10 +60,11 @@ module.exports = class ReportBuilder {
 
     _addSuccessResult(result, status) {
         const formattedResult = this.format(result);
+        const hasImage = formattedResult.imagePath || formattedResult.currentPath;
+
         this._addTestResult(result, {
             status,
-            actualPath: getCurrentPath(formattedResult),
-            expectedPath: getReferencePath(formattedResult)
+            expectedPath: hasImage ? getReferencePath(formattedResult) : null
         });
     }
 
@@ -87,10 +88,11 @@ module.exports = class ReportBuilder {
 
     _addErrorResult(result) {
         const formattedResult = this.format(result);
+        const hasImage = !!formattedResult.imagePath || !!formattedResult.currentPath || !!formattedResult.screenshot;
+
         this._addTestResult(result, {
-            actualPath: formattedResult.state ? getCurrentPath(formattedResult) : '',
+            actualPath: formattedResult.state && hasImage ? getCurrentPath(formattedResult) : null,
             status: ERROR,
-            image: !!formattedResult.imagePath || !!formattedResult.currentPath || !!formattedResult.screenshot,
             reason: formattedResult.error
         });
     }
@@ -122,6 +124,7 @@ module.exports = class ReportBuilder {
 
     _addTestResult(result, props) {
         result = this.format(result);
+        props = _.omitBy(props, _.isNil);
         const testResult = _.assign(this._createTestResult(result), props);
         const {browserId, suite} = result;
         const {status} = props;

--- a/lib/static/components/state/index.js
+++ b/lib/static/components/state/index.js
@@ -15,7 +15,6 @@ export default class State extends Component {
             suiteUrl: PropTypes.string.isRequired,
             metaInfo: PropTypes.object.isRequired,
             status: PropTypes.string,
-            image: PropTypes.bool,
             reason: PropTypes.object,
             expectedPath: PropTypes.string,
             actualPath: PropTypes.string,
@@ -25,13 +24,13 @@ export default class State extends Component {
     }
 
     render() {
-        const {suiteUrl, metaInfo, status, reason, image,
+        const {suiteUrl, metaInfo, status, reason,
             expectedPath, actualPath, diffPath, description} = this.props.state;
 
         let elem = null;
 
         if (isErroredStatus(status)) {
-            elem = <StateError image={Boolean(image)} actual={actualPath} reason={reason}/>;
+            elem = <StateError actual={actualPath} reason={reason}/>;
         } else if (isSuccessStatus(status) || isUpdatedStatus(status)) {
             elem = <StateSuccess expected={expectedPath}/>;
         } else if (isFailStatus(status)) {

--- a/lib/static/components/state/state-error.js
+++ b/lib/static/components/state/state-error.js
@@ -7,24 +7,23 @@ import Screenshot from './screenshot';
 
 export default class StateError extends Component {
     static propTypes = {
-        actual: PropTypes.string.isRequired,
-        image: PropTypes.bool.isRequired,
+        actual: PropTypes.string,
         reason: PropTypes.object.isRequired
     };
 
     render() {
-        const {image, reason, actual} = this.props;
+        const {reason, actual} = this.props;
 
         return (
             <div className="image-box__image">
                 <div className="reason">{reasonToElements(reason)}</div>
-                {this._drawImage(image, actual)}
+                {this._drawImage(actual)}
             </div>
         );
     }
 
-    _drawImage(image, actual) {
-        return image ? <Screenshot imagePath={actual}/> : null;
+    _drawImage(actual) {
+        return actual ? <Screenshot imagePath={actual}/> : null;
     }
 }
 

--- a/lib/static/components/state/state-success.js
+++ b/lib/static/components/state/state-success.js
@@ -6,13 +6,20 @@ import Screenshot from './screenshot';
 
 export default class StateSuccess extends Component {
     static propTypes = {
-        expected: PropTypes.string.isRequired
+        expected: PropTypes.string
     }
 
     render() {
+        return (this._drawImage(this.props.expected));
+    }
+
+    _drawImage(expected) {
+        if (!expected) {
+            return (null);
+        }
         return (
             <div className="image-box__image">
-                <Screenshot imagePath={this.props.expected}/>
+                <Screenshot imagePath={expected}/>
             </div>
         );
     }

--- a/lib/test-adapter/hermione-test-adapter.js
+++ b/lib/test-adapter/hermione-test-adapter.js
@@ -19,11 +19,11 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
     }
 
     get hasDiff() {
-        return this._testResult.err.type === IMAGE_DIFF_ERROR;
+        return this._testResult.err && this._testResult.err.type === IMAGE_DIFF_ERROR;
     }
 
     get error() {
-        return _.pick(this._testResult.err, ['message', 'stack', 'stateName']);
+        return this._testResult.err && _.pick(this._testResult.err, ['message', 'stack', 'stateName']);
     }
 
     get imageDir() {
@@ -41,15 +41,15 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
     }
 
     get referencePath() {
-        return this._testResult.err.refImagePath;
+        return this._testResult.err && this._testResult.err.refImagePath;
     }
 
     get currentPath() {
-        return this._testResult.err.currentImagePath;
+        return this._testResult.err && this._testResult.err.currentImagePath;
     }
 
     get screenshot() {
-        return this._testResult.err.screenshot;
+        return this._testResult.err && this._testResult.err.screenshot;
     }
 
     get description() {

--- a/test/lib/report-builder-factory/report-builder.js
+++ b/test/lib/report-builder-factory/report-builder.js
@@ -116,12 +116,12 @@ describe('ReportBuilder', () => {
 
         reportBuilder.addSuccess(stubTest_({
             browserId: 'bro1',
-            imageDir: 'some-image-dir'
+            imageDir: 'some-image-dir',
+            imagePath: 'some/path'
         }));
 
         assert.match(getReportBuilderResult_(reportBuilder), {
             status: SUCCESS,
-            actualPath: 'images/some-image-dir/bro1~current_0.png',
             expectedPath: 'images/some-image-dir/bro1~ref_0.png'
         });
     });


### PR DESCRIPTION
Раньше, чтобы понять, был ли сделан скриншот в `data.js` поле `result` каждого браузера (в определенных состояниях) имело поле `image: boolean`. Однако все `result` содержали `actualPath`. И создавалась ситуация, когда `result` имел поле `image: false`, но при этом `actualPath: "path"`, что выглядело очень неэстетично.

Отныне, поля `image` не будет. Если скриншота нет, поля `path` в `result` не будет тоже