### PR TITLE
fix(hack): do not close connection on event source error

### DIFF
--- a/lib/static/components/suites.js
+++ b/lib/static/components/suites.js
@@ -46,11 +46,6 @@ class Suites extends Component {
         eventSource.addEventListener(clientEvents.END, () => {
             this.props.actions.testsEnd();
         });
-
-        eventSource.onerror = () => {
-            console.error('Seems like servers went down. Closing connection...');
-            eventSource.close();
-        };
     }
 
     render() {


### PR DESCRIPTION
This is a temporary hack before the fix of the real problem in
chrome browser (unknown errors in a browser console) 
which causes closing of event source connection