### PR TITLE
fix: missed 'file' property in accepted result

### DIFF
--- a/lib/gui/tool-runner-factory/gemini/index.js
+++ b/lib/gui/tool-runner-factory/gemini/index.js
@@ -71,7 +71,7 @@ module.exports = class GeminiRunner extends BaseToolRunner {
         const {metaInfo: {sessionId, url: fullUrl}, attempt} = test;
 
         const testResult = {
-            suite: _.pick(currentState.suite, ['name', 'path', 'url']),
+            suite: _.pick(currentState.suite, ['file', 'name', 'path', 'url']),
             state: _.pick(currentState.state, 'name'),
             browserId: currentState.browserId
         };


### PR DESCRIPTION
`metaInfo` looses `file` property in serialized `data.js` when user clicked ''Accept' button in `gui`.

1. Cleanup html reporter results
2. Open gui with `gemini gui` and run tests.
3. Click 'Accept' button on test result
4. Check for `data.js` in test results directory

```
                metaInfo: {
                  url: "/user/profile",
       !!!        file: "gemini\\client\\common0.js",
                  sessionId: "620f9e87992b35f3de509b881d08f03d"
                },
```