### PR TITLE
feat: sticky toolbar

### DIFF
--- a/lib/static/styles.css
+++ b/lib/static/styles.css
@@ -1,3 +1,6 @@
+body {
+    margin: 0;
+}
 .report {
     font: 14px Helvetica Neue, Arial, sans-serif;
 }
@@ -486,4 +489,17 @@ a:active {
                 transform: scale(1);
         opacity: 1;
     }
+}
+
+.control-buttons {
+    background: #f6f5f3;
+    border-bottom: 1px solid #ccc;
+    position: sticky;
+    padding: 5px;
+    top: 0;
+    z-index: 1;
+}
+
+.sections {
+    margin: 20px 0 0 10px;
 }


### PR DESCRIPTION
PR sticks command buttons toolbar to the page top so the buttons are always on screen. The change is applicable to the both html report and gui.