### PR TITLE
feat: Sticky "Accept" button

### DIFF
--- a/lib/static/styles.css
+++ b/lib/static/styles.css
@@ -352,6 +352,16 @@ a:active {
     display: block;
 }
 
+.tab__item .button_type_suite-controls {
+    position: sticky;
+    top: 0;
+    border-color: #bbb;
+}
+
+.tab__item .button_type_suite-controls:hover {
+    border-color: #555;
+}
+
 .tab-switcher, .cswitcher {
     display: inline-block;
     vertical-align: top;


### PR DESCRIPTION
Accepting tall screenshots requires scrolling forth and back several times: scroll forth to compare the screenshots, and then scroll back to the "Accept" button. Sticky button minimizes scrolling.