### PR TITLE
fix: copyImageAsync uses non-promisified method

### DIFF
--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -44,7 +44,7 @@ function createPath(kind, result, stateName) {
 
 function copyImageAsync(srcPath, destPath) {
     return makeDirFor(destPath)
-        .then(() => fs.copy(srcPath, destPath));
+        .then(() => fs.copyAsync(srcPath, destPath));
 }
 
 /**

--- a/test/lib/server-utils.js
+++ b/test/lib/server-utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs-extra');
 const utils = require('../../lib/server-utils');
 
 describe('server-utils', () => {
@@ -98,6 +99,28 @@ describe('server-utils', () => {
             utils.prepareCommonJSData({some: 'data'});
 
             assert.calledOnceWith(JSON.stringify, {some: 'data'});
+        });
+    });
+
+    describe('copyImageAsync', () => {
+        const sandbox = sinon.sandbox.create();
+
+        beforeEach(() => {
+            sandbox.stub(fs, 'copyAsync').resolves();
+            sandbox.stub(fs, 'mkdirsAsync').resolves();
+        });
+
+        afterEach(() => sandbox.restore());
+
+        it('should create directory and copy image', () => {
+            const fromPath = '/from/image.png',
+                toPath = '/to/image.png';
+
+            return utils.copyImageAsync(fromPath, toPath)
+                .then(() => {
+                    assert.calledWithMatch(fs.mkdirsAsync, '/to');
+                    assert.calledWithMatch(fs.copyAsync, fromPath, toPath);
+                });
         });
     });
 });


### PR DESCRIPTION
It should use `fs.copyAsync` instead of `fs.copy`, because `fs.copy` expects callback (and it have not warnings about that)
Also found similair in hermione: https://github.com/gemini-testing/hermione/blob/4e6e7b99ebb39d470535d10805818f40ea6f46e1/lib/browser/commands/assert-view/capture-processors/update-refs.js#L5