### PR TITLE
fix: catch unhandled reject in prepareImages

### DIFF
--- a/hermione.js
+++ b/hermione.js
@@ -61,21 +61,21 @@ function prepareImages(hermione, pluginConfig, reportBuilder) {
         let queue = Promise.resolve();
 
         hermione.on(hermione.events.TEST_PASS, (testResult) => {
-            queue = queue.then(() => saveTestImages(reportBuilder.format(testResult), reportPath));
+            queue = queue.then(() => saveTestImages(reportBuilder.format(testResult), reportPath)).catch(reject);
         });
 
         hermione.on(hermione.events.RETRY, (testResult) => {
-            queue = queue.then(() => failHandler(testResult));
+            queue = queue.then(() => failHandler(testResult)).catch(reject);
         });
 
         hermione.on(hermione.events.TEST_FAIL, (testResult) => {
-            queue = queue.then(() => failHandler(testResult));
+            queue = queue.then(() => failHandler(testResult)).catch(reject);
         });
 
         hermione.on(hermione.events.TEST_PENDING, (testResult) => {
-            queue = queue.then(() => failHandler(testResult));
+            queue = queue.then(() => failHandler(testResult)).catch(reject);
         });
 
-        hermione.on(hermione.events.RUNNER_END, () => queue.then(resolve, reject));
+        hermione.on(hermione.events.RUNNER_END, () => queue.then(resolve));
     });
 }


### PR DESCRIPTION
One Error thrown from failHandler produce many "unhandled rejection" message.
Simple demo. 
Code:

> process.on('unhandledRejection', (reason, p) => {
>     console.error('Unhandled Rejection:\nPromise: ', p, '\nReason: ', reason);
> });
> 
> let queue = Promise.resolve();
> setTimeout(() => {
>     queue = queue.then(() => Promise.reject(new Error('111')));
> }, 0);
> 
> setTimeout(() => queue
>     .then(
>         ()=>{console.log('ok')}, 
>         (err)=>console.log('\nCatched error:  ' + err)
>     ), 100);

Output:

> Unhandled Rejection:
> Promise:  Promise {
>   <rejected> Error: 111
>     at queue.then (/Users/catwithapple/Downloads/test.js:7:45)
>     at <anonymous> }
> Reason:  Error: 111
>     at queue.then (/Users/catwithapple/Downloads/test.js:7:45)
>     at <anonymous>
> (node:39727) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 2)
>
> Catched error: 111