### PR TITLE
fix(merge-reports): do not fail in case of intersecting suite and state names

### DIFF
--- a/lib/merge-reports/data-tree.js
+++ b/lib/merge-reports/data-tree.js
@@ -80,6 +80,7 @@ module.exports = class DataTree {
             this._data.suites.push(suite);
         } else {
             const existentParentSuite = findNode(this._data.suites, suite.suitePath.slice(0, -1));
+            existentParentSuite.children = existentParentSuite.children || [];
             existentParentSuite.children.push(suite);
         }
 
@@ -89,6 +90,7 @@ module.exports = class DataTree {
 
     async _addBrowserResult(bro, suitePath) {
         const existentParentSuite = findNode(this._data.suites, suitePath);
+        existentParentSuite.browsers = existentParentSuite.browsers || [];
         existentParentSuite.browsers.push(bro);
 
         this._mergeStatistics(bro);

--- a/test/lib/merge-reports/data-tree.js
+++ b/test/lib/merge-reports/data-tree.js
@@ -106,6 +106,80 @@ describe('lib/merge-reports/data-tree', () => {
             assert.deepEqual(suites[0].children[0].browsers[0], srcDataSuites2.children[0].browsers[0]);
         });
 
+        it('should add data to state from suite with the same name', async () => {
+            const srcDataSuites1 = mkSuite({
+                suitePath: ['suite'],
+                children: [mkState({
+                    suitePath: ['suite', 'state'],
+                    browsers: [mkBrowserResult()]
+                })]
+            });
+            const srcDataSuites2 = mkSuite({
+                suitePath: ['suite'],
+                children: [mkSuite({
+                    suitePath: ['suite', 'state'],
+                    children: [mkState({
+                        suitePath: ['suite', 'state', 'state'],
+                        browsers: [mkBrowserResult()]
+                    })]
+                })]
+            });
+            const expected = mkSuite({
+                suitePath: ['suite'],
+                children: [mkState({
+                    suitePath: ['suite', 'state'],
+                    browsers: [mkBrowserResult()],
+                    children: [mkState({
+                        suitePath: ['suite', 'state', 'state'],
+                        browsers: [mkBrowserResult()]
+                    })]
+                })]
+            });
+
+            const initialData = {suites: [srcDataSuites1]};
+            const dataCollection = {'src-report/path': {suites: [srcDataSuites2]}};
+            const {suites} = await mkDataTree_(initialData).mergeWith(dataCollection);
+
+            assert.deepEqual(suites[0], expected);
+        });
+
+        it('should add data to suite from state with the same name', async () => {
+            const srcDataSuites1 = mkSuite({
+                suitePath: ['suite'],
+                children: [mkSuite({
+                    suitePath: ['suite', 'state'],
+                    children: [mkState({
+                        suitePath: ['suite', 'state', 'state'],
+                        browsers: [mkBrowserResult()]
+                    })]
+                })]
+            });
+            const srcDataSuites2 = mkSuite({
+                suitePath: ['suite'],
+                children: [mkState({
+                    suitePath: ['suite', 'state'],
+                    browsers: [mkBrowserResult()]
+                })]
+            });
+            const expected = mkSuite({
+                suitePath: ['suite'],
+                children: [mkState({
+                    suitePath: ['suite', 'state'],
+                    browsers: [mkBrowserResult()],
+                    children: [mkState({
+                        suitePath: ['suite', 'state', 'state'],
+                        browsers: [mkBrowserResult()]
+                    })]
+                })]
+            });
+
+            const initialData = {suites: [srcDataSuites1]};
+            const dataCollection = {'src-report/path': {suites: [srcDataSuites2]}};
+            const {suites} = await mkDataTree_(initialData).mergeWith(dataCollection);
+
+            assert.deepEqual(suites[0], expected);
+        });
+
         describe('from existent browser with correct modified "attempt" field', () => {
             it('should merge browser results if there are no successful tests', async () => {
                 const srcDataSuites1 = mkSuiteTree({


### PR DESCRIPTION
Мерж отчетов упадет, если первый сгенерирован вот такой иерархией сьютов:

```js
describe('suite', () => {
    it('test1', function() {
    
    });
});
```
а второй вот такой:

```js
describe('suite', () => {
    describe('test1', function() {
        it('test', () => {
            
        })
    });
});
```

Ошибка:

```
Html-reporter runtime error: TypeError: Cannot read property 'push' of undefined
```
