### PR TITLE
fix: show error info in tab which failed without any images

### DIFF
--- a/lib/static/components/section/body/index.js
+++ b/lib/static/components/section/body/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import {isEmpty} from 'lodash';
+import {isEmpty, defaults} from 'lodash';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
@@ -128,6 +128,7 @@ class Body extends Component {
 
     _drawTab(state, key = '', opts = {}) {
         const {result: {name: browserId}, suite: {suitePath}} = this.props;
+        opts = defaults({error: state.error}, opts);
 
         return (
             <div key={key} className="tab">

--- a/test/lib/static/components/section/body.js
+++ b/test/lib/static/components/section/body.js
@@ -91,6 +91,14 @@ describe('<Body />', () => {
         assert.lengthOf(component.find('.tab'), 2);
     });
 
+    it('should render tab with error item if test errored without images', () => {
+        const testResult = mkTestResult_({status: ERROR, error: {foo: 'bar'}, imagesInfo: []});
+
+        const component = mkConnectedComponent(<Body result={testResult} suite={mkSuite_()} />);
+
+        assert.lengthOf(component.find('.error__item'), 1);
+    });
+
     describe('should call "toggleTestResult" action on', () => {
         it('mount', () => {
             const testResult = mkTestResult_({name: 'bro'});


### PR DESCRIPTION
В случае если тест падает с ошибками и в нем отсутствует "imagesInfo", то необходимо в опции метода drawTab добавлять ошибку из теста.

https://github.com/gemini-testing/html-reporter/pull/207/files#diff-4cc0e96c3f6c956d87595ed2822ad234R114