### PR TITLE
fix(gui): handle test skipping in runtime

### DIFF
--- a/lib/gui/tool-runner-factory/hermione/report-subscriber.js
+++ b/lib/gui/tool-runner-factory/hermione/report-subscriber.js
@@ -3,16 +3,16 @@
 const clientEvents = require('../../constants/client-events');
 const {RUNNING} = require('../../../constants/test-statuses');
 const {getSuitePath} = require('../../../plugin-utils').getHermioneUtils();
-const {findTestResult} = require('../utils');
-const {saveTestImages, saveBase64Screenshot} = require('../../../reporter-helpers');
+const utils = require('../utils');
+const reporterHelper = require('../../../reporter-helpers');
 
 module.exports = (hermione, reportBuilder, client, reportPath) => {
     function failHandler(testResult) {
         const formattedResult = reportBuilder.format(testResult);
-        const actions = [saveTestImages(formattedResult, reportPath)];
+        const actions = [reporterHelper.saveTestImages(formattedResult, reportPath)];
 
         if (formattedResult.screenshot) {
-            actions.push(saveBase64Screenshot(formattedResult, reportPath));
+            actions.push(reporterHelper.saveBase64Screenshot(formattedResult, reportPath));
         }
 
         return Promise.all(actions);
@@ -42,9 +42,9 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
 
     hermione.on(hermione.events.TEST_PASS, (data) => {
         const formattedTest = reportBuilder.addSuccess(data);
-        const testResult = findTestResult(reportBuilder.getSuites(), formattedTest.prepareTestResult());
+        const testResult = utils.findTestResult(reportBuilder.getSuites(), formattedTest.prepareTestResult());
 
-        saveTestImages(formattedTest, reportPath)
+        reporterHelper.saveTestImages(formattedTest, reportPath)
             .then(() => client.emit(clientEvents.TEST_RESULT, testResult));
     });
 
@@ -55,7 +55,7 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
             ? reportBuilder.addFail(data)
             : reportBuilder.addError(data);
 
-        const testResult = findTestResult(reportBuilder.getSuites(), formattedResult.prepareTestResult());
+        const testResult = utils.findTestResult(reportBuilder.getSuites(), formattedResult.prepareTestResult());
         failHandler(data)
             .then(() => client.emit(clientEvents.TEST_RESULT, testResult));
     });
@@ -64,6 +64,16 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
         reportBuilder.addRetry(data);
 
         failHandler(data);
+    });
+
+    hermione.on(hermione.events.TEST_PENDING, (data) => {
+        reportBuilder.addSkipped(data);
+
+        const formattedResult = reportBuilder.format(data);
+        const testResult = utils.findTestResult(reportBuilder.getSuites(), formattedResult.prepareTestResult());
+
+        return failHandler(data)
+            .then(() => client.emit(clientEvents.TEST_RESULT, testResult));
     });
 
     hermione.on(hermione.events.RUNNER_END, () => {


### PR DESCRIPTION
// cc @DudaGod @rostik404

Если при запуске тестов через gui для одного из них стриггерить событие `TEST_PENDING`, то gui не отреагирует на это, т.к. мы не были подписаны на это событие. В результате, в gui тест подвиснет в состоянии выполнения тестов.