### PR TITLE
fix: forever yellow tests in gui mode after running all tests

### DIFF
--- a/lib/static/modules/reducer.js
+++ b/lib/static/modules/reducer.js
@@ -79,7 +79,7 @@ export default function reducer(state = getInitialState(compiledData), action) {
         }
         case actionNames.RUN_ALL_TESTS: {
             const suites = clone(state.suites);
-            setStatusToAll(suites, action.payload.status);
+            Object.values(suites).map(suite => setStatusToAll(suite, action.payload.status));
 
             // TODO: rewrite store on run all tests
             return merge({}, state, {running: true, suites, view: {groupByError: false}});


### PR DESCRIPTION
console error:
redux-logger.js?a9ae:1 Uncaught TypeError: Cannot read property ‘join’ of undefined
   at extract (group-errors.js?5a18:34)
   at extractErrors (group-errors.js?5a18:58)
   at groupErrors (group-errors.js?5a18:14)
   at addTestResult (reducer.js?9280:251)
   at reducer (reducer.js?9280:130)
   at dispatch (createStore.js?f974:165)
   at eval (redux-logger.js?a9ae:1)
   at eval (index.js?3446:11)
   at Object.eval [as testResult] (bindActionCreators.js?83c3:3)
   at EventSource.eval (main-tree.js?647a:39)