### PR TITLE
fix(gui): idle status for suite if some of browsers has such status

### DIFF
--- a/lib/common-utils.js
+++ b/lib/common-utils.js
@@ -3,10 +3,10 @@
 const {SUCCESS, FAIL, ERROR, SKIPPED, UPDATED, IDLE, RUNNING, QUEUED} = require('./constants/test-statuses');
 const statusPriority = [
     // non-final
-    RUNNING, QUEUED, IDLE,
+    RUNNING, QUEUED,
 
     // final
-    ERROR, FAIL, UPDATED, SUCCESS, SKIPPED
+    ERROR, FAIL, UPDATED, SUCCESS, SKIPPED, IDLE
 ];
 
 exports.isSuccessStatus = (status) => status === SUCCESS;

--- a/test/lib/common-utils.js
+++ b/test/lib/common-utils.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const {determineStatus} = require('lib/common-utils');
+const {SUCCESS, IDLE} = require('lib/constants/test-statuses');
+
+describe('common-utils', () => {
+    describe('determineStatus', () => {
+        it(`should not rewrite suite status to ${IDLE} if some test already has final status`, () => {
+            const status = determineStatus([SUCCESS, IDLE]);
+
+            assert.equal(status, SUCCESS);
+        });
+    });
+});

--- a/test/lib/report-builder-factory/report-builder.js
+++ b/test/lib/report-builder-factory/report-builder.js
@@ -357,14 +357,14 @@ describe('ReportBuilder', () => {
         });
 
         describe('for several browsers', () => {
-            it('should rewrite suite status if new status has "forced" type', () => {
+            it('should not rewrite suite status to IDLE if some test still has such status', () => {
                 const reportBuilder = mkReportBuilder_();
 
                 reportBuilder.addFail(stubTest_({browserId: 'bro'}));
                 reportBuilder.addIdle(stubTest_({browserId: 'another-bro'}));
 
                 const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, IDLE);
+                assert.equal(suiteResult.status, FAIL);
             });
 
             it('should determine "error" if first test has "error"', () => {


### PR DESCRIPTION
Fix case when suite has some test with IDLE status and all branch will be marked as idle, but others tests has final status (success, fail etc)