### PR TITLE
fix(screenshot): support windows paths

### DIFF
--- a/lib/static/components/state/screenshot.js
+++ b/lib/static/components/state/screenshot.js
@@ -85,7 +85,7 @@ class Screenshot extends Component {
 
 function encodeUri(imagePath) {
     return imagePath
-        .split('/')
+        .split(/\/|\\/)
         .map((item) => encodeURIComponent(item))
         .join('/');
 }


### PR DESCRIPTION
Allow correct urls to be generated for images in the report on windows.

Fixes #27