### PR TITLE
feat: collapse viewport screenshot on test fail

### DIFF
--- a/lib/static/components/section/body/description.js
+++ b/lib/static/components/section/body/description.js
@@ -1,9 +1,9 @@
 'use strict';
 
-import React, {Component, Fragment} from 'react';
+import React, {Component} from 'react';
 import Markdown from 'react-markdown';
 import PropTypes from 'prop-types';
-import ToggleOpen from './toggle-open';
+import ToggleOpen from '../../toggle-open';
 
 export default class Description extends Component {
     static propTypes = {
@@ -13,10 +13,6 @@ export default class Description extends Component {
     render() {
         const mdContent = <Markdown source={this.props.content}/>;
 
-        return (
-            <Fragment>
-                <ToggleOpen title='Description' content={mdContent}/>
-            </Fragment>
-        );
+        return <ToggleOpen title='Description' content={mdContent} extendClassNames="toggle-open_type_text"/>;
     }
 }

--- a/lib/static/components/section/body/meta-info.js
+++ b/lib/static/components/section/body/meta-info.js
@@ -1,10 +1,10 @@
 'use strict';
 
 import url from 'url';
-import React, {Component, Fragment} from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {map} from 'lodash';
-import ToggleOpen from './toggle-open';
+import ToggleOpen from '../../toggle-open';
 
 const mkLinkToUrl = (url, text = url) => {
     return <a data-suite-view-link={url} className="section__icon_view-local" target="_blank" href={url}>{text}</a>;
@@ -43,10 +43,6 @@ export default class MetaInfo extends Component {
         const formattedMetaInfo = Object.assign({}, metaInfo, extraMetaInfo, {url: mkLinkToUrl(suiteUrl, metaInfo.url)});
         const metaElements = metaToElements(formattedMetaInfo);
 
-        return (
-            <Fragment>
-                <ToggleOpen title='Meta-info' content={metaElements}/>
-            </Fragment>
-        );
+        return <ToggleOpen title='Meta-info' content={metaElements} extendClassNames="toggle-open_type_text"/>;
     }
 }

--- a/lib/static/components/state/screenshot.js
+++ b/lib/static/components/state/screenshot.js
@@ -27,15 +27,17 @@ class Screenshot extends Component {
             })
         }).isRequired,
         diffClusters: PropTypes.array,
-        lazyLoadOffset: PropTypes.number
+        lazyLoadOffset: PropTypes.number,
+        noLazyLoad: PropTypes.bool
     }
 
     static defaultProps = {
-        noCache: false
+        noCache: false,
+        noLazyLoad: false
     }
 
     _getScreenshotComponent(elem, diffClusters, placeholder = null) {
-        const {lazyLoadOffset: offset} = this.props;
+        const {lazyLoadOffset: offset, noLazyLoad} = this.props;
 
         const rawElem = <Fragment>
             {diffClusters && diffClusters.map((c, id) => <DiffCircle
@@ -48,7 +50,7 @@ class Screenshot extends Component {
             {elem}
         </Fragment>;
 
-        return offset
+        return offset && !noLazyLoad
             ? <LazyLoad offset={offset} debounce={50} placeholder={placeholder} once>{rawElem}</LazyLoad>
             : rawElem;
     }

--- a/lib/static/components/state/state-error.js
+++ b/lib/static/components/state/state-error.js
@@ -4,6 +4,8 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {map} from 'lodash';
 import Screenshot from './screenshot';
+import ToggleOpen from '../toggle-open';
+import {isNoRefImageError} from '../../modules/utils';
 
 export default class StateError extends Component {
     static propTypes = {
@@ -16,7 +18,7 @@ export default class StateError extends Component {
         const {image, error, actualImg} = this.props;
 
         return (
-            <div className="image-box__image">
+            <div className="image-box__image image-box__image_single">
                 <div className="error">{errorToElements(error)}</div>
                 {this._drawImage(image, actualImg)}
             </div>
@@ -24,7 +26,13 @@ export default class StateError extends Component {
     }
 
     _drawImage(image, actualImg) {
-        return image ? <Screenshot image={actualImg}/> : null;
+        if (!image) {
+            return null;
+        }
+
+        return isNoRefImageError(this.props.error)
+            ? <Screenshot image={actualImg} />
+            : <ToggleOpen title="Page screenshot" content={<Screenshot image={actualImg} noLazyLoad={true} />} />;
     }
 }
 

--- a/lib/static/components/toggle-open.js
+++ b/lib/static/components/toggle-open.js
@@ -7,7 +7,8 @@ import classNames from 'classnames';
 export default class ToggleOpen extends Component {
     static propTypes = {
         title: PropTypes.string.isRequired,
-        content: PropTypes.oneOfType([PropTypes.element, PropTypes.array])
+        content: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
+        extendClassNames: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
     }
 
     state = {
@@ -15,10 +16,11 @@ export default class ToggleOpen extends Component {
     }
 
     render() {
-        const {title, content} = this.props;
+        const {title, content, extendClassNames} = this.props;
         const className = classNames(
             'toggle-open',
-            {'toggle-open_collapsed': this.state.isCollapsed}
+            {'toggle-open_collapsed': this.state.isCollapsed},
+            extendClassNames
         );
 
         return (

--- a/lib/static/modules/utils.js
+++ b/lib/static/modules/utils.js
@@ -13,8 +13,13 @@ function hasFailedImages(result) {
         || isErroredStatus(status) || isFailStatus(status);
 }
 
+function isNoRefImageError(error) {
+    const stack = get(error, 'stack', '');
+    return stack.startsWith(NO_REF_IMAGE_ERROR);
+}
+
 function hasNoRefImageErrors({imagesInfo = []}) {
-    return Boolean(imagesInfo.filter((v) => get(v, 'error.stack', '').startsWith(NO_REF_IMAGE_ERROR)).length);
+    return Boolean(imagesInfo.filter(({error}) => isNoRefImageError(error)).length);
 }
 
 function hasFails(node) {
@@ -29,9 +34,7 @@ function isSuiteFailed(suite) {
 }
 
 function isAcceptable({status, error}) {
-    const stack = get(error, 'stack', '');
-
-    return isErroredStatus(status) && stack.startsWith(NO_REF_IMAGE_ERROR) || isFailStatus(status);
+    return isErroredStatus(status) && isNoRefImageError(error) || isFailStatus(status);
 }
 
 function hasRetries(node) {
@@ -177,6 +180,7 @@ function shouldBrowserBeShown({browser, fullTestName, filteredBrowsers = [], err
 }
 
 module.exports = {
+    isNoRefImageError,
     hasNoRefImageErrors,
     hasFails,
     isSuiteFailed,

--- a/lib/static/styles.css
+++ b/lib/static/styles.css
@@ -135,6 +135,10 @@
     max-width: 100%;
 }
 
+.image-box__image.image-box__image_single {
+    display: block;
+}
+
 .image-box__screenshot {
     max-width: 100%;
 }
@@ -430,7 +434,7 @@ a:active {
     cursor: pointer;
 }
 
-.toggle-open__content {
+.toggle-open_type_text .toggle-open__content {
     margin: 5px 0;
     background: #f6f5f3;
     padding: 5px;

--- a/test/lib/static/components/section/screenshot.js
+++ b/test/lib/static/components/section/screenshot.js
@@ -47,5 +47,14 @@ describe('Screenshot component', () => {
 
             assert.lengthOf(screenshotComponent.find(Placeholder), 1);
         });
+
+        it('should not use lazyLoad wrapper if "noLazyLoad" prop was set', () => {
+            const screenshotComponent = mkConnectedComponent(
+                <Screenshot image={{path: '', size: {}}} noLazyLoad={true} />,
+                {initialState: {view: {lazyLoadOffset: 100}}}
+            );
+
+            assert.lengthOf(screenshotComponent.find(LazyLoad), 0);
+        });
     });
 });


### PR DESCRIPTION
by default screenshot is collapsed (but not NoRefImage screenshot)
![image](https://user-images.githubusercontent.com/1658415/59765588-14f05800-92a7-11e9-894a-ff4e4c7aebde.png)
