### PR TITLE
fix(merge-reports): do not try to move images specified as urls

### DIFF
--- a/lib/merge-reports/data-tree.js
+++ b/lib/merge-reports/data-tree.js
@@ -147,6 +147,10 @@ module.exports = class DataTree {
 
     async _moveImages(node, {newAttempt, fromFields}) {
         await Promise.map(getImagePaths(node, fromFields), async (imgPath) => {
+            if (/^http(s)?:\/\//.test(imgPath)) {
+                return;
+            }
+
             const srcImgPath = path.resolve(this._srcPath, imgPath);
             const destImgPath = path.resolve(
                 this._destPath,

--- a/lib/merge-reports/report-builder.js
+++ b/lib/merge-reports/report-builder.js
@@ -45,15 +45,6 @@ module.exports = class ReportBuilder {
             .value();
     }
 
-    async _copyToReportDir(files, {from, to}) {
-        await Promise.map(files, async (dataName) => {
-            const srcDataPath = path.resolve(from, dataName);
-            const destDataPath = path.resolve(to, dataName);
-
-            await fs.move(srcDataPath, destDataPath);
-        });
-    }
-
     async _saveDataFile(data) {
         const formattedData = serverUtils.prepareCommonJSData(data);
         const destDataPath = path.resolve(this.destPath, 'data.js');

--- a/test/unit/lib/merge-reports/data-tree.js
+++ b/test/unit/lib/merge-reports/data-tree.js
@@ -600,6 +600,48 @@ describe('lib/merge-reports/data-tree', () => {
             );
         });
 
+        it('should not move image specified as http url', async () => {
+            const srcDataSuites1 = mkSuiteTree();
+            const srcDataSuites2 = mkSuiteTree({
+                browsers: [mkBrowserResult({
+                    name: 'yabro',
+                    result: mkTestResult({imagesInfo: [{
+                        actualImg: {path: 'http://host.com/screens/yabro/actual.png'},
+                        expectedImg: {path: 'http://host.com/screens/yabro/expected.png'},
+                        diffImg: {path: 'http://host.com/screens/yabro/diff.png'}
+                    }]})
+                })]
+            });
+
+            const initialData = {suites: [srcDataSuites1]};
+            const dataCollection = {'src-report/path': {suites: [srcDataSuites2]}};
+
+            await mkDataTree_(initialData).mergeWith(dataCollection);
+
+            assert.notCalled(fs.move);
+        });
+
+        it('should not move image specified as https url', async () => {
+            const srcDataSuites1 = mkSuiteTree();
+            const srcDataSuites2 = mkSuiteTree({
+                browsers: [mkBrowserResult({
+                    name: 'yabro',
+                    result: mkTestResult({imagesInfo: [{
+                        actualImg: {path: 'https://host.com/screens/yabro/actual.png'},
+                        expectedImg: {path: 'https://host.com/screens/yabro/expected.png'},
+                        diffImg: {path: 'https://host.com/screens/yabro/diff.png'}
+                    }]})
+                })]
+            });
+
+            const initialData = {suites: [srcDataSuites1]};
+            const dataCollection = {'src-report/path': {suites: [srcDataSuites2]}};
+
+            await mkDataTree_(initialData).mergeWith(dataCollection);
+
+            assert.notCalled(fs.move);
+        });
+
         [
             {keyName: 'actualImg', imgPaths: ['images/yabro~current_0.png', 'images/yabro~current_1.png']},
             {keyName: 'expectedImg', imgPaths: ['images/yabro~ref_0.png', 'images/yabro~ref_1.png']},


### PR DESCRIPTION
cc @DudaGod @rostik404 

У нас будут все изображения выгружаться в s3, то есть отчеты не будут фактически содержать папки images, поэтому при мерже нужно учитывать это.

Прошу обратить внимание на первый коммит, в котором (как мне кажется) удаляется неиспользуемый код.