### PR TITLE
fix: metaInfo serialization

### DIFF
--- a/lib/static/components/section/body/meta-info.js
+++ b/lib/static/components/section/body/meta-info.js
@@ -3,7 +3,7 @@
 import url from 'url';
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {map} from 'lodash';
+import {map, mapValues, isObject} from 'lodash';
 import ToggleOpen from '../../toggle-open';
 
 const mkLinkToUrl = (url, text = url) => {
@@ -20,6 +20,8 @@ const isUrl = (str) => {
     return parsedUrl.host && parsedUrl.protocol;
 };
 
+const serializeMetaValues = (metaInfo) => mapValues(metaInfo, (v) => isObject(v) ? JSON.stringify(v) : v);
+
 const metaToElements = (metaInfo) => {
     return map(metaInfo, (value, key) => {
         if (isUrl(value)) {
@@ -35,12 +37,17 @@ export default class MetaInfo extends Component {
         metaInfo: PropTypes.object.isRequired,
         suiteUrl: PropTypes.string.isRequired,
         getExtraMetaInfo: PropTypes.func.isRequired
-    }
+    };
 
     render() {
         const {metaInfo, suiteUrl, getExtraMetaInfo} = this.props;
+        const serializedMetaValues = serializeMetaValues(metaInfo);
         const extraMetaInfo = getExtraMetaInfo();
-        const formattedMetaInfo = Object.assign({}, metaInfo, extraMetaInfo, {url: mkLinkToUrl(suiteUrl, metaInfo.url)});
+        const formattedMetaInfo = {
+            ...serializedMetaValues,
+            ...extraMetaInfo,
+            url: mkLinkToUrl(suiteUrl, metaInfo.url)
+        };
         const metaElements = metaToElements(formattedMetaInfo);
 
         return <ToggleOpen title='Meta-info' content={metaElements} extendClassNames="toggle-open_type_text"/>;

--- a/test/unit/lib/static/components/section/body/meta-info.js
+++ b/test/unit/lib/static/components/section/body/meta-info.js
@@ -34,4 +34,23 @@ describe('<MetaInfo />', () => {
             assert.equal(node.text(), expectedMetaInfo[i]);
         });
     });
+
+    it('should render meta-info with non-primitive values', () => {
+        const expectedMetaInfo = [
+            'foo1: {"bar":"baz"}',
+            'foo2: [{"bar":"baz"}]',
+            'url: some-url'
+        ];
+
+        const metaInfo = {
+            foo1: {bar: 'baz'},
+            foo2: [{bar: 'baz'}]
+        };
+
+        const component = mkMetaInfoComponent({metaInfo, suiteUrl: 'some-url'});
+
+        component.find('.toggle-open__item').forEach((node, i) => {
+            assert.equal(node.text(), expectedMetaInfo[i]);
+        });
+    });
 });


### PR DESCRIPTION
Fix issue with rendering Meta-info when meta is object :)

![image](https://user-images.githubusercontent.com/21066057/61497152-443dd600-a9c7-11e9-8373-99dcddbf3752.png)
