### PR TITLE
fix: overflow meta and error text on report

### DIFF
--- a/lib/static/styles.css
+++ b/lib/static/styles.css
@@ -305,6 +305,10 @@
     font-weight: bold;
 }
 
+.toggle-open__item {
+    word-wrap: break-word;
+}
+
 .error {
     background: #f6f5f3;
     padding: 5px;
@@ -318,6 +322,7 @@
 
 .error__item {
     white-space: pre-wrap;
+    word-wrap: break-word;
 }
 
 .state-button {


### PR DESCRIPTION
Исправлен выход текста за границу блока в мета-информации и в сообщении об ошибках.

Было:
<img width="1356" alt="Снимок экрана 2019-08-08 в 10 39 53" src="https://user-images.githubusercontent.com/24471472/62684349-28778f80-b9c9-11e9-9175-b09166580a00.png">

Стало:
<img width="1396" alt="Снимок экрана 2019-08-08 в 10 29 23" src="https://user-images.githubusercontent.com/24471472/62684142-b56e1900-b9c8-11e9-97d1-7a3813a9ae79.png">
