### PR TITLE
feat: make links from meta-info values

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ directory.
 Array element must be `Object` ({'*name*': `String`, '*pattern*': `String`}) or `String` (interpret as *name* and *pattern*).
 Test will be associated with group if test error matches on group error pattern.
 New group will be created if test cannot be associated with existing groups.
+* **metaInfoBaseUrls** (optional) `Object` - base paths for making link from Meta-info values. Object option must be Meta-info's key and value must be `String`. For example, {'file': 'base/path'}.
 
 Also there is ability to override plugin parameters by CLI options or environment variables
 (see [configparser](https://github.com/gemini-testing/configparser)).

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,6 +41,17 @@ const assertErrorPatterns = (errorPatterns) => {
     }
 };
 
+const assertMetaInfoBaseUrls = (metaInfoBaseUrls) => {
+    if (!_.isObject(metaInfoBaseUrls)) {
+        throw new Error(`"metaInfoBaseUrls" option must be object, but got ${typeof metaInfoBaseUrls}`);
+    }
+    for (const key in metaInfoBaseUrls) {
+        if (!_.isString(metaInfoBaseUrls[key])) {
+            throw new Error(`Value of "${key}" in "metaInfoBaseUrls" option must be string, but got ${typeof metaInfoBaseUrls[key]}`);
+        }
+    }
+};
+
 const mapErrorPatterns = (errorPatterns) => {
     return errorPatterns.map(patternInfo => {
         if (typeof patternInfo === 'string') {
@@ -89,6 +100,12 @@ const getParser = () => {
             parseEnv: JSON.parse,
             validate: assertErrorPatterns,
             map: mapErrorPatterns
+        }),
+        metaInfoBaseUrls: option({
+            defaultValue: configDefaults.metaInfoBaseUrls,
+            parseEnv: JSON.parse,
+            parseCli: JSON.parse,
+            validate: assertMetaInfoBaseUrls
         })
     }), {envPrefix: ENV_PREFIX, cliPrefix: CLI_PREFIX});
 };

--- a/lib/constants/defaults.js
+++ b/lib/constants/defaults.js
@@ -7,6 +7,7 @@ module.exports = {
         baseHost: '',
         scaleImages: false,
         lazyLoadOffset: 800,
-        errorPatterns: []
+        errorPatterns: [],
+        metaInfoBaseUrls: {}
     }
 };

--- a/lib/report-builder-factory/report-builder.js
+++ b/lib/report-builder-factory/report-builder.js
@@ -233,14 +233,14 @@ module.exports = class ReportBuilder {
     }
 
     getResult() {
-        const {defaultView, baseHost, scaleImages, lazyLoadOffset, errorPatterns} = this._pluginConfig;
+        const {defaultView, baseHost, scaleImages, lazyLoadOffset, errorPatterns, metaInfoBaseUrls} = this._pluginConfig;
 
         this._sortTree();
 
         return _.extend({
             skips: _.uniq(this._skips, JSON.stringify),
             suites: this._tree.children,
-            config: {defaultView, baseHost, scaleImages, lazyLoadOffset, errorPatterns},
+            config: {defaultView, baseHost, scaleImages, lazyLoadOffset, errorPatterns, metaInfoBaseUrls},
             apiValues: this._apiValues,
             date: new Date().toString()
         }, this._stats);

--- a/lib/static/components/section/body/meta-info.js
+++ b/lib/static/components/section/body/meta-info.js
@@ -1,6 +1,9 @@
 'use strict';
 
+import path from 'path';
+import url from 'url';
 import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import {map, mapValues, isObject} from 'lodash';
 import ToggleOpen from '../../toggle-open';
@@ -12,25 +15,30 @@ const mkLinkToUrl = (url, text = url) => {
 
 const serializeMetaValues = (metaInfo) => mapValues(metaInfo, (v) => isObject(v) ? JSON.stringify(v) : v);
 
-const metaToElements = (metaInfo) => {
+const metaToElements = (metaInfo, metaInfoBaseUrls) => {
     return map(metaInfo, (value, key) => {
         if (isUrl(value)) {
             value = mkLinkToUrl(value);
+        } else if (metaInfoBaseUrls[key]) {
+            const baseUrl = metaInfoBaseUrls[key];
+            const link = isUrl(baseUrl) ? url.resolve(baseUrl, value) : path.join(baseUrl, value);
+            value = mkLinkToUrl(link, value);
         }
 
         return <div key = {key} className="toggle-open__item"><span className="toggle-open__item-key">{key}</span>: {value}</div>;
     });
 };
 
-export default class MetaInfo extends Component {
+class MetaInfo extends Component {
     static propTypes = {
         metaInfo: PropTypes.object.isRequired,
         suiteUrl: PropTypes.string.isRequired,
-        getExtraMetaInfo: PropTypes.func.isRequired
+        getExtraMetaInfo: PropTypes.func.isRequired,
+        metaInfoBaseUrls: PropTypes.object.isRequired
     };
 
     render() {
-        const {metaInfo, suiteUrl, getExtraMetaInfo} = this.props;
+        const {metaInfo, suiteUrl, getExtraMetaInfo, metaInfoBaseUrls} = this.props;
         const serializedMetaValues = serializeMetaValues(metaInfo);
         const extraMetaInfo = getExtraMetaInfo();
         const formattedMetaInfo = {
@@ -38,8 +46,15 @@ export default class MetaInfo extends Component {
             ...extraMetaInfo,
             url: mkLinkToUrl(suiteUrl, metaInfo.url)
         };
-        const metaElements = metaToElements(formattedMetaInfo);
+
+        const metaElements = metaToElements(formattedMetaInfo, metaInfoBaseUrls);
 
         return <ToggleOpen title='Meta-info' content={metaElements} extendClassNames="toggle-open_type_text"/>;
     }
 }
+
+export default connect(
+    (state) => ({
+        metaInfoBaseUrls: state.config.metaInfoBaseUrls
+    })
+)(MetaInfo);

--- a/test/unit/lib/config.js
+++ b/test/unit/lib/config.js
@@ -17,6 +17,7 @@ describe('config', () => {
         delete process.env['html_reporter_base_host'];
         delete process.env['html_reporter_scale_images'];
         delete process.env['html_reporter_lazy_load_offset'];
+        delete process.env['html_reporter_meta_info_base_urls'];
     });
 
     describe('"enabled" option', () => {
@@ -166,6 +167,38 @@ describe('config', () => {
 
         it('should validate if passed value is number', () => {
             assert.throws(() => parseConfig({lazyLoadOffset: 'some-value'}), /option must be number, but got string/);
+        });
+    });
+
+    describe('"metaInfoBaseUrls" option', () => {
+        it('should set from configuration file', () => {
+            const config = parseConfig({
+                metaInfoBaseUrls: {
+                    file: 'base/path'
+                }
+            });
+
+            assert.deepEqual(config.metaInfoBaseUrls, {file: 'base/path'});
+        });
+
+        it('should be set from environment variable', () => {
+            process.env['html_reporter_meta_info_base_urls'] = '{"file": "base/path"}';
+
+            assert.deepEqual(parseConfig({}).metaInfoBaseUrls, {file: 'base/path'});
+        });
+
+        it('should be set from cli', () => {
+            process.argv = process.argv.concat('--html-reporter-meta-info-base-urls', '{"file":"base/path"}');
+
+            assert.deepEqual(parseConfig({}).metaInfoBaseUrls, {file: 'base/path'});
+        });
+
+        it('should validate if passed value is string', () => {
+            assert.throws(() => parseConfig({metaInfoBaseUrls: 'some/urls'}), /option must be object, but got string/);
+        });
+
+        it('should validate if passed to object value is number', () => {
+            assert.throws(() => parseConfig({metaInfoBaseUrls: {file: 10}}), /option must be string, but got number/);
         });
     });
 });

--- a/test/unit/lib/report-builder-factory/report-builder.js
+++ b/test/unit/lib/report-builder-factory/report-builder.js
@@ -17,7 +17,7 @@ describe('ReportBuilder', () => {
 
     const mkReportBuilder_ = ({toolConfig, pluginConfig} = {}) => {
         toolConfig = _.defaults(toolConfig || {}, {getAbsoluteUrl: _.noop});
-        pluginConfig = _.defaults(pluginConfig || {}, {baseHost: '', path: ''});
+        pluginConfig = _.defaults(pluginConfig || {}, {baseHost: '', path: '', baseTestPath: ''});
 
         const browserConfigStub = {getAbsoluteUrl: toolConfig.getAbsoluteUrl};
         const config = {forBrowser: sandbox.stub().returns(browserConfigStub)};

--- a/test/unit/lib/static/components/section/body/meta-info.js
+++ b/test/unit/lib/static/components/section/body/meta-info.js
@@ -8,14 +8,14 @@ describe('<MetaInfo />', () => {
 
     let getExtraMetaInfo;
 
-    const mkMetaInfoComponent = (props = {}) => {
+    const mkMetaInfoComponent = (props = {}, initialState = {}) => {
         props = defaults(props, {
             metaInfo: {},
             suiteUrl: 'default-url',
             getExtraMetaInfo
         });
 
-        return mkConnectedComponent(<MetaInfo {...props} />);
+        return mkConnectedComponent(<MetaInfo {...props} />, {initialState});
     };
 
     beforeEach(() => {
@@ -51,6 +51,28 @@ describe('<MetaInfo />', () => {
 
         component.find('.toggle-open__item').forEach((node, i) => {
             assert.equal(node.text(), expectedMetaInfo[i]);
+        });
+    });
+
+    [
+        {
+            type: 'path',
+            metaInfoBaseUrls: {file: 'base/path'},
+            expectedFileUrl: 'base/path/test/file'
+        },
+        {
+            type: 'url',
+            metaInfoBaseUrls: {file: 'http://127.0.0.1'},
+            expectedFileUrl: 'http://127.0.0.1/test/file'
+        }
+    ].forEach((stub) => {
+        it(`should render link in meta info based upon metaInfoBaseUrls ${stub.type}`, () => {
+            const initialConfig = {config: {metaInfoBaseUrls: stub.metaInfoBaseUrls}};
+
+            const component = mkMetaInfoComponent({metaInfo: {file: 'test/file'}}, initialConfig);
+
+            assert.equal(component.find('.toggle-open__item:first-child').text(), 'file: test/file');
+            assert.equal(component.find('.toggle-open__item:first-child a').prop('href'), stub.expectedFileUrl);
         });
     });
 });


### PR DESCRIPTION
В конфиге появилась новая опция `metaInfoBaseUrls`, позволяющая указать базовые Url'ы для значений Мета-информации, чтобы сделать из них соответствующие ссылки.

Напрмер, так выглядит ссылка на файл:
<img width="830" alt="Снимок экрана 2019-08-15 в 16 07 17" src="https://user-images.githubusercontent.com/24471472/63096606-022c9380-bf77-11e9-82a1-5c95f878de75.png">

