### PR TITLE
fix: header controls too close to each other when they wrap

### DIFF
--- a/lib/static/styles.css
+++ b/lib/static/styles.css
@@ -613,11 +613,15 @@ a:active {
 }
 
 .control-buttons {
-    margin:5px 0
+    margin: 5px 0;
+}
+
+.control-buttons .button {
+    margin-bottom: 5px;
 }
 
 .control-filters {
-    margin:5px 0;
+    margin: 5px 0;
 }
 
 .diff-circle {


### PR DESCRIPTION
Before and after:
![image](https://user-images.githubusercontent.com/1968822/63405728-3aadf080-c401-11e9-9b12-c1827c92f982.png)