### PR TITLE
fix: correct retries order in report

### DIFF
--- a/lib/gui/tool-runner-factory/base-tool-runner.js
+++ b/lib/gui/tool-runner-factory/base-tool-runner.js
@@ -10,6 +10,7 @@ const utils = require('../../server-utils');
 const {findTestResult} = require('./utils');
 const {findNode} = require('../../../lib/static/modules/utils');
 const reporterHelper = require('../../reporter-helpers');
+const {UPDATED} = require('../../constants/test-statuses');
 
 module.exports = class ToolRunner {
     static create(paths, tool, configs) {
@@ -74,7 +75,7 @@ module.exports = class ToolRunner {
 
         return Promise.map(tests, (test) => {
             const updateResult = this._prepareUpdateResult(test);
-            const formattedResult = reportBuilder.format(updateResult);
+            const formattedResult = reportBuilder.format(updateResult, UPDATED);
 
             return Promise.map(updateResult.imagesInfo, (imageInfo) => {
                 const {stateName} = imageInfo;

--- a/lib/gui/tool-runner-factory/gemini/report-subscriber.js
+++ b/lib/gui/tool-runner-factory/gemini/report-subscriber.js
@@ -29,10 +29,10 @@ module.exports = (gemini, reportBuilder, client, reportPath) => {
     });
 
     gemini.on(gemini.events.TEST_RESULT, (data) => {
-        const formattedResult = data.equal
-            ? reportBuilder.addSuccess(data)
-            : reportBuilder.addFail(data);
+        const formattedResult = reportBuilder.format(data);
+        formattedResult.attempt = reportBuilder.getCurrAttempt(formattedResult);
 
+        data.equal ? reportBuilder.addSuccess(formattedResult) : reportBuilder.addFail(formattedResult);
         const testResult = findTestResult(reportBuilder.getSuites(), formattedResult.prepareTestResult());
 
         formattedResult.saveTestImages(reportPath)
@@ -40,7 +40,11 @@ module.exports = (gemini, reportBuilder, client, reportPath) => {
     });
 
     gemini.on(gemini.events.ERROR, (error) => {
-        const formattedResult = reportBuilder.addError(error);
+        const formattedResult = reportBuilder.format(error);
+        formattedResult.attempt = reportBuilder.getCurrAttempt(formattedResult);
+
+        reportBuilder.addError(formattedResult);
+
         const testResult = findTestResult(reportBuilder.getSuites(), formattedResult.prepareTestResult());
 
         saveTestCurrentImage(formattedResult, reportPath)
@@ -48,7 +52,10 @@ module.exports = (gemini, reportBuilder, client, reportPath) => {
     });
 
     gemini.on(gemini.events.RETRY, (data) => {
-        const formattedResult = reportBuilder.addRetry(data);
+        const formattedResult = reportBuilder.format(data);
+        formattedResult.attempt = reportBuilder.getCurrAttempt(formattedResult);
+
+        reportBuilder.addRetry(formattedResult);
 
         return formattedResult.hasDiff()
             ? formattedResult.saveTestImages(reportPath)

--- a/lib/gui/tool-runner-factory/hermione/report-subscriber.js
+++ b/lib/gui/tool-runner-factory/hermione/report-subscriber.js
@@ -9,12 +9,6 @@ const createHermioneWorkers = require('../../../workers/create-hermione-workers'
 let workers;
 
 module.exports = (hermione, reportBuilder, client, reportPath) => {
-    function setAttempt(formattedResult) {
-        formattedResult.attempt = reportBuilder.getCurrAttempt(formattedResult);
-
-        return formattedResult;
-    }
-
     function failHandler(formattedResult) {
         const actions = [formattedResult.saveTestImages(reportPath, workers)];
 
@@ -52,11 +46,12 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
     });
 
     hermione.on(hermione.events.TEST_PASS, (data) => {
-        const formattedResult = reportBuilder.format(data);
+        const formattedResult = reportBuilder.format(data, hermione.events.TEST_PASS);
+        formattedResult.attempt = reportBuilder.getCurrAttempt(formattedResult);
 
         return formattedResult.saveTestImages(reportPath, workers)
             .then(() => {
-                reportBuilder.addSuccess(data);
+                reportBuilder.addSuccess(formattedResult);
 
                 const testResult = utils.findTestResult(
                     reportBuilder.getSuites(),
@@ -68,9 +63,8 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
     });
 
     hermione.on(hermione.events.TEST_FAIL, (data) => {
-        const formattedResult = reportBuilder.format(data);
-
-        setAttempt(formattedResult);
+        const formattedResult = reportBuilder.format(data, hermione.events.TEST_FAIL);
+        formattedResult.attempt = reportBuilder.getCurrAttempt(formattedResult);
 
         return failHandler(formattedResult)
             .then(() => {
@@ -84,17 +78,15 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
     });
 
     hermione.on(hermione.events.RETRY, (data) => {
-        const formattedResult = reportBuilder.format(data);
-
-        setAttempt(formattedResult);
+        const formattedResult = reportBuilder.format(data, hermione.events.RETRY);
+        formattedResult.attempt = reportBuilder.getCurrAttempt(formattedResult);
 
         return failHandler(formattedResult).then(() => reportBuilder.addRetry(formattedResult));
     });
 
     hermione.on(hermione.events.TEST_PENDING, (data) => {
-        const formattedResult = reportBuilder.format(data);
-
-        setAttempt(formattedResult);
+        const formattedResult = reportBuilder.format(data, hermione.events.TEST_PENDING);
+        formattedResult.attempt = reportBuilder.getCurrAttempt(formattedResult);
 
         return failHandler(formattedResult)
             .then(() => {

--- a/lib/report-builder-factory/report-builder.js
+++ b/lib/report-builder-factory/report-builder.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const fs = require('fs-extra');
 const {IDLE, RUNNING, SUCCESS, FAIL, ERROR, SKIPPED, UPDATED} = require('../constants/test-statuses');
-const {hasImage, logger, prepareCommonJSData} = require('../server-utils');
+const {hasImage, logger, prepareCommonJSData, shouldUpdateAttempt} = require('../server-utils');
 const {setStatusForBranch, hasFails, allSkipped, hasNoRefImageErrors} = require('../static/modules/utils');
 
 const NO_STATE = 'NO_STATE';
@@ -24,14 +24,14 @@ module.exports = class ReportBuilder {
         this._TestAdapter = TestAdapter;
     }
 
-    format(result) {
+    format(result, status) {
         return result instanceof this._TestAdapter
             ? result
-            : this._TestAdapter.create(result, this._tool);
+            : this._TestAdapter.create(result, this._tool, status);
     }
 
     addIdle(result) {
-        return this._addTestResult(this.format(result), {status: IDLE});
+        return this._addTestResult(this.format(result, IDLE), {status: IDLE});
     }
 
     addSkipped(result) {
@@ -58,7 +58,7 @@ module.exports = class ReportBuilder {
     }
 
     addUpdated(result) {
-        const formattedResult = this.format(result);
+        const formattedResult = this.format(result, UPDATED);
 
         formattedResult.imagesInfo = (result.imagesInfo || []).map((imageInfo) => {
             const {stateName} = imageInfo;
@@ -153,47 +153,76 @@ module.exports = class ReportBuilder {
     getCurrAttempt(formattedResult) {
         const previousResult = this._getPreviousResult({formattedResult});
 
-        return formattedResult.currStatus === UPDATED
-            ? formattedResult.attempt
-            : previousResult.attempt + 1;
+        return shouldUpdateAttempt(previousResult.status) ? previousResult.attempt + 1 : previousResult.attempt;
     }
 
     _addTestResult(formattedResult, props) {
-        const testResult = this._createTestResult(formattedResult, _.extend(props, {attempt: 0}));
-        const {browserId} = formattedResult;
+        const testResult = this._createTestResult(formattedResult, _.extend(props, {attempt: formattedResult.attempt}));
 
         const node = this._getResultNode(formattedResult);
         const stateInBrowser = this._getStateInBrowser(node, formattedResult);
 
         if (!stateInBrowser) {
+            this._initNode(node, formattedResult, testResult);
             formattedResult.image = hasImage(formattedResult);
-            extendTestWithImagePaths(testResult, formattedResult);
-
-            if (hasNoRefImageErrors(formattedResult)) {
-                testResult.status = FAIL;
-            }
-
-            node.browsers.push({name: browserId, result: testResult, retries: []});
-            setStatusForBranch(this._tree, node.suitePath);
 
             return formattedResult;
         }
 
-        const previousResult = this._getPreviousResult({stateInBrowser});
-        const statuses = [SKIPPED, RUNNING, IDLE];
+        this._updateNode({node, stateInBrowser, formattedResult, testResult});
 
-        if (!statuses.includes(previousResult.status)) {
-            testResult.attempt = formattedResult.attempt;
-            if (testResult.status !== UPDATED) {
-                stateInBrowser.retries.push(previousResult);
-            }
+        return formattedResult;
+    }
+
+    _initNode(node, formattedResult, testResult) {
+        const {browserId} = formattedResult;
+        extendTestWithImagePaths(testResult, formattedResult);
+
+        if (hasNoRefImageErrors(formattedResult)) {
+            testResult.status = FAIL;
         }
 
-        formattedResult.image = hasImage(formattedResult);
+        node.browsers.push({name: browserId, result: testResult, retries: []});
+        setStatusForBranch(this._tree, node.suitePath);
+    }
 
-        const {imagesInfo, status: currentStatus} = stateInBrowser.result;
-        stateInBrowser.result = extendTestWithImagePaths(testResult, formattedResult, imagesInfo);
+    _updateNode({node, stateInBrowser, formattedResult, testResult}) {
+        const previousResult = this._getPreviousResult({formattedResult, stateInBrowser});
+        const {imagesInfo} = stateInBrowser.result;
+        const newResult = extendTestWithImagePaths(testResult, formattedResult, imagesInfo);
+        const shouldUpdateResult = this._shouldUpdateResult(formattedResult, previousResult);
+        const shouldAddRetry = this._shouldAddRetry(testResult, previousResult);
 
+        if (shouldAddRetry && !shouldUpdateResult) {
+            stateInBrowser.retries[formattedResult.attempt] = newResult;
+        }
+
+        if (shouldUpdateResult) {
+            if (shouldAddRetry) {
+                stateInBrowser.retries[previousResult.attempt] = previousResult;
+            }
+            formattedResult.image = hasImage(formattedResult);
+
+            const {status: currentStatus} = stateInBrowser.result;
+            stateInBrowser.result = newResult;
+
+            this._setResultStatus(stateInBrowser, currentStatus);
+        }
+
+        setStatusForBranch(this._tree, node.suitePath);
+    }
+
+    _shouldAddRetry(testResult, previousResult) {
+        const statuses = [SKIPPED, RUNNING, IDLE];
+
+        return !statuses.includes(previousResult.status) && testResult.status !== UPDATED;
+    }
+
+    _shouldUpdateResult(formattedResult, previousResult) {
+        return formattedResult.attempt >= previousResult.attempt;
+    }
+
+    _setResultStatus(stateInBrowser, currentStatus) {
         if (!hasFails(stateInBrowser) && !allSkipped(stateInBrowser)) {
             stateInBrowser.result.status = SUCCESS;
         } else if (hasNoRefImageErrors(stateInBrowser.result)) {
@@ -201,10 +230,6 @@ module.exports = class ReportBuilder {
         } else if (stateInBrowser.result.status === UPDATED) {
             stateInBrowser.result.status = currentStatus;
         }
-
-        setStatusForBranch(this._tree, node.suitePath);
-
-        return formattedResult;
     }
 
     save() {

--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -6,7 +6,7 @@ const chalk = require('chalk');
 const _ = require('lodash');
 const fs = require('fs-extra');
 
-const {ERROR} = require('./constants/test-statuses');
+const {ERROR, UPDATED, IDLE} = require('./constants/test-statuses');
 
 const getReferencePath = (testResult, stateName) => createPath('ref', testResult, stateName);
 const getCurrentPath = (testResult, stateName) => createPath('current', testResult, stateName);
@@ -85,6 +85,10 @@ function prepareCommonJSData(data) {
     ].join('\n');
 }
 
+function shouldUpdateAttempt(status) {
+    return ![UPDATED, IDLE].includes(status);
+}
+
 module.exports = {
     getReferencePath,
     getCurrentPath,
@@ -103,5 +107,7 @@ module.exports = {
     logError,
 
     require,
-    prepareCommonJSData
+    prepareCommonJSData,
+
+    shouldUpdateAttempt
 };

--- a/lib/test-adapter/hermione-test-adapter.js
+++ b/lib/test-adapter/hermione-test-adapter.js
@@ -21,15 +21,31 @@ function createHash(buffer) {
 }
 
 const globalCacheDiffImages = new Map();
+const testsAttempts = new Map();
 
 module.exports = class HermioneTestResultAdapter extends TestAdapter {
-    constructor(testResult, tool) {
-        super(testResult);
+    constructor(testResult, tool, status) {
+        super(testResult, tool, status);
 
         this._tool = tool;
         this._errors = this._tool.errors;
         this._suite = HermioneSuiteAdapter.create(this._testResult);
         this._imagesSaver = this._tool.htmlReporter.imagesSaver;
+        this._testId = `${this._testResult.fullTitle()}.${this._testResult.browserId}`;
+        if (utils.shouldUpdateAttempt(status)) {
+            testsAttempts.set(this._testId, _.isUndefined(testsAttempts.get(this._testId)) ? 0 : testsAttempts.get(this._testId) + 1);
+        }
+
+        this._attempt = testsAttempts.get(this._testId) || 0;
+    }
+
+    get attempt() {
+        return this._attempt;
+    }
+
+    set attempt(attemptNum) {
+        testsAttempts.set(this._testId, attemptNum);
+        this._attempt = attemptNum;
     }
 
     hasDiff() {
@@ -105,22 +121,6 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
 
     get state() {
         return {name: this._testResult.title};
-    }
-
-    get attempt() {
-        const {retry} = this._tool.config.forBrowser(this._testResult.browserId);
-        if (this._testResult.attempt > retry) {
-            return this._testResult.attempt;
-        }
-
-        return this._testResult.retriesLeft >= 0
-            ? retry - this._testResult.retriesLeft
-            : retry;
-    }
-
-    // for correct determine image paths in gui
-    set attempt(attemptNum) {
-        this._testResult.attempt = attemptNum;
     }
 
     get screenshot() {

--- a/lib/test-adapter/test-adapter.js
+++ b/lib/test-adapter/test-adapter.js
@@ -9,8 +9,8 @@ const {SUCCESS, FAIL, ERROR, UPDATED} = require('../constants/test-statuses');
 const globalCacheAllImages = new Map();
 
 module.exports = class TestAdapter {
-    static create(testResult = {}, tool) {
-        return new this(testResult, tool);
+    static create(testResult = {}, tool, status) {
+        return new this(testResult, tool, status);
     }
 
     constructor(testResult) {

--- a/test/unit/hermione.js
+++ b/test/unit/hermione.js
@@ -61,6 +61,7 @@ describe('lib/hermione', () => {
 
     function mkStubResult_(options = {}) {
         return _.defaultsDeep(options, {
+            fullTitle: () => 'default-title',
             id: () => 'some-id',
             err: {
                 type: options.diff && 'ImageDiffError',
@@ -133,7 +134,7 @@ describe('lib/hermione', () => {
 
     it('should add skipped test to result', async () => {
         await initReporter_();
-        hermione.emit(events.TEST_PENDING, {title: 'some-title'});
+        hermione.emit(events.TEST_PENDING, mkStubResult_({title: 'some-title'}));
         await hermione.emitAndWait(hermione.events.RUNNER_END);
 
         assert.deepEqual(ReportBuilder.prototype.addSkipped.args[0][0].state, {name: 'some-title'});
@@ -141,7 +142,7 @@ describe('lib/hermione', () => {
 
     it('should add passed test to result', async () => {
         await initReporter_();
-        hermione.emit(events.TEST_PASS, {title: 'some-title'});
+        hermione.emit(events.TEST_PASS, mkStubResult_({title: 'some-title'}));
         await hermione.emitAndWait(hermione.events.RUNNER_END);
 
         assert.deepEqual(ReportBuilder.prototype.addSuccess.args[0][0].state, {name: 'some-title'});
@@ -164,7 +165,7 @@ describe('lib/hermione', () => {
                 const err = new Error();
                 err.stateName = 'state-name';
 
-                hermione.emit(events[event], {title: 'some-title', assertViewResults: [err]});
+                hermione.emit(events[event], mkStubResult_({title: 'some-title', assertViewResults: [err]}));
                 await hermione.emitAndWait(hermione.events.RUNNER_END);
 
                 assert.deepEqual(ReportBuilder.prototype.addError.args[0][0].state, {name: 'some-title'});
@@ -192,7 +193,7 @@ describe('lib/hermione', () => {
                 const err = new ImageDiffError();
                 err.stateName = 'state-name';
 
-                hermione.emit(events[event], {title: 'some-title', assertViewResults: [err]});
+                hermione.emit(events[event], mkStubResult_({title: 'some-title', assertViewResults: [err]}));
                 await hermione.emitAndWait(hermione.events.RUNNER_END);
 
                 assert.deepEqual(ReportBuilder.prototype.addFail.args[0][0].state, {name: 'some-title'});


### PR DESCRIPTION
Ранее массив с ретраями накапливался в `report-builder` обычным допушиванем в массив. После [рефакторинга](https://github.com/gemini-testing/html-reporter/pull/238), накапливание результата стало ассинхронным и механизм допушивания в массив уже не подходит, т.к. порядок ретраев уже не гарантирован (например, в первом ретрае мы еще сохраняем изображение, а в это время прилетел второй ретрай, для которого изображение сохранилось быстрее).
Решение - сохраняем ретраи в массив, учитывая индекс. Для этого пришлось переработать не только логику сохранения ретраев в `report-builder`, но и логику подсчета attempt в hermione-test-adapter, которая работала некорректно. Эта логика завязывалась на общее количество ретраев для прогона и поле `retriesLeft` из `hermione`, что вообще говоря неверно, т.к. есть плагины, которые могут менять общее количество ретраев прямо во время прогона. Теперь количество попыток хранится в состоянии hermione-test-adapter.