### PR TITLE
fix: increase timeouts for GUI server

### DIFF
--- a/lib/gui/constants/server.js
+++ b/lib/gui/constants/server.js
@@ -1,5 +1,7 @@
 'use strict';
 
 module.exports = {
-    MAX_REQUEST_SIZE: '100mb'
+    MAX_REQUEST_SIZE: '100mb',
+    KEEP_ALIVE_TIMEOUT: 120 * 1000,
+    HEADERS_TIMEOUT: 125 * 1000
 };

--- a/lib/gui/server.js
+++ b/lib/gui/server.js
@@ -6,7 +6,7 @@ const onExit = require('signal-exit');
 const Promise = require('bluebird');
 const bodyParser = require('body-parser');
 const App = require('./app');
-const {MAX_REQUEST_SIZE} = require('./constants/server');
+const {MAX_REQUEST_SIZE, KEEP_ALIVE_TIMEOUT, HEADERS_TIMEOUT} = require('./constants/server');
 const {logger} = require('../server-utils');
 
 exports.start = ({paths, tool, guiApi, configs}) => {
@@ -70,7 +70,9 @@ exports.start = ({paths, tool, guiApi, configs}) => {
     return app.initialize()
         .then(() => {
             return Promise.fromCallback((callback) => {
-                server.listen(options.port, options.hostname, callback);
+                const httpServer = server.listen(options.port, options.hostname, callback);
+                httpServer.keepAliveTimeout = KEEP_ALIVE_TIMEOUT;
+                httpServer.headersTimeout = HEADERS_TIMEOUT;
             });
         })
         .then(() => {


### PR DESCRIPTION
fix for error 'net::ERR_CONTENT_LENGTH_MISMATCH 200 (OK)' on slow '/init' request.