### PR TITLE
feat: save & show error details

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ Plugin has following configuration:
 * **path** (optional) `String` - path to directory for saving html report file; by
 default html report will be saved into `gemini-report/index.html` inside current work
 directory.
-* **saveErrorDetails** (optional) `Boolean` – save/don't save error details to json-files (to error-details folder); `false` by default
+* **saveErrorDetails** (optional) `Boolean` – save/don't save error details to json-files (to error-details folder); `false` by default.
+
+  Any plugin of hermione can add error details when throwing an error. Details can help a user to debug a problem in a test. Html-reporter saves these details to a file with name `<hash of suite path>-<browser>_<retry number>_<timestamp>.json` in the error-details folder. Below a stacktrace html-reporter adds the section `Error details` with the link `title` pointing to the json-file. A user can open it in a browser or any IDE.
+
+  How to add error details when throwing an error from a plugin:
+```
+   const err = new Error('some error');
+   err.details = {title: 'description, will be used as url title', data: {} | [] | 'some additional info'};
+```
 * **defaultView** (optional) `String` - default view mode. Available values are:
   * `all` - show all tests. Default value.
   * `failed` - show only failed tests.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Plugin has following configuration:
 * **path** (optional) `String` - path to directory for saving html report file; by
 default html report will be saved into `gemini-report/index.html` inside current work
 directory.
+* **saveErrorDetails** (optional) `Boolean` – save/don't save error details to json-files (to error-details folder); `false` by default
 * **defaultView** (optional) `String` - default view mode. Available values are:
   * `all` - show all tests. Default value.
   * `failed` - show only failed tests.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ directory.
 ```
    const err = new Error('some error');
    err.details = {title: 'description, will be used as url title', data: {} | [] | 'some additional info'};
+   throw err;
 ```
 * **defaultView** (optional) `String` - default view mode. Available values are:
   * `all` - show all tests. Default value.

--- a/hermione.js
+++ b/hermione.js
@@ -32,6 +32,10 @@ async function prepare(hermione, reportBuilder, pluginConfig) {
         const formattedResult = reportBuilder.format(testResult);
         const actions = [formattedResult.saveTestImages(reportPath, workers)];
 
+        if (formattedResult.errorDetails) {
+            actions.push(formattedResult.saveErrorDetails(reportPath));
+        }
+
         if (formattedResult.screenshot) {
             actions.push(formattedResult.saveBase64Screenshot(reportPath));
         }

--- a/lib/config.js
+++ b/lib/config.js
@@ -76,6 +76,12 @@ const getParser = () => {
             defaultValue: 'html-report',
             validate: assertString('path')
         }),
+        saveErrorDetails: option({
+            defaultValue: false,
+            parseEnv: JSON.parse,
+            parseCli: JSON.parse,
+            validate: assertBoolean('saveErrorDetails')
+        }),
         defaultView: option({
             defaultValue: configDefaults.defaultView,
             validate: assertString('defaultView')

--- a/lib/constants/defaults.js
+++ b/lib/constants/defaults.js
@@ -3,6 +3,7 @@
 module.exports = {
     CIRCLE_RADIUS: 150,
     config: {
+        saveErrorDetails: false,
         defaultView: 'all',
         baseHost: '',
         scaleImages: false,

--- a/lib/constants/paths.js
+++ b/lib/constants/paths.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+    IMAGES_PATH: 'images',
+    ERROR_DETAILS_PATH: 'error-details'
+};

--- a/lib/gui/server.js
+++ b/lib/gui/server.js
@@ -7,6 +7,7 @@ const Promise = require('bluebird');
 const bodyParser = require('body-parser');
 const App = require('./app');
 const {MAX_REQUEST_SIZE, KEEP_ALIVE_TIMEOUT, HEADERS_TIMEOUT} = require('./constants/server');
+const {IMAGES_PATH, ERROR_DETAILS_PATH} = require('../constants/paths');
 const {logger} = require('../server-utils');
 
 exports.start = ({paths, tool, guiApi, configs}) => {
@@ -20,8 +21,8 @@ exports.start = ({paths, tool, guiApi, configs}) => {
 
     server.use(express.static(path.join(__dirname, '../static'), {index: 'gui.html'}));
     server.use(express.static(process.cwd()));
-    server.use('/images', express.static(path.join(process.cwd(), pluginConfig.path, 'images')));
-    server.use('/error-details', express.static(path.join(process.cwd(), pluginConfig.path, 'error-details')));
+    server.use(`/${IMAGES_PATH}`, express.static(path.join(process.cwd(), pluginConfig.path, IMAGES_PATH)));
+    server.use(`/${ERROR_DETAILS_PATH}`, express.static(path.join(process.cwd(), pluginConfig.path, ERROR_DETAILS_PATH)));
 
     server.get('/', (req, res) => res.sendFile(path.join(__dirname, '../static', 'gui.html')));
 

--- a/lib/gui/server.js
+++ b/lib/gui/server.js
@@ -21,6 +21,7 @@ exports.start = ({paths, tool, guiApi, configs}) => {
     server.use(express.static(path.join(__dirname, '../static'), {index: 'gui.html'}));
     server.use(express.static(process.cwd()));
     server.use('/images', express.static(path.join(process.cwd(), pluginConfig.path, 'images')));
+    server.use('/error-details', express.static(path.join(process.cwd(), pluginConfig.path, 'error-details')));
 
     server.get('/', (req, res) => res.sendFile(path.join(__dirname, '../static', 'gui.html')));
 

--- a/lib/gui/tool-runner-factory/hermione/report-subscriber.js
+++ b/lib/gui/tool-runner-factory/hermione/report-subscriber.js
@@ -16,6 +16,10 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
             actions.push(formattedResult.saveBase64Screenshot(reportPath));
         }
 
+        if (formattedResult.errorDetails) {
+            actions.push(formattedResult.saveErrorDetails(reportPath));
+        }
+
         return Promise.all(actions);
     }
 

--- a/lib/report-builder-factory/report-builder.js
+++ b/lib/report-builder-factory/report-builder.js
@@ -119,7 +119,7 @@ module.exports = class ReportBuilder {
             browserId, suite, sessionId, description, imagesInfo, screenshot, multipleTabs, errorDetails
         } = result;
 
-        const {baseHost} = this._pluginConfig;
+        const {baseHost, saveErrorDetails} = this._pluginConfig;
         const suiteUrl = suite.getUrl({browserId, baseHost});
         const metaInfo = _.merge(_.cloneDeep(result.meta), {url: suite.fullUrl, file: suite.file, sessionId});
 
@@ -128,7 +128,7 @@ module.exports = class ReportBuilder {
             screenshot: Boolean(screenshot), multipleTabs
         }, props);
 
-        if (errorDetails) {
+        if (saveErrorDetails && errorDetails) {
             testResult.errorDetails = _.pick(errorDetails, ['title', 'filePath']);
         }
 

--- a/lib/report-builder-factory/report-builder.js
+++ b/lib/report-builder-factory/report-builder.js
@@ -115,8 +115,10 @@ module.exports = class ReportBuilder {
     }
 
     _createTestResult(result, props) {
-        const {browserId, suite, sessionId, description, imagesInfo, screenshot, multipleTabs} = result;
-        const {errorDetails} = result;
+        const {
+            browserId, suite, sessionId, description, imagesInfo, screenshot, multipleTabs, errorDetails
+        } = result;
+
         const {baseHost} = this._pluginConfig;
         const suiteUrl = suite.getUrl({browserId, baseHost});
         const metaInfo = _.merge(_.cloneDeep(result.meta), {url: suite.fullUrl, file: suite.file, sessionId});

--- a/lib/report-builder-factory/report-builder.js
+++ b/lib/report-builder-factory/report-builder.js
@@ -116,14 +116,21 @@ module.exports = class ReportBuilder {
 
     _createTestResult(result, props) {
         const {browserId, suite, sessionId, description, imagesInfo, screenshot, multipleTabs} = result;
+        const {errorDetails} = result;
         const {baseHost} = this._pluginConfig;
         const suiteUrl = suite.getUrl({browserId, baseHost});
         const metaInfo = _.merge(_.cloneDeep(result.meta), {url: suite.fullUrl, file: suite.file, sessionId});
 
-        return Object.assign({
+        const testResult = Object.assign({
             suiteUrl, name: browserId, metaInfo, description, imagesInfo,
             screenshot: Boolean(screenshot), multipleTabs
         }, props);
+
+        if (errorDetails) {
+            testResult.errorDetails = _.pick(errorDetails, ['title', 'filePath']);
+        }
+
+        return testResult;
     }
 
     _getResultNode(formattedResult) {

--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -6,6 +6,7 @@ const chalk = require('chalk');
 const _ = require('lodash');
 const fs = require('fs-extra');
 
+const {getShortMD5} = require('./gui/tool-runner-factory/hermione/utils');
 const {ERROR, UPDATED, IDLE} = require('./constants/test-statuses');
 
 const getReferencePath = (testResult, stateName) => createPath('ref', testResult, stateName);
@@ -89,7 +90,13 @@ function shouldUpdateAttempt(status) {
     return ![UPDATED, IDLE].includes(status);
 }
 
+function getDetailsFileName(suitePath, browserId, attempt) {
+    return `${getShortMD5(suitePath.join(' '))}-${browserId}_${+attempt + 1}_${Date.now()}.json`;
+}
+
 module.exports = {
+    getDetailsFileName,
+
     getReferencePath,
     getCurrentPath,
     getDiffPath,

--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -6,8 +6,8 @@ const chalk = require('chalk');
 const _ = require('lodash');
 const fs = require('fs-extra');
 
-const {getShortMD5} = require('./gui/tool-runner-factory/hermione/utils');
 const {ERROR, UPDATED, IDLE} = require('./constants/test-statuses');
+const {IMAGES_PATH} = require('./constants/paths');
 
 const getReferencePath = (testResult, stateName) => createPath('ref', testResult, stateName);
 const getCurrentPath = (testResult, stateName) => createPath('current', testResult, stateName);
@@ -39,7 +39,7 @@ const getDiffAbsolutePath = (testResult, reportDir, stateName) => {
  */
 function createPath(kind, result, stateName) {
     const attempt = result.attempt || 0;
-    const imageDir = _.compact(['images', result.imageDir, stateName]);
+    const imageDir = _.compact([IMAGES_PATH, result.imageDir, stateName]);
     const components = imageDir.concat(`${result.browserId}~${kind}_${attempt}.png`);
 
     return path.join.apply(null, components);
@@ -90,8 +90,8 @@ function shouldUpdateAttempt(status) {
     return ![UPDATED, IDLE].includes(status);
 }
 
-function getDetailsFileName(suitePath, browserId, attempt) {
-    return `${getShortMD5(suitePath.join(' '))}-${browserId}_${+attempt + 1}_${Date.now()}.json`;
+function getDetailsFileName(testId, browserId, attempt) {
+    return `${testId}-${browserId}_${Number(attempt) + 1}_${Date.now()}.json`;
 }
 
 module.exports = {

--- a/lib/static/components/section/body/error-details.js
+++ b/lib/static/components/section/body/error-details.js
@@ -11,7 +11,7 @@ export default class ErrorDetails extends Component {
 
     render() {
         const {title, filePath} = this.props.errorDetails;
-        const content = <div className="toggle-open__item"><a href={filePath}>{title}</a></div>;
+        const content = <div className="toggle-open__item"><a href={filePath} target="_blank">{title}</a></div>;
 
         return <ToggleOpen title='Error details' content={content} extendClassNames="toggle-open_type_text"/>;
     }

--- a/lib/static/components/section/body/error-details.js
+++ b/lib/static/components/section/body/error-details.js
@@ -1,0 +1,18 @@
+'use strict';
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import ToggleOpen from '../../toggle-open';
+
+export default class ErrorDetails extends Component {
+    static propTypes = {
+        errorDetails: PropTypes.object.isRequired
+    };
+
+    render() {
+        const {title, filePath} = this.props.errorDetails;
+        const content = <div className="toggle-open__item"><a href={filePath}>{title}</a></div>;
+
+        return <ToggleOpen title='Error details' content={content} extendClassNames="toggle-open_type_text"/>;
+    }
+}

--- a/lib/static/components/section/body/index.js
+++ b/lib/static/components/section/body/index.js
@@ -10,7 +10,6 @@ import SwitcherRetry from '../switcher-retry';
 import ControlButton from '../../controls/control-button';
 import State from '../../state';
 import MetaInfo from './meta-info';
-import ErrorDetails from './error-details';
 import Description from './description';
 import * as actions from '../../../modules/actions';
 import {isSuccessStatus, isErroredStatus} from '../../../../common-utils';
@@ -119,9 +118,15 @@ class Body extends Component {
     }
 
     _getActiveResult = () => {
+        if (this._activeResult) {
+            return this._activeResult;
+        }
+
         const {result, retries} = this.props;
 
-        return retries.concat(result)[this.state.retry];
+        this._activeResult = retries.concat(result)[this.state.retry];
+
+        return this._activeResult;
     }
 
     _getTabs() {
@@ -146,6 +151,8 @@ class Body extends Component {
 
     _drawTab(state, key = '', opts = {}) {
         const {result: {name: browserId}, suite: {suitePath}} = this.props;
+        const {errorDetails} = this._getActiveResult();
+
         opts = defaults({error: state.error}, opts);
 
         return (
@@ -154,7 +161,7 @@ class Body extends Component {
                     <State
                         state={state} suitePath={suitePath} browserId={browserId}
                         acceptHandler={this.onTestAccept} toggleHandler={this.onToggleStateResult}
-                        findSameDiffsHandler={this.onTestFindSameDiffs} {...opts}
+                        findSameDiffsHandler={this.onTestFindSameDiffs} {...opts} errorDetails={errorDetails}
                     />
                 </div>
             </div>
@@ -168,7 +175,7 @@ class Body extends Component {
     render() {
         const {retries} = this.props;
         const activeResult = this._getActiveResult();
-        const {metaInfo, suiteUrl, description, errorDetails} = activeResult;
+        const {metaInfo, suiteUrl, description} = activeResult;
 
         return (
             <div className="section__body">
@@ -183,7 +190,6 @@ class Body extends Component {
                     <MetaInfo metaInfo={metaInfo} suiteUrl={suiteUrl} getExtraMetaInfo={this.getExtraMetaInfo}/>
                     {description && <Description content={description}/>}
                     {this._getTabs()}
-                    {errorDetails && <ErrorDetails errorDetails={errorDetails}/>}
                 </div>
             </div>
         );

--- a/lib/static/components/section/body/index.js
+++ b/lib/static/components/section/body/index.js
@@ -131,27 +131,29 @@ class Body extends Component {
 
     _getTabs() {
         const activeResult = this._getActiveResult();
+        const {errorDetails} = activeResult;
         const retryIndex = this.state.retry;
 
         if (isEmpty(activeResult.imagesInfo)) {
-            return isSuccessStatus(activeResult.status) ? null : this._drawTab(activeResult);
+            return isSuccessStatus(activeResult.status) ? null : this._drawTab(activeResult, {errorDetails});
         }
 
         const tabs = activeResult.imagesInfo.map((imageInfo, idx) => {
             const {stateName} = imageInfo;
             const error = imageInfo.error || activeResult.error;
 
-            return this._drawTab(imageInfo, `${stateName || idx}_${retryIndex}`, {image: true, error});
+            const options = imageInfo.stateName ? {} : {errorDetails};
+
+            return this._drawTab(imageInfo, {...options, image: true, error}, `${stateName || idx}_${retryIndex}`);
         });
 
         return this._shouldAddErrorTab(activeResult)
-            ? tabs.concat(this._drawTab(activeResult))
+            ? tabs.concat(this._drawTab(activeResult, {errorDetails}))
             : tabs;
     }
 
-    _drawTab(state, key = '', opts = {}) {
+    _drawTab(state, opts = {}, key = '') {
         const {result: {name: browserId}, suite: {suitePath}} = this.props;
-        const {errorDetails} = this._getActiveResult();
 
         opts = defaults({error: state.error}, opts);
 
@@ -161,7 +163,7 @@ class Body extends Component {
                     <State
                         state={state} suitePath={suitePath} browserId={browserId}
                         acceptHandler={this.onTestAccept} toggleHandler={this.onToggleStateResult}
-                        findSameDiffsHandler={this.onTestFindSameDiffs} {...opts} errorDetails={errorDetails}
+                        findSameDiffsHandler={this.onTestFindSameDiffs} {...opts}
                     />
                 </div>
             </div>

--- a/lib/static/components/section/body/index.js
+++ b/lib/static/components/section/body/index.js
@@ -182,8 +182,8 @@ class Body extends Component {
                     </div>
                     <MetaInfo metaInfo={metaInfo} suiteUrl={suiteUrl} getExtraMetaInfo={this.getExtraMetaInfo}/>
                     {description && <Description content={description}/>}
-                    {errorDetails && <ErrorDetails errorDetails={errorDetails}/>}
                     {this._getTabs()}
+                    {errorDetails && <ErrorDetails errorDetails={errorDetails}/>}
                 </div>
             </div>
         );

--- a/lib/static/components/section/body/index.js
+++ b/lib/static/components/section/body/index.js
@@ -10,6 +10,7 @@ import SwitcherRetry from '../switcher-retry';
 import ControlButton from '../../controls/control-button';
 import State from '../../state';
 import MetaInfo from './meta-info';
+import ErrorDetails from './error-details';
 import Description from './description';
 import * as actions from '../../../modules/actions';
 import {isSuccessStatus, isErroredStatus} from '../../../../common-utils';
@@ -167,7 +168,7 @@ class Body extends Component {
     render() {
         const {retries} = this.props;
         const activeResult = this._getActiveResult();
-        const {metaInfo, suiteUrl, description} = activeResult;
+        const {metaInfo, suiteUrl, description, errorDetails} = activeResult;
 
         return (
             <div className="section__body">
@@ -180,6 +181,7 @@ class Body extends Component {
                         {this._addRetryButton()}
                     </div>
                     <MetaInfo metaInfo={metaInfo} suiteUrl={suiteUrl} getExtraMetaInfo={this.getExtraMetaInfo}/>
+                    {errorDetails && <ErrorDetails errorDetails={errorDetails}/>}
                     {description && <Description content={description}/>}
                     {this._getTabs()}
                 </div>

--- a/lib/static/components/section/body/index.js
+++ b/lib/static/components/section/body/index.js
@@ -181,8 +181,8 @@ class Body extends Component {
                         {this._addRetryButton()}
                     </div>
                     <MetaInfo metaInfo={metaInfo} suiteUrl={suiteUrl} getExtraMetaInfo={this.getExtraMetaInfo}/>
-                    {errorDetails && <ErrorDetails errorDetails={errorDetails}/>}
                     {description && <Description content={description}/>}
+                    {errorDetails && <ErrorDetails errorDetails={errorDetails}/>}
                     {this._getTabs()}
                 </div>
             </div>

--- a/lib/static/components/state/error-details.js
+++ b/lib/static/components/state/error-details.js
@@ -2,7 +2,7 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import ToggleOpen from '../../toggle-open';
+import ToggleOpen from '../toggle-open';
 
 export default class ErrorDetails extends Component {
     static propTypes = {

--- a/lib/static/components/state/index.js
+++ b/lib/static/components/state/index.js
@@ -119,7 +119,7 @@ class State extends Component {
 
     render() {
         const {status, expectedImg, actualImg, diffImg, stateName, diffClusters} = this.props.state;
-        const {image, error} = this.props;
+        const {image, error, errorDetails} = this.props;
         let elem = null;
 
         if (!this.state.opened) {
@@ -132,12 +132,12 @@ class State extends Component {
         }
 
         if (isErroredStatus(status)) {
-            elem = <StateError image={Boolean(image)} actualImg={actualImg} error={error}/>;
+            elem = <StateError image={Boolean(image)} actualImg={actualImg} error={error} errorDetails={errorDetails}/>;
         } else if (isSuccessStatus(status) || isUpdatedStatus(status) || (isIdleStatus(status) && get(expectedImg, 'path'))) {
             elem = <StateSuccess status={status} expectedImg={expectedImg} />;
         } else if (isFailStatus(status)) {
             elem = error
-                ? <StateError image={Boolean(image)} actualImg={actualImg} error={error}/>
+                ? <StateError image={Boolean(image)} actualImg={actualImg} error={error} errorDetails={errorDetails}/>
                 : <StateFail expectedImg={expectedImg} actualImg={actualImg} diffImg={diffImg} diffClusters={diffClusters}/>;
         }
 

--- a/lib/static/components/state/state-error.js
+++ b/lib/static/components/state/state-error.js
@@ -6,6 +6,7 @@ import {map} from 'lodash';
 import Screenshot from './screenshot';
 import ToggleOpen from '../toggle-open';
 import {isNoRefImageError} from '../../modules/utils';
+import ErrorDetails from './error-details';
 
 export default class StateError extends Component {
     static propTypes = {
@@ -15,11 +16,12 @@ export default class StateError extends Component {
     };
 
     render() {
-        const {image, error, actualImg} = this.props;
+        const {image, error, errorDetails, actualImg} = this.props;
 
         return (
             <div className="image-box__image image-box__image_single">
                 <div className="error">{errorToElements(error)}</div>
+                {errorDetails && <ErrorDetails errorDetails={errorDetails}/>}
                 {this._drawImage(image, actualImg)}
             </div>
         );

--- a/lib/test-adapter/hermione-test-adapter.js
+++ b/lib/test-adapter/hermione-test-adapter.js
@@ -194,7 +194,7 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
             return;
         }
 
-        const detailsFilePath = `${path.resolve(reportPath)}/${this.errorDetails.filePath}`;
+        const detailsFilePath = path.resolve(reportPath, this.errorDetails.filePath);
         const detailsData = _.isObject(this.errorDetails.data)
             ? JSON.stringify(this.errorDetails.data, null, 2)
             : this.errorDetails.data;

--- a/lib/test-adapter/hermione-test-adapter.js
+++ b/lib/test-adapter/hermione-test-adapter.js
@@ -32,6 +32,8 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
         this._suite = HermioneSuiteAdapter.create(this._testResult);
         this._imagesSaver = this._tool.htmlReporter.imagesSaver;
         this._testId = `${this._testResult.fullTitle()}.${this._testResult.browserId}`;
+        this._errorDetails = undefined;
+
         if (utils.shouldUpdateAttempt(status)) {
             testsAttempts.set(this._testId, _.isUndefined(testsAttempts.get(this._testId)) ? 0 : testsAttempts.get(this._testId) + 1);
         }
@@ -141,6 +143,24 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
         return this._testResult.meta;
     }
 
+    get errorDetails() {
+        if (this._errorDetails !== undefined) {
+            return this._errorDetails;
+        }
+
+        const details = _.get(this._testResult, 'err.details', null);
+
+        this._errorDetails = details ? {
+            title: details.title || 'error details',
+            data: details.data,
+            filePath: `error-details/${utils.getDetailsFileName(
+                getSuitePath(this._testResult), this._testResult.browserId, this.attempt
+            )}`
+        } : null;
+
+        return this._errorDetails;
+    }
+
     getRefImg(stateName) {
         return _.get(_.find(this.assertViewResults, {stateName}), 'refImg', {});
     }
@@ -162,6 +182,17 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
 
     get multipleTabs() {
         return true;
+    }
+
+    async saveErrorDetails(reportPath) {
+        if (!this.errorDetails) {
+            return;
+        }
+
+        const destDetailsFilePath = `${path.resolve(reportPath)}/${this.errorDetails.filePath}`;
+
+        await utils.makeDirFor(destDetailsFilePath);
+        await fs.writeFile(destDetailsFilePath, JSON.stringify(this.errorDetails.data, null, 2));
     }
 
     saveTestImages(reportPath, workers) {

--- a/lib/test-adapter/hermione-test-adapter.js
+++ b/lib/test-adapter/hermione-test-adapter.js
@@ -145,7 +145,7 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
     }
 
     get errorDetails() {
-        if (this._errorDetails !== undefined) {
+        if (!_.isUndefined(this._errorDetails)) {
             return this._errorDetails;
         }
 

--- a/lib/test-adapter/hermione-test-adapter.js
+++ b/lib/test-adapter/hermione-test-adapter.js
@@ -9,6 +9,7 @@ const TestAdapter = require('./test-adapter');
 const HermioneSuiteAdapter = require('../suite-adapter/hermione-suite-adapter.js');
 const {getSuitePath} = require('../plugin-utils').getHermioneUtils();
 const {SUCCESS, FAIL, ERROR} = require('../constants/test-statuses');
+const {ERROR_DETAILS_PATH} = require('../constants/paths');
 const utils = require('../server-utils');
 const fs = require('fs-extra');
 const crypto = require('crypto');
@@ -150,13 +151,17 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
 
         const details = _.get(this._testResult, 'err.details', null);
 
-        this._errorDetails = details ? {
-            title: details.title || 'error details',
-            data: details.data,
-            filePath: `error-details/${utils.getDetailsFileName(
-                getSuitePath(this._testResult), this._testResult.browserId, this.attempt
-            )}`
-        } : null;
+        if (details) {
+            this._errorDetails = {
+                title: details.title || 'error details',
+                data: details.data,
+                filePath: `${ERROR_DETAILS_PATH}/${utils.getDetailsFileName(
+                    this._testResult.id, this._testResult.browserId, this.attempt
+                )}`
+            };
+        } else {
+            this._errorDetails = null;
+        }
 
         return this._errorDetails;
     }
@@ -189,10 +194,13 @@ module.exports = class HermioneTestResultAdapter extends TestAdapter {
             return;
         }
 
-        const destDetailsFilePath = `${path.resolve(reportPath)}/${this.errorDetails.filePath}`;
+        const detailsFilePath = `${path.resolve(reportPath)}/${this.errorDetails.filePath}`;
+        const detailsData = _.isObject(this.errorDetails.data)
+            ? JSON.stringify(this.errorDetails.data, null, 2)
+            : this.errorDetails.data;
 
-        await utils.makeDirFor(destDetailsFilePath);
-        await fs.writeFile(destDetailsFilePath, JSON.stringify(this.errorDetails.data, null, 2));
+        await utils.makeDirFor(detailsFilePath);
+        await fs.writeFile(detailsFilePath, detailsData);
     }
 
     saveTestImages(reportPath, workers) {

--- a/test/unit/lib/config.js
+++ b/test/unit/lib/config.js
@@ -68,6 +68,30 @@ describe('config', () => {
         });
     });
 
+    describe('"saveErrorDetails" option', () => {
+        it('should be false by default', () => {
+            assert.isFalse(parseConfig({}).saveErrorDetails);
+        });
+
+        it('should set from configuration file', () => {
+            const config = parseConfig({saveErrorDetails: true});
+
+            assert.isTrue(config.saveErrorDetails);
+        });
+
+        it('should set from environment variable', () => {
+            process.env['html_reporter_save_error_details'] = 'true';
+
+            assert.isTrue(parseConfig({}).saveErrorDetails);
+        });
+
+        it('should set from cli', () => {
+            process.argv = process.argv.concat('--html-reporter-save-error-details', 'true');
+
+            assert.isTrue(parseConfig({}).saveErrorDetails);
+        });
+    });
+
     describe('"defaultView" option', () => {
         it('should show all suites by default', () => {
             assert.equal(parseConfig({}).defaultView, 'all');

--- a/test/unit/lib/merge-reports/data-tree.js
+++ b/test/unit/lib/merge-reports/data-tree.js
@@ -8,6 +8,7 @@ const _ = require('lodash');
 const DataTree = require('lib/merge-reports/data-tree');
 const {mkSuiteTree, mkSuite, mkState, mkBrowserResult, mkTestResult} = require('test/unit/utils');
 const {SUCCESS, FAIL, ERROR, SKIPPED} = require('lib/constants/test-statuses');
+const {IMAGES_PATH} = require('lib/constants/paths');
 const {logger} = require('lib/server-utils');
 
 describe('lib/merge-reports/data-tree', () => {
@@ -982,9 +983,9 @@ describe('lib/merge-reports/data-tree', () => {
         });
 
         [
-            {keyName: 'actualImg', imgPaths: ['images/yabro~current_0.png', 'images/yabro~current_1.png']},
-            {keyName: 'expectedImg', imgPaths: ['images/yabro~ref_0.png', 'images/yabro~ref_1.png']},
-            {keyName: 'diffImg', imgPaths: ['images/yabro~diff_0.png', 'images/yabro~diff_1.png']}
+            {keyName: 'actualImg', imgPaths: [`${IMAGES_PATH}/yabro~current_0.png`, `${IMAGES_PATH}/yabro~current_1.png`]},
+            {keyName: 'expectedImg', imgPaths: [`${IMAGES_PATH}/yabro~ref_0.png`, `${IMAGES_PATH}/yabro~ref_1.png`]},
+            {keyName: 'diffImg', imgPaths: [`${IMAGES_PATH}/yabro~diff_0.png`, `${IMAGES_PATH}/yabro~diff_1.png`]}
         ].forEach(({keyName, imgPaths}) => {
             it(`should move image specified in "${keyName}" field`, async () => {
                 const srcDataSuites1 = mkSuiteTree();
@@ -1013,13 +1014,26 @@ describe('lib/merge-reports/data-tree', () => {
 
         it('should move images from non-existent suite in tree', async () => {
             const srcDataSuites1 = mkSuiteTree({suite: mkSuite({suitePath: ['suite1']})});
+
             const srcDataSuites2 = mkSuiteTree({
                 suite: mkSuite({suitePath: ['suite2']}),
                 state: mkState({suitePath: ['suite2', 'state']}),
                 browsers: [mkBrowserResult({
                     name: 'yabro',
-                    result: mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_1.png'}}]}),
-                    retries: [mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]})]
+                    result: mkTestResult({
+                        imagesInfo: [{
+                            actualImg: {
+                                path: `${IMAGES_PATH}/yabro~current_1.png`
+                            }
+                        }]
+                    }),
+                    retries: [mkTestResult({
+                        imagesInfo: [{
+                            actualImg: {
+                                path: `${IMAGES_PATH}/yabro~current_0.png`
+                            }
+                        }]
+                    })]
                 })]
             });
 
@@ -1031,8 +1045,8 @@ describe('lib/merge-reports/data-tree', () => {
             [0, 1].forEach((attempt) => {
                 assert.calledWith(
                     fs.move,
-                    path.resolve('src-report/path', `images/yabro~current_${attempt}.png`),
-                    path.resolve('dest-report/path', `images/yabro~current_${attempt}.png`)
+                    path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_${attempt}.png`),
+                    path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_${attempt}.png`)
                 );
             });
         });
@@ -1042,13 +1056,26 @@ describe('lib/merge-reports/data-tree', () => {
                 suite: mkSuite({suitePath: ['suite']}),
                 state: mkState({suitePath: ['suite', 'state']})
             });
+
             const srcDataSuites2 = mkSuiteTree({
                 suite: mkSuite({suitePath: ['suite']}),
                 state: mkState({suitePath: ['suite', 'state2']}),
                 browsers: [mkBrowserResult({
                     name: 'yabro',
-                    result: mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_1.png'}}]}),
-                    retries: [mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]})]
+                    result: mkTestResult({
+                        imagesInfo: [{
+                            actualImg: {
+                                path: `${IMAGES_PATH}/yabro~current_1.png`
+                            }
+                        }]
+                    }),
+                    retries: [mkTestResult({
+                        imagesInfo: [{
+                            actualImg: {
+                                path: `${IMAGES_PATH}/yabro~current_0.png`
+                            }
+                        }]
+                    })]
                 })]
             });
 
@@ -1060,8 +1087,8 @@ describe('lib/merge-reports/data-tree', () => {
             [0, 1].forEach((attempt) => {
                 assert.calledWith(
                     fs.move,
-                    path.resolve('src-report/path', `images/yabro~current_${attempt}.png`),
-                    path.resolve('dest-report/path', `images/yabro~current_${attempt}.png`)
+                    path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_${attempt}.png`),
+                    path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_${attempt}.png`)
                 );
             });
         });
@@ -1072,13 +1099,26 @@ describe('lib/merge-reports/data-tree', () => {
                 state: mkState({suitePath: ['suite', 'state']}),
                 browsers: []
             });
+
             const srcDataSuites2 = mkSuiteTree({
                 suite: mkSuite({suitePath: ['suite']}),
                 state: mkState({suitePath: ['suite', 'state']}),
                 browsers: [mkBrowserResult({
                     name: 'yabro',
-                    result: mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_1.png'}}]}),
-                    retries: [mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]})]
+                    result: mkTestResult({
+                        imagesInfo: [{
+                            actualImg: {
+                                path: `${IMAGES_PATH}/yabro~current_1.png`
+                            }
+                        }]
+                    }),
+                    retries: [mkTestResult({
+                        imagesInfo: [{
+                            actualImg: {
+                                path: `${IMAGES_PATH}/yabro~current_0.png`
+                            }
+                        }]
+                    })]
                 })]
             });
 
@@ -1090,8 +1130,8 @@ describe('lib/merge-reports/data-tree', () => {
             [0, 1].forEach((attempt) => {
                 assert.calledWith(
                     fs.move,
-                    path.resolve('src-report/path', `images/yabro~current_${attempt}.png`),
-                    path.resolve('dest-report/path', `images/yabro~current_${attempt}.png`)
+                    path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_${attempt}.png`),
+                    path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_${attempt}.png`)
                 );
             });
         });
@@ -1104,12 +1144,17 @@ describe('lib/merge-reports/data-tree', () => {
                         result: mkTestResult({status: SUCCESS})
                     })]
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     browsers: [mkBrowserResult({
                         name: 'yabro',
                         result: mkTestResult({
                             status: SUCCESS,
-                            imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_0.png`
+                                }
+                            }]
                         })
                     })]
                 });
@@ -1121,8 +1166,8 @@ describe('lib/merge-reports/data-tree', () => {
 
                 assert.calledOnceWith(
                     fs.move,
-                    path.resolve('src-report/path', 'images/yabro~current_0.png'),
-                    path.resolve('dest-report/path', 'images/yabro~current_1.png')
+                    path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_0.png`),
+                    path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_1.png`)
                 );
             });
 
@@ -1133,10 +1178,17 @@ describe('lib/merge-reports/data-tree', () => {
                         result: mkTestResult()
                     })]
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     browsers: [mkBrowserResult({
                         name: 'yabro',
-                        result: mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]})
+                        result: mkTestResult({
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_0.png`
+                                }
+                            }]
+                        })
                     })]
                 });
 
@@ -1147,8 +1199,8 @@ describe('lib/merge-reports/data-tree', () => {
 
                 assert.calledWith(
                     fs.move,
-                    path.resolve('src-report/path', `images/yabro~current_0.png`),
-                    path.resolve('dest-report/path', `images/yabro~current_1.png`)
+                    path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_0.png`),
+                    path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_1.png`)
                 );
             });
 
@@ -1159,11 +1211,24 @@ describe('lib/merge-reports/data-tree', () => {
                         result: mkTestResult()
                     })]
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     browsers: [mkBrowserResult({
                         name: 'yabro',
-                        result: mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_1.png'}}]}),
-                        retries: [mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]})]
+                        result: mkTestResult({
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_1.png`
+                                }
+                            }]
+                        }),
+                        retries: [mkTestResult({
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_0.png`
+                                }
+                            }]
+                        })]
                     })]
                 });
 
@@ -1175,8 +1240,8 @@ describe('lib/merge-reports/data-tree', () => {
                 [0, 1].forEach((attempt) => {
                     assert.calledWith(
                         fs.move,
-                        path.resolve('src-report/path', `images/yabro~current_${attempt}.png`),
-                        path.resolve('dest-report/path', `images/yabro~current_${attempt + 1}.png`)
+                        path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_${attempt}.png`),
+                        path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_${attempt + 1}.png`)
                     );
                 });
             });
@@ -1187,14 +1252,25 @@ describe('lib/merge-reports/data-tree', () => {
                         name: 'yabro',
                         result: mkTestResult({
                             status: SUCCESS,
-                            imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_0.png`
+                                }
+                            }]
                         })
                     })]
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     browsers: [mkBrowserResult({
                         name: 'yabro',
-                        result: mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]})
+                        result: mkTestResult({
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_0.png`
+                                }
+                            }]
+                        })
                     })]
                 });
 
@@ -1205,8 +1281,8 @@ describe('lib/merge-reports/data-tree', () => {
 
                 assert.calledWith(
                     fs.move,
-                    path.resolve('src-report/path', `images/yabro~current_0.png`),
-                    path.resolve('dest-report/path', `images/yabro~current_1.png`)
+                    path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_0.png`),
+                    path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_1.png`)
                 );
             });
 
@@ -1214,15 +1290,34 @@ describe('lib/merge-reports/data-tree', () => {
                 const srcDataSuites1 = mkSuiteTree({
                     browsers: [mkBrowserResult({
                         name: 'yabro',
-                        result: mkTestResult({status: SUCCESS, imagesInfo: [{actualImg: {path: 'images/yabro~current_1.png'}}]}),
+                        result: mkTestResult({
+                            status: SUCCESS, imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_1.png`
+                                }
+                            }]
+                        }),
                         retries: [mkTestResult()]
                     })]
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     browsers: [mkBrowserResult({
                         name: 'yabro',
-                        result: mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_1.png'}}]}),
-                        retries: [mkTestResult({imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]})]
+                        result: mkTestResult({
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_1.png`
+                                }
+                            }]
+                        }),
+                        retries: [mkTestResult({
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_0.png`
+                                }
+                            }]
+                        })]
                     })]
                 });
 
@@ -1234,8 +1329,8 @@ describe('lib/merge-reports/data-tree', () => {
                 [0, 1].forEach((attempt) => {
                     assert.calledWith(
                         fs.move,
-                        path.resolve('src-report/path', `images/yabro~current_${attempt}.png`),
-                        path.resolve('dest-report/path', `images/yabro~current_${attempt + 2}.png`)
+                        path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_${attempt}.png`),
+                        path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_${attempt + 2}.png`)
                     );
                 });
             });
@@ -1271,12 +1366,17 @@ describe('lib/merge-reports/data-tree', () => {
                         result: mkTestResult()
                     })]
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     browsers: [mkBrowserResult({
                         name: 'yabro',
                         result: mkTestResult({
                             status: SUCCESS,
-                            imagesInfo: [{actualImg: {path: 'images/yabro~current_0.png'}}]
+                            imagesInfo: [{
+                                actualImg: {
+                                    path: `${IMAGES_PATH}/yabro~current_0.png`
+                                }
+                            }]
                         })
                     })]
                 });
@@ -1288,8 +1388,8 @@ describe('lib/merge-reports/data-tree', () => {
 
                 assert.calledWith(
                     fs.move,
-                    path.resolve('src-report/path', 'images/yabro~current_0.png'),
-                    path.resolve('dest-report/path', 'images/yabro~current_1.png')
+                    path.resolve('src-report/path', `${IMAGES_PATH}/yabro~current_0.png`),
+                    path.resolve('dest-report/path', `${IMAGES_PATH}/yabro~current_1.png`)
                 );
             });
         });
@@ -1309,6 +1409,7 @@ describe('lib/merge-reports/data-tree', () => {
                         result: mkTestResult({status, attempt: 0})
                     })]
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     suite: mkSuite({status}),
                     state: mkState({suitePath: ['default-suite', 'state2'], status}),
@@ -1355,6 +1456,7 @@ describe('lib/merge-reports/data-tree', () => {
                         result: mkTestResult({status: from, attempt: 0})
                     })]
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     browsers: [mkBrowserResult({
                         name: 'yabro',
@@ -1404,6 +1506,7 @@ describe('lib/merge-reports/data-tree', () => {
                         result: mkTestResult({status, attempt: 0})
                     }))
                 });
+
                 const srcDataSuites2 = mkSuiteTree({
                     browsers: Object.entries(after).map(([name, status]) => mkBrowserResult({
                         name,

--- a/test/unit/lib/plugin-utils.js
+++ b/test/unit/lib/plugin-utils.js
@@ -5,26 +5,32 @@ const {getSuitePath} = require('lib/plugin-utils').getHermioneUtils();
 describe('getHermioneUtils', () => {
     describe('getSuitePath', () => {
         it('should return correct path for simple suite', () => {
-            const suite = {parent: {root: true}, title: 'some-title'};
-
-            const suitePath = getSuitePath(suite);
-
-            assert.match(suitePath, ['some-title']);
-        });
-
-        it('should return correct path for complex suite', () => {
             const suite = {
                 parent: {
-                    parent: {
-                        parent: {root: true}, title: 'root-title'
-                    }, title: 'parent-title'
+                    root: true
                 },
                 title: 'some-title'
             };
 
             const suitePath = getSuitePath(suite);
 
-            assert.match(suitePath, ['root-title', 'parent-title', 'some-title']);
+            assert.deepEqual(suitePath, ['some-title']);
+        });
+
+        it('should return correct path for nested suite', () => {
+            const suite = {
+                parent: {
+                    parent: {
+                        root: true
+                    },
+                    title: 'root-title'
+                },
+                title: 'some-title'
+            };
+
+            const suitePath = getSuitePath(suite);
+
+            assert.deepEqual(suitePath, ['root-title', 'some-title']);
         });
     });
 });

--- a/test/unit/lib/plugin-utils.js
+++ b/test/unit/lib/plugin-utils.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const {getSuitePath} = require('lib/plugin-utils').getHermioneUtils();
+
+describe('getHermioneUtils', () => {
+    describe('getSuitePath', () => {
+        it('should return correct path for simple suite', () => {
+            const suite = {parent: {root: true}, title: 'some-title'};
+
+            const suitePath = getSuitePath(suite);
+
+            assert.match(suitePath, ['some-title']);
+        });
+
+        it('should return correct path for complex suite', () => {
+            const suite = {
+                parent: {
+                    parent: {
+                        parent: {root: true}, title: 'root-title'
+                    }, title: 'parent-title'
+                },
+                title: 'some-title'
+            };
+
+            const suitePath = getSuitePath(suite);
+
+            assert.match(suitePath, ['root-title', 'parent-title', 'some-title']);
+        });
+    });
+});

--- a/test/unit/lib/report-builder-factory/report-builder.js
+++ b/test/unit/lib/report-builder-factory/report-builder.js
@@ -208,6 +208,34 @@ describe('ReportBuilder', () => {
         });
     });
 
+    it('should add error details to result if saveErrorDetails is set', () => {
+        const reportBuilder = mkReportBuilder_({pluginConfig: {saveErrorDetails: true}});
+
+        reportBuilder.addFail(stubTest_({
+            errorDetails: {title: 'some-title', filePath: 'some-path'}
+        }));
+
+        assert.match(getReportBuilderResult_(reportBuilder), {
+            errorDetails: {
+                title: 'some-title', filePath: 'some-path'
+            }
+        });
+    });
+
+    it('should not add error details to result if saveErrorDetails is not set', () => {
+        const reportBuilder = mkReportBuilder_({pluginConfig: {saveErrorDetails: false}});
+
+        reportBuilder.addFail(stubTest_({
+            errorDetails: {title: 'some-title', filePath: 'some-path'}
+        }));
+
+        assert.notDeepInclude(getReportBuilderResult_(reportBuilder), {
+            errorDetails: {
+                title: 'some-title', filePath: 'some-path'
+            }
+        });
+    });
+
     it('should add error test to result', () => {
         const reportBuilder = mkReportBuilder_();
 

--- a/test/unit/lib/server-utils.js
+++ b/test/unit/lib/server-utils.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 const utils = require('lib/server-utils');
-const {getShortMD5} = require('lib/gui/tool-runner-factory/hermione/utils');
+const {IMAGES_PATH} = require('lib/constants/paths');
 
 describe('server-utils', () => {
     const sandbox = sinon.sandbox.create();
@@ -25,7 +25,7 @@ describe('server-utils', () => {
 
                 const resultPath = utils[`get${testData.name}Path`](test);
 
-                assert.equal(resultPath, path.join('images', 'some', 'dir', `bro~${testData.prefix}_2.png`));
+                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_2.png`));
             });
 
             it('should add default attempt if it does not exist from test', () => {
@@ -36,7 +36,7 @@ describe('server-utils', () => {
 
                 const resultPath = utils[`get${testData.name}Path`](test);
 
-                assert.equal(resultPath, path.join('images', 'some', 'dir', `bro~${testData.prefix}_0.png`));
+                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_0.png`));
             });
 
             it('should add state name to the path if it was passed', () => {
@@ -47,7 +47,7 @@ describe('server-utils', () => {
 
                 const resultPath = utils[`get${testData.name}Path`](test, 'plain');
 
-                assert.equal(resultPath, path.join('images', 'some', 'dir', `plain/bro~${testData.prefix}_0.png`));
+                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `plain/bro~${testData.prefix}_0.png`));
             });
         });
 
@@ -64,7 +64,7 @@ describe('server-utils', () => {
 
                 const resultPath = utils[`get${testData.name}AbsolutePath`](test, 'reportPath');
 
-                assert.equal(resultPath, path.join('/root', 'reportPath', 'images', 'some', 'dir', `bro~${testData.prefix}_0.png`));
+                assert.equal(resultPath, path.join('/root', 'reportPath', IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_0.png`));
             });
 
             it('should add state name to the path if it was passed', () => {
@@ -75,7 +75,7 @@ describe('server-utils', () => {
 
                 const resultPath = utils[`get${testData.name}AbsolutePath`](test, 'reportPath', 'plain');
 
-                assert.equal(resultPath, path.join('/root', 'reportPath', 'images', 'some', 'dir', 'plain', `bro~${testData.prefix}_0.png`));
+                assert.equal(resultPath, path.join('/root', 'reportPath', IMAGES_PATH, 'some', 'dir', 'plain', `bro~${testData.prefix}_0.png`));
             });
         });
     });
@@ -120,10 +120,10 @@ describe('server-utils', () => {
     describe('getDetailsFileName', () => {
         it('should compose correct file name from suite path, browser id and attempt', () => {
             sandbox.stub(Date, 'now').returns('123456789');
-            const suitePath = ['root-title', 'some-title'];
-            const expected = `${getShortMD5('root-title some-title')}-bro_2_123456789.json`;
+            const testId = 'abcdef';
+            const expected = `${testId}-bro_2_123456789.json`;
 
-            assert.equal(utils.getDetailsFileName(suitePath, 'bro', 1), expected);
+            assert.equal(utils.getDetailsFileName(testId, 'bro', 1), expected);
         });
     });
 });

--- a/test/unit/lib/server-utils.js
+++ b/test/unit/lib/server-utils.js
@@ -3,8 +3,13 @@
 const path = require('path');
 const fs = require('fs-extra');
 const utils = require('lib/server-utils');
+const {getShortMD5} = require('lib/gui/tool-runner-factory/hermione/utils');
 
 describe('server-utils', () => {
+    const sandbox = sinon.sandbox.create();
+
+    afterEach(() => sandbox.restore());
+
     [
         {name: 'Reference', prefix: 'ref'},
         {name: 'Current', prefix: 'current'},
@@ -47,13 +52,9 @@ describe('server-utils', () => {
         });
 
         describe(`get${testData.name}AbsolutePath`, () => {
-            const sandbox = sinon.sandbox.create();
-
             beforeEach(() => {
                 sandbox.stub(process, 'cwd').returns('/root');
             });
-
-            afterEach(() => sandbox.restore());
 
             it('should generate correct absolute path for test image', () => {
                 const test = {
@@ -80,10 +81,6 @@ describe('server-utils', () => {
     });
 
     describe('prepareCommonJSData', () => {
-        const sandbox = sinon.sandbox.create();
-
-        afterEach(() => sandbox.restore());
-
         it('should wrap passed data with commonjs wrapper', () => {
             const result = utils.prepareCommonJSData({some: 'data'});
 
@@ -103,14 +100,10 @@ describe('server-utils', () => {
     });
 
     describe('copyImageAsync', () => {
-        const sandbox = sinon.sandbox.create();
-
         beforeEach(() => {
             sandbox.stub(fs, 'copy').resolves();
             sandbox.stub(fs, 'mkdirs').resolves();
         });
-
-        afterEach(() => sandbox.restore());
 
         it('should create directory and copy image', () => {
             const fromPath = '/from/image.png',
@@ -121,6 +114,16 @@ describe('server-utils', () => {
                     assert.calledWithMatch(fs.mkdirs, '/to');
                     assert.calledWithMatch(fs.copy, fromPath, toPath);
                 });
+        });
+    });
+
+    describe('getDetailsFileName', () => {
+        it('should compose correct file name from suite path, browser id and attempt', () => {
+            sandbox.stub(Date, 'now').returns('123456789');
+            const suitePath = ['root-title', 'some-title'];
+            const expected = `${getShortMD5('root-title some-title')}-bro_2_123456789.json`;
+
+            assert.equal(utils.getDetailsFileName(suitePath, 'bro', 1), expected);
         });
     });
 });


### PR DESCRIPTION
Основная идея ПР:
– любой плагин гермионы может докинуть в ошибку, которую он генерит, `details`;
– эти `details` должны быть формата: `{title: 'some-title', data}`;
– html-reporter сохранит `data` в папку `error-details`, в отдельный файл вида:
`short-md5(suite-path)-browser_attempt_timestamp.json`;
– а в отчет добавит `Error details`, которые раскрываясь покажут ссылку на файл с деталями ошибки; при этом `title` будет названием этой ссылки, чтобы пользователь понимал что именно содержится в этом файле, например, `counters` итп.