### PR TITLE
fix: retry only selected successful test

### DIFF
--- a/lib/static/modules/actions.js
+++ b/lib/static/modules/actions.js
@@ -6,8 +6,8 @@ import actionNames from './action-names';
 import modalTypes from './modal-types';
 import {QUEUED, UPDATED} from '../../constants/test-statuses';
 import {VIEW_CHANGED} from '../../constants/client-events';
-import {isSuiteIdle, isSuiteSuccessful, isSuiteFailed, isAcceptable} from './utils';
-import {isFailStatus, isErroredStatus} from '../../common-utils';
+import {isSuiteFailed, isAcceptable} from './utils';
+import {isSuccessStatus, isFailStatus, isErroredStatus, isIdleStatus} from '../../common-utils';
 import {
     getRefImagesInfo, getAllOpenedImagesInfo, getImagesInfoId, filterByBro, rejectRefImagesInfo,
     filterStatus, filterImagesInfo, filterByEqualDiffSizes
@@ -60,14 +60,12 @@ export const retrySuite = (suite) => {
     return runTests({tests: [suite], action: {type: actionNames.RETRY_SUITE}});
 };
 
-export const retryTest = (suite, browserId = null) => {
+export const retryTest = (suite, browserId) => {
     let tests = assign({browserId}, suite);
+    tests = omit(tests, 'children');
+    const browserStatus = tests.browsers.find(({name}) => name === browserId).result.status;
 
-    if (browserId) {
-        tests = omit(tests, 'children');
-    }
-
-    return isSuiteIdle(suite) || isSuiteSuccessful(suite)
+    return isIdleStatus(browserStatus) || isSuccessStatus(browserStatus)
         ? runSuccessfulTests(tests, actionNames.RETRY_TEST)
         : runFailedTests(tests, actionNames.RETRY_TEST);
 };

--- a/test/unit/lib/static/modules/actions.js
+++ b/test/unit/lib/static/modules/actions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import axios from 'axios';
+import {isArray} from 'lodash';
 
 import {acceptOpened, retryTest, runFailedTests} from 'lib/static/modules/actions';
 import {
@@ -13,16 +14,16 @@ import {
 } from '../../../utils';
 import {SUCCESS, FAIL} from 'lib/constants/test-statuses';
 
-const mkBrowserResultWithImagesInfo = name => {
+const mkBrowserResultWithImagesInfo = (name, status = FAIL) => {
     return mkBrowserResult({
         name,
-        status: FAIL,
+        status,
         result: mkTestResult({
             name,
-            status: FAIL,
+            status,
             imagesInfo: [
                 mkImagesInfo({
-                    status: FAIL,
+                    status,
                     opened: true
                 })
             ]
@@ -84,6 +85,10 @@ describe('lib/static/modules/actions', () => {
     describe('retryTest', () => {
         const suite = mkSuite({
             suitePath: ['suite1'],
+            browsers: [
+                mkBrowserResultWithImagesInfo('yabro', SUCCESS),
+                mkBrowserResultWithImagesInfo('foo-bar', FAIL)
+            ],
             children: [
                 mkState({
                     suitePath: ['suite1', 'suite2'],
@@ -93,43 +98,30 @@ describe('lib/static/modules/actions', () => {
                         mkBrowserResultWithImagesInfo('yabro')
                     ]
                 })
-            ],
-            browsers: [mkBrowserResultWithImagesInfo('yabro')]
+            ]
         });
 
-        it('should run tests from suite with children and browsers', async () => {
-            await retryTest(suite)(dispatch);
+        [
+            {browserId: 'yabro', status: 'successful'},
+            {browserId: 'foo-bar', status: 'failed'}
+        ].forEach(({browserId, status}) => {
+            it(`should run only ${status} test if it was passed`, async () => {
+                await retryTest(suite, browserId)(dispatch);
 
-            assert.calledWith(
-                axios.post,
-                sinon.match.any,
-                sinon.match(tests => {
-                    assert.equal(tests.browserId, null);
-                    assert.lengthOf(tests.browsers, 1);
-                    assert.lengthOf(tests.children, 1);
-                    assert.lengthOf(tests.children[0].browsers, 2);
-                    assert.notProperty(tests.children[0], 'children');
-                    return true;
-                })
-            );
-        });
+                assert.calledWith(
+                    axios.post,
+                    sinon.match.any,
+                    sinon.match(tests => {
+                        if (isArray(tests)) {
+                            assert.equal(tests[0].browserId, browserId);
+                        } else {
+                            assert.equal(tests.browserId, browserId);
+                        }
 
-        it('should not run children if browserId defined', async () => {
-            const browserId = 'yabro';
-
-            await retryTest(suite, browserId)(dispatch);
-
-            assert.calledWith(
-                axios.post,
-                sinon.match.any,
-                sinon.match(tests => {
-                    assert.equal(tests.browserId, 'yabro');
-                    assert.notProperty(tests, 'children');
-                    assert.lengthOf(tests.browsers, 1);
-                    assert.equal(tests.browsers[0].name, 'yabro');
-                    return true;
-                })
-            );
+                        return true;
+                    })
+                );
+            });
         });
     });
 


### PR DESCRIPTION
Экшен `retryTest` вызывается только после нажатия на кнопку "Retry" конкретного теста, поэтому статус `suite`-а проверять не нужно.