### PR TITLE
test: remove tunnel-identifier from hermione config

### DIFF
--- a/.hermione.conf.js
+++ b/.hermione.conf.js
@@ -25,7 +25,6 @@ module.exports = {
             windowSize: '1280x1024',
             desiredCapabilities: {
                 browserName: 'chrome',
-                'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
                 chromeOptions: {
                     mobileEmulation: {deviceMetrics: {pixelRatio: 1}}
                 }

--- a/test/func/fixtures/.hermione.fixtures.js
+++ b/test/func/fixtures/.hermione.fixtures.js
@@ -20,8 +20,7 @@ module.exports = {
         chrome: {
             windowSize: '1280x1024',
             desiredCapabilities: {
-                browserName: 'chrome',
-                'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER
+                browserName: 'chrome'
             }
         }
     },


### PR DESCRIPTION
Удаление опции `tunnel-identifier`, которая стала неиспользуемой после перехода на Circle CI.