### PR TITLE
feat(gui): add min{-height, -width} to  .button_type_suite-controls class

### DIFF
--- a/lib/static/gui.css
+++ b/lib/static/gui.css
@@ -61,6 +61,8 @@
 .button_type_suite-controls {
     border: 1px solid #fff;
     margin-top: 5px;
+    min-width: 2vw;
+    min-height: 2vh;
 }
 .button_blink {
     -webkit-animation: blink 0.5s linear 0s infinite alternate;


### PR DESCRIPTION
**Problem**: Buttons too small with negative zoom while trying to fit the image (heighty ones) comparison within one screen

**Proposed solution**: see PR's title

<details>
  <summary>Russian</summary>

**Проблема**: При отрицательном зуме кнопки неадекватно маленького размера, по которым сложно попасть без положительного зума или пользовательских патчей стилей. Зачем зумить? Чтобы в экран поместились большие (по высоте) изображения и в рамках одного экрана увидеть дифф, а не скролить туда и обратно.

**Решение**: добавить ограничение на мин размеры
</details>