### PR TITLE
fix: filter suites by browsers in non-gui mode

### DIFF
--- a/lib/static/modules/reducer.js
+++ b/lib/static/modules/reducer.js
@@ -39,7 +39,7 @@ function getInitialState(data) {
     if (isSqlite(saveFormat)) {
         formattedSuites = {};
     } else {
-        formattedSuites = formatSuitesData(suites);
+        formattedSuites = formatSuitesData(filterSuites(suites, filteredBrowsers));
     }
 
     const groupedErrors = groupErrors({suites: formattedSuites.suites, viewMode, errorPatterns, filteredBrowsers});


### PR DESCRIPTION
Фильтрация тестов по браузерам в редьюсере во `VIEW_INITIAL` в режиме открытия отчета напрямую (index.html) не работает, так как это действие летит только в режиме `gui`.

С другой стороны, если перенести фильтрацию в `getInitialState`, то тогда она не будет работать в gui-режиме, так как в `gui` мы получаем данные от сервера (см. ручку `/init` в `server.js`). Поэтому фильтровать надо и там, и там.