### PR TITLE
feat(error): use errorPatterns to show more understandable error info

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,19 @@ directory.
 * **baseHost** (optional) - `String` - it changes original host for view in the browser; by default original host does not change
 * **scaleImages** (optional) – `Boolean` – fit images into page width; `false` by default
 * **lazyLoadOffset** (optional) - `Number` - allows you to specify how far above and below the viewport you want to begin loading images. Lazy loading would be disabled if you specify 0. `800` by default.
-* **errorPatterns** (optional) - `Array` - error message patterns for 'Group by error' mode.
-Array element must be `Object` ({'*name*': `String`, '*pattern*': `String`}) or `String` (interpret as *name* and *pattern*).
-Test will be associated with group if test error matches on group error pattern.
-New group will be created if test cannot be associated with existing groups.
+* **errorPatterns** (optional) - `Array` - error message patterns are used:
+  * to show more understandable information about matched error;
+  * in 'Group by error' mode.
+
+  Array elements must be one of the types:
+  * `Object` with required fields *name*, *pattern* and optional field *hint* - {*name*: `String`, *pattern*: `String`, *hint*: `String`};
+  * `String` which will be interpret as *name* and *pattern*.
+
+  When one of error patterns are matched on error message then:
+  * *name* of error pattern will be displayed as title of error message and original error message will be hidden under details;
+  * *hint* of error pattern will be displayed after error *stack* field. Can be specified as html string. For example, `<div>some-useful-hint</div>`.
+
+  In 'Group by error' mode test will be associated with group if test error matches on group error pattern. New group will be created if test cannot be associated with existing groups.
 * **metaInfoBaseUrls** (optional) `Object` - base paths for making link from Meta-info values. Object option must be Meta-info's key and value must be `String`. For example, {'file': 'base/path'}.
 * **saveFormat** (optional) `String` - allows to specify the format, in which the results will be saved. Available values are:
   * `js` - save tests results to data.js file as object. Default value.
@@ -48,7 +57,7 @@ New group will be created if test cannot be associated with existing groups.
     * `sqlite.db` - Sqlite database with tests results
     * `data.js` - report's config
     * `databaseUrls.json` - absolute or relative URLs to Sqlite databases (`sqlite.db`) or/and URLs to other `databaseUrls.json` (see [merge-reports](#merge-reports))
-  
+
      You can't open local report by 'file://' protocol. Use gui mode or start a local server. For example, execute `npx http-server -p 8080` at terminal from folder where report placed and open page `http://localhost:8080` at browser.
 * **customGui** (optional) `Object` – allows to specify custom controls for gui-mode and define actions for them. `{}` is default value. Ordinarily custom controls should be split by sections depending on the purposes of the controls. At least one section should be specified.
   The structure of the custom-gui object:
@@ -162,7 +171,8 @@ module.exports = {
                 'Parameter .* must be a string',
                 {
                     name: 'Cannot read property of undefined',
-                    pattern: 'Cannot read property .* of undefined'
+                    pattern: 'Cannot read property .* of undefined',
+                    hint: '<div>google it, i dont know how to fix it =(</div>'
                 }
             ]
         }
@@ -190,7 +200,7 @@ Command that adds ability to merge reports which are created after running the t
 
 #### When save format is js (default)
 
-Command takes paths to directories with reports. 
+Command takes paths to directories with reports.
 It merge "data.js" files into single file and move reports files to destination directory.
 
 Example of usage:
@@ -202,7 +212,7 @@ npx hermione merge-reports src-report-1 src-report-2 -d dest-report
 
 Command takes paths to databases files or "databaseUrls.json" files from other html reports.
 It creates new html report at destination directory with common "databaseUrls.json"
-which will contain link to databases files or "databaseUrls.json" files from input parameters. 
+which will contain link to databases files or "databaseUrls.json" files from input parameters.
 Databases files will not be copied to destination directory.
 
 Example of usage:

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -68,13 +68,9 @@ const assertMetaInfoBaseUrls = (metaInfoBaseUrls) => {
 
 const mapErrorPatterns = (errorPatterns) => {
     return errorPatterns.map(patternInfo => {
-        if (typeof patternInfo === 'string') {
-            return {
-                name: patternInfo,
-                pattern: patternInfo
-            };
-        }
-        return patternInfo;
+        return _.isString(patternInfo)
+            ? {name: patternInfo, pattern: patternInfo}
+            : patternInfo;
     });
 };
 

--- a/lib/constants/errors.js
+++ b/lib/constants/errors.js
@@ -1,5 +1,8 @@
 'use strict';
 
-exports.getCommonErrors = () => ({
-    NO_REF_IMAGE_ERROR: 'NoRefImageError'
-});
+module.exports = {
+    getCommonErrors: () => ({
+        NO_REF_IMAGE_ERROR: 'NoRefImageError'
+    }),
+    ERROR_TITLE_TEXT_LENGTH: 200
+};

--- a/lib/report-builder/report-builder-json.js
+++ b/lib/report-builder/report-builder-json.js
@@ -54,4 +54,3 @@ module.exports = class ReportBuilderJson extends ReportBuilder {
         return saveFormats.JS;
     }
 };
-

--- a/lib/static/components/state/index.js
+++ b/lib/static/components/state/index.js
@@ -117,6 +117,10 @@ class State extends Component {
             : null;
     }
 
+    _getErrorPattern(error) {
+        return this.props.config.errorPatterns.find(({regexp}) => error.message.match(regexp));
+    }
+
     render() {
         const {status, expectedImg, actualImg, diffImg, stateName, diffClusters} = this.props.state;
         const {image, error, errorDetails} = this.props;
@@ -132,12 +136,12 @@ class State extends Component {
         }
 
         if (isErroredStatus(status)) {
-            elem = <StateError image={Boolean(image)} actualImg={actualImg} error={error} errorDetails={errorDetails}/>;
+            elem = <StateError image={Boolean(image)} actualImg={actualImg} error={error} errorPattern={this._getErrorPattern(error)} errorDetails={errorDetails}/>;
         } else if (isSuccessStatus(status) || isUpdatedStatus(status) || (isIdleStatus(status) && get(expectedImg, 'path'))) {
             elem = <StateSuccess status={status} expectedImg={expectedImg} />;
         } else if (isFailStatus(status)) {
             elem = error
-                ? <StateError image={Boolean(image)} actualImg={actualImg} error={error} errorDetails={errorDetails}/>
+                ? <StateError image={Boolean(image)} actualImg={actualImg} error={error} errorPattern={this._getErrorPattern(error)} errorDetails={errorDetails}/>
                 : <StateFail expectedImg={expectedImg} actualImg={actualImg} diffImg={diffImg} diffClusters={diffClusters}/>;
         }
 
@@ -158,5 +162,5 @@ class State extends Component {
 }
 
 export default connect(
-    ({reporter: {gui, view: {expand, scaleImages}, closeIds}}) => ({gui, expand, scaleImages, closeIds})
+    ({reporter: {gui, view: {expand, scaleImages}, closeIds, config}}) => ({gui, expand, scaleImages, closeIds, config})
 )(State);

--- a/lib/static/components/state/state-error.js
+++ b/lib/static/components/state/state-error.js
@@ -2,25 +2,31 @@
 
 import React, {Component, Fragment} from 'react';
 import PropTypes from 'prop-types';
-import {map} from 'lodash';
+import {isEmpty, map} from 'lodash';
+import ReactHtmlParser from 'react-html-parser';
 import Screenshot from './screenshot';
 import {isNoRefImageError} from '../../modules/utils';
 import ErrorDetails from './error-details';
 import Details from '../details';
+import {ERROR_TITLE_TEXT_LENGTH} from '../../../constants/errors';
 
 export default class StateError extends Component {
     static propTypes = {
         image: PropTypes.bool.isRequired,
         error: PropTypes.object.isRequired,
-        actualImg: PropTypes.object
+        actualImg: PropTypes.object,
+        errorPattern: PropTypes.object
     };
 
     render() {
-        const {image, error, errorDetails, actualImg} = this.props;
+        const {image, error, errorDetails, actualImg, errorPattern = {}} = this.props;
+        const extendedError = isEmpty(errorPattern)
+            ? error
+            : {...error, message: `${errorPattern.name}\n${error.message}`, hint: parseHtmlString(errorPattern.hint)};
 
         return (
             <div className="image-box__image image-box__image_single">
-                <div className="error">{this._errorToElements(error)}</div>
+                <div className="error">{this._errorToElements(extendedError)}</div>
                 {errorDetails && <ErrorDetails errorDetails={errorDetails}/>}
                 {this._drawImage(image, actualImg)}
             </div>
@@ -39,15 +45,51 @@ export default class StateError extends Component {
 
     _errorToElements(error) {
         return map(error, (value, key) => {
-            const [titleText, ...content] = value.split('\n');
-            const title = <Fragment><span className="error__item-key">{key}:</span> {titleText}</Fragment>;
+            if (!value) {
+                return null;
+            }
+
+            let titleText = '';
+            let content = '';
+
+            if (typeof value === 'string') {
+                if (value.match(/\n/)) {
+                    [titleText, ...content] = value.split('\n');
+                } else if (value.length < ERROR_TITLE_TEXT_LENGTH) {
+                    titleText = value;
+                } else {
+                    [titleText, ...content] = splitBySpace(value);
+                }
+
+                if (Array.isArray(content)) {
+                    content = content.join('\n');
+                }
+            } else {
+                titleText = <span style={{color: '#ccc'}}>show more</span>;
+                content = value;
+            }
+
+            const title = <Fragment><span className="error__item-key">{key}: </span>{titleText}</Fragment>;
 
             return <Details
                 key={key}
                 title={title}
-                content={content.length > 0 ? content.join('\n') : ''}
+                content={content}
                 extendClassNames="error__item"
             />;
         });
     }
+}
+
+function parseHtmlString(str = '') {
+    const html = str ? ReactHtmlParser(str) : null;
+
+    return Array.isArray(html) && html.length === 1 ? html[0] : html;
+}
+
+function splitBySpace(str) {
+    const spaceIndex = str.slice(0, ERROR_TITLE_TEXT_LENGTH).lastIndexOf(' ');
+    const breakIndex = spaceIndex === -1 ? ERROR_TITLE_TEXT_LENGTH : spaceIndex;
+
+    return [str.slice(0, breakIndex), str.slice(breakIndex + 1)];
 }

--- a/lib/static/modules/group-errors.js
+++ b/lib/static/modules/group-errors.js
@@ -86,7 +86,6 @@ function extractErrorsFromRetries(retries) {
 
 function getErrorGroupList(testWithErrors, errorPatterns, filteredBrowsers, testNameFilter, strictMatchFilter) {
     const errorGroups = {};
-    const errorPatternsWithRegExp = addRegExpToErrorPatterns(errorPatterns);
 
     for (const [testName, browsers] of Object.entries(testWithErrors)) {
         if (!isTestNameMatchFilters(testName, testNameFilter, strictMatchFilter)) {
@@ -98,7 +97,7 @@ function getErrorGroupList(testWithErrors, errorPatterns, filteredBrowsers, test
                 continue;
             }
             for (const errorText of errors) {
-                const patternInfo = matchGroup(errorText, errorPatternsWithRegExp);
+                const patternInfo = matchGroup(errorText, errorPatterns);
                 const {pattern, name} = patternInfo;
 
                 if (!errorGroups.hasOwnProperty(name)) {
@@ -124,15 +123,8 @@ function getErrorGroupList(testWithErrors, errorPatterns, filteredBrowsers, test
     return Object.values(errorGroups);
 }
 
-function addRegExpToErrorPatterns(errorPatterns) {
-    return errorPatterns.map(patternInfo => ({
-        ...patternInfo,
-        regexp: new RegExp(patternInfo.pattern)
-    }));
-}
-
-function matchGroup(errorText, errorPatternsWithRegExp) {
-    for (const group of errorPatternsWithRegExp) {
+function matchGroup(errorText, errorPatterns) {
+    for (const group of errorPatterns) {
         if (errorText.match(group.regexp)) {
             return group;
         }

--- a/lib/static/modules/reducers/reporter.js
+++ b/lib/static/modules/reducers/reporter.js
@@ -33,6 +33,9 @@ function getInitialState(data) {
         skips, suites, config, total, updated, passed,
         failed, skipped, warned, retries, perBrowser, apiValues, gui = false, autoRun, date, saveFormat
     } = data;
+
+    config.errorPatterns = config.errorPatterns.map((patternInfo) => ({...patternInfo, regexp: new RegExp(patternInfo.pattern)}));
+
     const {errorPatterns, scaleImages, lazyLoadOffset, defaultView: viewMode} = config;
     const viewQuery = getViewQuery(window.location.search);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4795,7 +4795,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
@@ -4809,8 +4808,7 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -4825,7 +4823,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
       "requires": {
         "domelementtype": "1"
       }
@@ -4834,7 +4831,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -4996,8 +4992,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "enzyme": {
       "version": "3.10.0",
@@ -7966,7 +7961,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -7980,7 +7974,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -7990,14 +7983,12 @@
         "safe-buffer": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-          "dev": true
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         },
         "string_decoder": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           }
@@ -12661,6 +12652,14 @@
             }
           }
         }
+      }
+    },
+    "react-html-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-html-parser/-/react-html-parser-2.0.2.tgz",
+      "integrity": "sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==",
+      "requires": {
+        "htmlparser2": "^3.9.0"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "opener": "^1.4.3",
     "p-queue": "^5.0.0",
     "qs": "^6.9.1",
+    "react-html-parser": "^2.0.2",
     "react-markdown": "^3.2.0",
     "reapop": "2.1.0",
     "reapop-theme-wybo": "1.0.2",

--- a/test/unit/lib/config/index.js
+++ b/test/unit/lib/config/index.js
@@ -220,6 +220,57 @@ describe('config', () => {
         });
     });
 
+    describe('"errorPatterns", option', () => {
+        describe('should throw an error if value', () => {
+            it('is not an array', () => {
+                assert.throws(
+                    () => parseConfig({errorPatterns: 100500}),
+                    '"errorPatterns" option must be array, but got number'
+                );
+            });
+
+            it('is not a string or object', () => {
+                assert.throws(
+                    () => parseConfig({errorPatterns: [100500]}),
+                    'Element of "errorPatterns" option must be plain object or string, but got number'
+                );
+            });
+
+            it('is object but does not have "name" field', () => {
+                assert.throws(
+                    () => parseConfig({errorPatterns: [{pattern: 'some-pattern'}]}),
+                    'Field "name" in element of "errorPatterns" option must be string, but got undefined'
+                );
+            });
+
+            it('is object but does not have "pattern" field', () => {
+                assert.throws(
+                    () => parseConfig({errorPatterns: [{name: 'some-err'}]}),
+                    'Field "pattern" in element of "errorPatterns" option must be string, but got undefined'
+                );
+            });
+        });
+
+        it('should has default value', () => {
+            assert.deepEqual(parseConfig({}).errorPatterns, configDefaults.errorPatterns);
+        });
+
+        it('should modify string to object', () => {
+            const config = parseConfig({errorPatterns: ['some-err']});
+
+            assert.deepEqual(config.errorPatterns[0], {name: 'some-err', pattern: 'some-err'});
+        });
+
+        it('should set object', () => {
+            const config = parseConfig({errorPatterns: [{name: 'some-err', pattern: 'some-pattern'}]});
+
+            assert.deepEqual(
+                config.errorPatterns[0],
+                {name: 'some-err', pattern: 'some-pattern'}
+            );
+        });
+    });
+
     describe('"metaInfoBaseUrls" option', () => {
         it('should set from configuration file', () => {
             const config = parseConfig({

--- a/test/unit/lib/static/components/section/state-error.js
+++ b/test/unit/lib/static/components/section/state-error.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import StateError from 'lib/static/components/state/state-error';
+import {ERROR_TITLE_TEXT_LENGTH} from 'lib/constants/errors';
+
+describe('<StateError/> component', () => {
+    const mkStateErrorComponent = (props = {}) => {
+        props = {
+            image: false,
+            error: {message: 'default-message', stack: 'default-stack'},
+            actualImg: {},
+            errorPattern: null,
+            ...props
+        };
+
+        return mount(<StateError {...props} />);
+    };
+
+    describe('"errorPattern" prop is not passed', () => {
+        it('should render error "message" and "stack" if "errorPattern" prop is not passed', () => {
+            const error = {message: 'some-msg', stack: 'some-stack'};
+
+            const component = mkStateErrorComponent({error});
+
+            assert.equal(component.find('.error__item').first().text(), 'message: some-msg');
+            assert.equal(component.find('.error__item').last().text(), 'stack: some-stack');
+        });
+
+        it('should break error fields by line break', () => {
+            const error = {message: 'msg-title\nmsg-content'};
+
+            const component = mkStateErrorComponent({error});
+
+            assert.equal(component.find('.details__summary').first().text(), 'message: msg-title');
+            assert.equal(component.find('.details__content').first().text(), 'msg-content');
+        });
+
+        it(`should not break error fields if theirs length is less than ${ERROR_TITLE_TEXT_LENGTH} charachters`, () => {
+            const error = {message: Array(ERROR_TITLE_TEXT_LENGTH - 1).join('a')};
+
+            const component = mkStateErrorComponent({error});
+
+            assert.equal(component.find('.error__item').first().text(), `message: ${error.message}`);
+        });
+
+        it(`should break error fields by spaces if theirs length more than ${ERROR_TITLE_TEXT_LENGTH} characters`, () => {
+            const messageTitle = Array(ERROR_TITLE_TEXT_LENGTH - 50).join('a');
+            const messageContent = Array(ERROR_TITLE_TEXT_LENGTH).join('b');
+            const error = {message: `${messageTitle} ${messageContent}`};
+
+            const component = mkStateErrorComponent({error});
+
+            assert.equal(component.find('.details__summary').first().text(), `message: ${messageTitle}`);
+            assert.equal(component.find('.details__content').first().text(), messageContent);
+        });
+    });
+
+    describe('"errorPattern" prop is passed', () => {
+        it('should render error "message" with starting "name" of "errorPattern" prop', () => {
+            const error = {message: 'some-msg'};
+            const errorPattern = {name: 'some-name'};
+
+            const component = mkStateErrorComponent({error, errorPattern});
+
+            assert.equal(component.find('.details__summary').first().text(), 'message: some-name');
+            assert.equal(component.find('.details__content').first().text(), 'some-msg');
+        });
+
+        it('should render "hint" as plain string', () => {
+            const error = {message: 'some-msg'};
+            const errorPattern = {name: 'some-name', hint: 'some-hint'};
+
+            const component = mkStateErrorComponent({error, errorPattern});
+
+            assert.equal(component.find('.error__item').last().text(), 'hint: some-hint');
+        });
+
+        it('should render "hint" as html string', () => {
+            const error = {message: 'some-msg'};
+            const errorPattern = {name: 'some-name', hint: '<span class="foo-bar">some-hint</span>'};
+
+            const component = mkStateErrorComponent({error, errorPattern});
+
+            assert.equal(component.find('.details__summary').last().text(), 'hint: show more');
+            assert.equal(component.find('.details__content .foo-bar').text(), 'some-hint');
+        });
+    });
+});

--- a/test/unit/lib/static/components/section/state.js
+++ b/test/unit/lib/static/components/section/state.js
@@ -2,6 +2,7 @@ import React from 'react';
 import proxyquire from 'proxyquire';
 import {defaults, defaultsDeep} from 'lodash';
 import {SUCCESS, FAIL, ERROR, UPDATED, IDLE} from 'lib/constants/test-statuses';
+import StateError from 'lib/static/components/state/state-error';
 import {mkConnectedComponent, mkTestResult_, mkImg_} from '../utils';
 
 describe('<State/>', () => {
@@ -28,6 +29,7 @@ describe('<State/>', () => {
 
         initialState = defaultsDeep(initialState, {
             gui: true,
+            config: {errorPatterns: []},
             view: {expand: 'all', scaleImages: false, showOnlyDiff: false, lazyLoadOffset: 0}
         });
 
@@ -303,6 +305,21 @@ describe('<State/>', () => {
             assert.calledTwice(toggleHandler);
             assert.calledWith(toggleHandler.firstCall, {stateName: 'plain', opened: true});
             assert.calledWith(toggleHandler.secondCall, {stateName: 'plain', opened: false});
+        });
+    });
+
+    [ERROR, FAIL].forEach((status) => {
+        describe(`<StateError/> with ${status} status`, () => {
+            it('should render with first matched error pattern', () => {
+                const error = {message: 'foo-bar'};
+                const errorPatterns = [{name: 'first', regexp: /foo-bar/}, {name: 'second', regexp: /foo-bar/}];
+                const testResult = mkTestResult_({status, stateName: 'plain', opened: true});
+
+                const stateComponent = mkStateComponent({state: testResult, error}, {config: {errorPatterns}});
+
+                assert.lengthOf(stateComponent.find(StateError), 1);
+                assert.deepEqual(stateComponent.find(StateError).prop('errorPattern'), errorPatterns[0]);
+            });
         });
     });
 });

--- a/test/unit/lib/static/modules/group-errors.js
+++ b/test/unit/lib/static/modules/group-errors.js
@@ -535,7 +535,8 @@ describe('static/modules/group-errors', () => {
         const errorPatterns = [
             {
                 name: 'Name group: message stub first',
-                pattern: 'message .* first'
+                pattern: 'message .* first',
+                regexp: /message .* first/
             }
         ];
 

--- a/test/unit/lib/static/modules/reducers/reporter.js
+++ b/test/unit/lib/static/modules/reducers/reporter.js
@@ -35,6 +35,15 @@ describe('lib/static/modules/reducers', () => {
         describe('VIEW_INITIAL', () => {
             const baseUrl = 'http://localhost/';
 
+            const _mkInitialState = (state = {}) => {
+                return {
+                    config: {
+                        errorPatterns: []
+                    },
+                    ...state
+                };
+            };
+
             beforeEach(() => {
                 global.window = {
                     location: {
@@ -48,25 +57,41 @@ describe('lib/static/modules/reducers', () => {
                 global.window = undefined;
             });
 
-            it('should take error patterns from config', () => {
-                const action = {
-                    type: actionNames.VIEW_INITIAL,
-                    payload: {
-                        config: {
-                            errorPatterns: [{name: 'err1', pattern: 'pattern1'}]
-                        }
-                    }
-                };
+            describe('"errorPatterns" field in config', () => {
+                it('should add "regexp" field', () => {
+                    const errorPatterns = [{name: 'err1', pattern: 'pattern1'}];
+                    const action = {
+                        type: actionNames.VIEW_INITIAL,
+                        payload: _mkInitialState({
+                            config: {errorPatterns}
+                        })
+                    };
 
-                const newState = reducer(defaultState, action);
+                    const newState = reducer(defaultState, action);
 
-                assert.deepEqual(newState.config.errorPatterns, [{name: 'err1', pattern: 'pattern1'}]);
+                    assert.deepEqual(newState.config.errorPatterns, [{name: 'err1', pattern: 'pattern1', regexp: /pattern1/}]);
+                });
+
+                it('should not modify original object', () => {
+                    const origErrorPatterns = [{name: 'err1', pattern: 'pattern1'}];
+                    const action = {
+                        type: actionNames.VIEW_INITIAL,
+                        payload: _mkInitialState({
+                            config: {errorPatterns: origErrorPatterns}
+                        })
+                    };
+
+                    const newState = reducer(defaultState, action);
+
+                    assert.notExists(origErrorPatterns[0].regexp);
+                    assert.notDeepEqual(newState.config.errorPatterns, origErrorPatterns);
+                });
             });
 
             describe('query params', () => {
                 describe('"browser" option', () => {
                     it('should set "filteredBrowsers" property to an empty array by default', () => {
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -75,7 +100,7 @@ describe('lib/static/modules/reducers', () => {
 
                     it('should set "filteredBrowsers" property to specified browsers', () => {
                         global.window.location = new URL(`${baseUrl}?browser=firefox&browser=safari`);
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -85,7 +110,7 @@ describe('lib/static/modules/reducers', () => {
 
                 describe('"testNameFilter" option', () => {
                     it('should set "testNameFilter" property to an empty array by default', () => {
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -95,7 +120,7 @@ describe('lib/static/modules/reducers', () => {
                     it('should set "testNameFilter" property to specified value', () => {
                         global.window.location = new URL(`${baseUrl}?testNameFilter=sometest`);
 
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -105,7 +130,7 @@ describe('lib/static/modules/reducers', () => {
 
                 describe('"strictMatchFilter" option', () => {
                     it('should set "strictMatchFilter" property to an empty array by default', () => {
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -115,7 +140,7 @@ describe('lib/static/modules/reducers', () => {
                     it('should set "strictMatchFilter" property to specified value', () => {
                         global.window.location = new URL(`${baseUrl}?strictMatchFilter=true`);
 
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -125,7 +150,7 @@ describe('lib/static/modules/reducers', () => {
 
                 describe('"retryIndex" option', () => {
                     it('should set "retryIndex" property to an empty array by default', () => {
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -135,7 +160,7 @@ describe('lib/static/modules/reducers', () => {
                     it('should set "retryIndex" property to string when not a number specified', () => {
                         global.window.location = new URL(`${baseUrl}?retryIndex=1abc`);
 
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -145,7 +170,7 @@ describe('lib/static/modules/reducers', () => {
                     it('should set "retryIndex" property to specified number', () => {
                         global.window.location = new URL(`${baseUrl}?retryIndex=10`);
 
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -155,7 +180,7 @@ describe('lib/static/modules/reducers', () => {
 
                 describe('"viewMode" option', () => {
                     it('should set "viewMode" to "all" by default', () => {
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -165,7 +190,7 @@ describe('lib/static/modules/reducers', () => {
                     it('should set "viewMode" property to specified value', () => {
                         global.window.location = new URL(`${baseUrl}?viewMode=failed`);
 
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -175,7 +200,7 @@ describe('lib/static/modules/reducers', () => {
 
                 describe('"expand" option', () => {
                     it('should set "expand" to "errors" by default', () => {
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -185,7 +210,7 @@ describe('lib/static/modules/reducers', () => {
                     it('should set "expand" property to specified value', () => {
                         global.window.location = new URL(`${baseUrl}?expand=all`);
 
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -195,7 +220,7 @@ describe('lib/static/modules/reducers', () => {
 
                 describe('"groupByError" option', () => {
                     it('should set "groupByError" to false by default', () => {
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 
@@ -205,7 +230,7 @@ describe('lib/static/modules/reducers', () => {
                     it('should set "groupByError" property to specified value', () => {
                         global.window.location = new URL(`${baseUrl}?groupByError=true`);
 
-                        const action = {type: actionNames.VIEW_INITIAL, payload: {config: {}}};
+                        const action = {type: actionNames.VIEW_INITIAL, payload: _mkInitialState()};
 
                         const newState = reducer(undefined, action);
 


### PR DESCRIPTION
Что сделано:
- при матчинге оригинальной ошибки с паттерном из `errorPatterns` вывожу первой строку `name` паттерна и под расхлопушку прячу `message` оригинальной ошибки. Также при матчинге добавляю отдельное поле `hint`, которое может быть указано в виде html строки;
- так же добавил обрезку полей ошибок по пробелу если ошибка не содержит переводов строк;