### PR TITLE
feat: show command history on error

### DIFF
--- a/lib/history-utils.js
+++ b/lib/history-utils.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const {takeRightWhile, isUndefined} = require('lodash');
+
+const normalizeArg = (arg) => typeof arg === 'object' ? JSON.stringify(arg) : `"${arg}"`;
+
+const getCommandWithArgs = ({name, args = []}) => `${name}(${args.map(normalizeArg).join(', ')})`;
+
+const getFileFromStack = ({stack}) => {
+    if (!stack || typeof stack !== 'string') {
+        return '';
+    }
+
+    const openingParenthesisPos = stack.lastIndexOf('(');
+    if (openingParenthesisPos !== -1) {
+        const closingParenthesisPos = stack.lastIndexOf(')');
+
+        return stack.substring(openingParenthesisPos + 1, closingParenthesisPos);
+    }
+
+    return stack;
+};
+
+const getCommandWithArgsAndFile = (record) => `${getCommandWithArgs(record)}: ${getFileFromStack(record)}`;
+
+const getCommandHistory = (allHistory, runnableFile) => {
+    if (isUndefined(allHistory)) {
+        return;
+    }
+
+    try {
+        const commands = allHistory
+            .filter(({stack}) => stack.includes(runnableFile))
+            .map(getCommandWithArgs)
+            .map((s) => `\t${s}\n`);
+
+        const lastSubHistory = takeRightWhile(allHistory, ({stack}) => !stack.includes(runnableFile));
+
+        const lastSubCommands = lastSubHistory
+            .map(getCommandWithArgsAndFile)
+            .map((s) => `\t\t${s}\n`);
+
+        return [...commands, ...lastSubCommands];
+    } catch (e) {
+        return `failed to get command history: ${e.message}`;
+    }
+};
+
+module.exports = {
+    getCommandHistory
+};

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -9,6 +9,7 @@ const crypto = require('crypto');
 
 const SuiteAdapter = require('./suite-adapter');
 const {getSuitePath} = require('./plugin-utils').getHermioneUtils();
+const {getCommandHistory} = require('./history-utils');
 const {SUCCESS, FAIL, ERROR, UPDATED} = require('./constants/test-statuses');
 const {ERROR_DETAILS_PATH} = require('./constants/paths');
 const utils = require('./server-utils');
@@ -210,7 +211,13 @@ module.exports = class TestAdapter {
     }
 
     get error() {
-        return _.pick(this._testResult.err, ['message', 'stack', 'stateName']);
+        const err = _.pick(this._testResult.err, ['message', 'stack', 'history', 'stateName']);
+
+        if (err.history) {
+            err.history = getCommandHistory(err.history, this._testResult.file);
+        }
+
+        return err;
     }
 
     get imageDir() {

--- a/test/unit/lib/history-utils.js
+++ b/test/unit/lib/history-utils.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const {getCommandHistory} = require('lib/history-utils');
+
+describe('history-utils', () => {
+    describe('getCommandHistory', () => {
+        it('should return commands executed in test file and all sub commands of the last command', async () => {
+            const allHistory = [
+                {name: 'foo', args: ['foo-arg'], stack: 'foo("foo-arg") (/path/to/test/file:10:4)'},
+                {name: 'baz', args: ['baz-arg'], stack: 'baz("baz-arg") (/path/to/baz/file:20:4)'},
+                {name: 'bar', args: ['bar-arg'], stack: 'bar("bar-arg") (/path/to/test/file:11:4)'},
+                {name: 'qux', args: ['qux-arg'], stack: 'qux("qux-arg") (/path/to/qux/file:21:4)'}
+            ];
+
+            const history = await getCommandHistory(allHistory, '/path/to/test/file');
+
+            assert.deepEqual(history, [
+                '\tfoo("foo-arg")\n',
+                '\tbar("bar-arg")\n',
+                '\t\tqux("qux-arg"): /path/to/qux/file:21:4\n'
+            ]);
+        });
+
+        it('should return undefined if all history is not given', async () => {
+            const history = await getCommandHistory(undefined, '/path/to/test/file');
+
+            assert.isUndefined(history);
+        });
+
+        it('should return failure message in case of exception', async () => {
+            const history = await getCommandHistory([{}], '/path/to/test/file');
+
+            assert.match(history, /failed to get command history: .*/);
+        });
+    });
+});

--- a/test/unit/lib/static/components/section/state-error.js
+++ b/test/unit/lib/static/components/section/state-error.js
@@ -16,13 +16,14 @@ describe('<StateError/> component', () => {
     };
 
     describe('"errorPattern" prop is not passed', () => {
-        it('should render error "message" and "stack" if "errorPattern" prop is not passed', () => {
-            const error = {message: 'some-msg', stack: 'some-stack'};
+        it('should render error "message", "stack" and "history" if "errorPattern" prop is not passed', () => {
+            const error = {message: 'some-msg', stack: 'some-stack', history: 'some-history'};
 
             const component = mkStateErrorComponent({error});
 
-            assert.equal(component.find('.error__item').first().text(), 'message: some-msg');
-            assert.equal(component.find('.error__item').last().text(), 'stack: some-stack');
+            assert.equal(component.find('.error__item').at(0).text(), 'message: some-msg');
+            assert.equal(component.find('.error__item').at(1).text(), 'stack: some-stack');
+            assert.equal(component.find('.error__item').at(2).text(), 'history: some-history');
         });
 
         it('should break error fields by line break', () => {

--- a/test/unit/lib/static/modules/reducers/reporter.js
+++ b/test/unit/lib/static/modules/reducers/reporter.js
@@ -311,7 +311,7 @@ describe('lib/static/modules/reducers', () => {
                         'url',
                         JSON.stringify({muted: false}),
                         'description',
-                        JSON.stringify({message: 'error message', stack: 'error stack'}),
+                        JSON.stringify({message: 'error message', stack: 'error stack', history: 'some history'}),
                         'skipReason',
                         JSON.stringify([{actualImg: {path: 'path', size: {width: 0, height: 0}}}]),
                         Number(true), // multiple tabs
@@ -326,7 +326,7 @@ describe('lib/static/modules/reducers', () => {
                         'url',
                         JSON.stringify({muted: false}),
                         'description',
-                        JSON.stringify({message: 'error message', stack: 'error stack'}),
+                        JSON.stringify({message: 'error message', stack: 'error stack', history: 'some history'}),
                         'skipReason',
                         JSON.stringify([{actualImg: {path: 'path', size: {width: 0, height: 0}}}]),
                         Number(true), // multiple tabs
@@ -341,7 +341,7 @@ describe('lib/static/modules/reducers', () => {
                         'url',
                         JSON.stringify({muted: false}),
                         'description',
-                        JSON.stringify({message: 'error message', stack: 'error stack'}),
+                        JSON.stringify({message: 'error message', stack: 'error stack', history: 'some history'}),
                         'skipReason',
                         JSON.stringify([{actualImg: {path: 'path', size: {width: 0, height: 0}}}]),
                         Number(true), // multiple tabs


### PR DESCRIPTION
If an error of a failed hermione-test contains the history of all executed commands, then we show in the report all high level commands and all sub-commands of the last command.

<img width="1596" alt="Captura de pantalla 2020-03-29 a las 11 31 58" src="https://user-images.githubusercontent.com/37290350/77844663-1b561d80-71b1-11ea-8ee4-e16ecac71801.png">