### PR TITLE
fix(screenshot): load image on viewport resize

### DIFF
--- a/lib/static/components/state/screenshot.js
+++ b/lib/static/components/state/screenshot.js
@@ -52,7 +52,7 @@ class Screenshot extends Component {
         </Fragment>;
 
         return offset && !noLazyLoad
-            ? <LazyLoad offset={offset} debounce={50} placeholder={placeholder} once>{rawElem}</LazyLoad>
+            ? <LazyLoad offset={offset} debounce={50} placeholder={placeholder} resize once>{rawElem}</LazyLoad>
             : rawElem;
     }
 


### PR DESCRIPTION
There is a bug when you click the `accept` button on screenshots many times without scrolling. I see infinite `loading` until I scroll.