### PR TITLE
feat: normalize redux store with temporary fallback to old format

### DIFF
--- a/lib/gui/tool-runner/index.js
+++ b/lib/gui/tool-runner/index.js
@@ -11,7 +11,6 @@ const subscribeOnToolEvents = require('./report-subscriber');
 const GuiReportBuilder = require('../../report-builder/gui');
 const EventSource = require('../event-source');
 const utils = require('../../server-utils');
-const {findNode} = require('../../../lib/static/modules/utils');
 const reporterHelper = require('../../reporter-helpers');
 const {UPDATED} = require('../../constants/test-statuses');
 const constantFileNames = require('../../constants/file-names');
@@ -52,7 +51,8 @@ module.exports = class ToolRunner {
     }
 
     get tree() {
-        return this._tree;
+        const {suites} = this._reportBuilder.getResult();
+        return {...this._tree, suites};
     }
 
     async initialize() {
@@ -110,41 +110,6 @@ module.exports = class ToolRunner {
                 .then(() => reportBuilder.addUpdated(updateResult))
                 .then(() => findTestResult(reportBuilder.getSuites(), formattedResult.prepareTestResult()));
         });
-    }
-
-    async _fillTestsTree() {
-        const {autoRun} = this._guiOpts;
-        this._tree = {...this._reportBuilder.getResult(), gui: true, autoRun};
-
-        const {suites} = await this._applyReuseData(this._tree.suites);
-
-        this._tree.suites = suites;
-    }
-
-    async _applyReuseData(testSuites) {
-        if (!testSuites) {
-            return {};
-        }
-
-        const {suites: preparedSuites} = await this._loadReuseData();
-
-        const suites = _.isEmpty(preparedSuites)
-            ? testSuites
-            : testSuites.map((suite) => applyReuse(preparedSuites)(suite));
-
-        return {suites};
-    }
-
-    async _loadReuseData() {
-        const dbPath = path.resolve(this._reportPath, constantFileNames.LOCAL_DATABASE_NAME);
-
-        if (await fs.pathExists(dbPath)) {
-            return getDataFromDatabase(dbPath);
-        }
-
-        logger.warn(chalk.yellow(`Nothing to reuse in ${this._reportPath}: can not load data from ${constantFileNames.DATABASE_URLS_JSON_NAME}`));
-
-        return {};
     }
 
     run(tests = []) {
@@ -207,46 +172,27 @@ module.exports = class ToolRunner {
             {refImg, state}
         );
     }
+
+    async _fillTestsTree() {
+        const {autoRun} = this._guiOpts;
+        const testsTree = await this._loadDataFromDatabase();
+
+        if (!_.isEmpty(testsTree)) {
+            this._reportBuilder.reuseTestsTree(testsTree);
+        }
+
+        this._tree = {...this._reportBuilder.getResult(), gui: true, autoRun};
+    }
+
+    async _loadDataFromDatabase() {
+        const dbPath = path.resolve(this._reportPath, constantFileNames.LOCAL_DATABASE_NAME);
+
+        if (await fs.pathExists(dbPath)) {
+            return getDataFromDatabase(dbPath);
+        }
+
+        logger.warn(chalk.yellow(`Nothing to reuse in ${this._reportPath}: can not load data from ${constantFileNames.DATABASE_URLS_JSON_NAME}`));
+
+        return {};
+    }
 };
-
-function applyReuse(reuseSuites) {
-    let isBrowserResultReused = false;
-
-    const reuseBrowserResult = (suite) => {
-        if (suite.children) {
-            suite.children = suite.children.map(reuseBrowserResult);
-
-            if (isBrowserResultReused) {
-                suite.status = getReuseStatus(reuseSuites, suite);
-            }
-        }
-
-        if (suite.browsers) {
-            suite.browsers = suite.browsers.map((bro) => {
-                const browserResult = getReuseBrowserResult(reuseSuites, suite.suitePath, bro.name);
-
-                if (browserResult) {
-                    isBrowserResultReused = true;
-
-                    suite.status = getReuseStatus(reuseSuites, suite);
-                }
-
-                return _.extend(bro, browserResult);
-            });
-        }
-
-        return suite;
-    };
-
-    return reuseBrowserResult;
-}
-
-function getReuseStatus(reuseSuites, {suitePath, status: defaultStatus}) {
-    const reuseNode = findNode(reuseSuites, suitePath);
-    return _.get(reuseNode, 'status', defaultStatus);
-}
-
-function getReuseBrowserResult(reuseSuites, suitePath, browserId) {
-    const reuseNode = findNode(reuseSuites, suitePath);
-    return _.find(_.get(reuseNode, 'browsers'), {name: browserId});
-}

--- a/lib/gui/tool-runner/utils.js
+++ b/lib/gui/tool-runner/utils.js
@@ -8,10 +8,10 @@ const crypto = require('crypto');
 const Database = require('better-sqlite3');
 const NestedError = require('nested-error-stacks');
 
+const StaticTestsTreeBuilder = require('../../tests-tree-builder/static');
 const {logger, logError} = require('../../server-utils');
 const constantFileNames = require('../../constants/file-names');
-const {findNode, setStatusForBranch} = require('../../static/modules/utils');
-const {formatTestAttempt} = require('../../../lib/static/modules/database-utils');
+const {findNode} = require('../../static/modules/utils');
 const {mergeTablesQueries, selectAllSuitesQuery, compareDatabaseRowsByTimestamp} = require('../../common-utils');
 const {writeDatabaseUrlsFile} = require('../../server-utils');
 
@@ -62,58 +62,6 @@ exports.findTestResult = (suites = [], test) => {
     return {name, suitePath, browserId, browserResult};
 };
 
-function parseDatabaseSuitesRows(rows) {
-    const suitesArray = [];
-    for (const row of rows) {
-        const formattedRow = formatTestAttempt(row);
-        const [suiteId, ...suitePath] = formattedRow.suitePath;
-        const suite = _.find(suitesArray, {name: suiteId});
-
-        if (!suite) {
-            suitesArray.push({
-                name: suiteId,
-                suitePath: [suiteId]
-            });
-        }
-
-        populateSuitesArray(formattedRow, _.find(suitesArray, {name: suiteId}), suitePath);
-        setStatusForBranch(suitesArray, formattedRow.suitePath);
-    }
-
-    return {suites: suitesArray};
-}
-
-function populateSuitesArray(attempt, node, suitePath) {
-    const pathPart = suitePath.shift();
-    if (!pathPart) {
-        node.browsers = Array.isArray(node.browsers) ? node.browsers : [];
-        const browserResult = attempt.children[0].browsers[0];
-        const browser = _.find(node.browsers, {name: browserResult.name});
-        if (!browser) {
-            browserResult.result.attempt = 0;
-            node.browsers.push(browserResult);
-            return;
-        }
-
-        const prevResult = browser.result;
-        const currentResult = browserResult.result;
-        browser.retries.push(prevResult);
-        currentResult.attempt = prevResult.attempt + 1;
-        browser.result = currentResult;
-        return;
-    }
-    node.children = Array.isArray(node.children) ? node.children : [];
-    let child = _.find(node.children, {name: pathPart});
-    if (!child) {
-        child = {
-            name: pathPart,
-            suitePath: node.suitePath.concat(pathPart)
-        };
-        node.children.push(child);
-    }
-    populateSuitesArray(attempt, child, suitePath);
-}
-
 // 'databaseUrls.json' may contain many databases urls but html-reporter at gui mode can work with single databases file.
 // all databases should be local files.
 exports.mergeDatabasesForReuse = async (reportPath) => {
@@ -163,12 +111,14 @@ exports.mergeDatabasesForReuse = async (reportPath) => {
 exports.getDataFromDatabase = (dbPath) => {
     try {
         const db = new Database(dbPath, {readonly: true, fileMustExist: true});
-        const suitesRows = db.prepare(selectAllSuitesQuery()).raw().all();
-        const suites = parseDatabaseSuitesRows(suitesRows.sort(compareDatabaseRowsByTimestamp));
+        const testsTreeBuilder = StaticTestsTreeBuilder.create();
+
+        const suitesRows = db.prepare(selectAllSuitesQuery()).raw().all().sort(compareDatabaseRowsByTimestamp);
+        const {tree} = testsTreeBuilder.build(suitesRows, {convertToOldFormat: false});
 
         db.close();
 
-        return suites;
+        return tree;
     } catch (err) {
         throw new NestedError('Error while getting data from database ', err);
     }

--- a/lib/report-builder/gui.js
+++ b/lib/report-builder/gui.js
@@ -2,11 +2,9 @@
 
 const _ = require('lodash');
 const StaticReportBuilder = require('./static');
-const {IDLE, RUNNING, SUCCESS, FAIL, SKIPPED, UPDATED} = require('../constants/test-statuses');
-const {setStatusForBranch, hasNoRefImageErrors, hasFails, allSkipped} = require('../static/modules/utils');
-const {shouldUpdateAttempt} = require('../server-utils');
-
-const statusesToSkip = [SKIPPED, RUNNING, IDLE];
+const GuiTestsTreeBuilder = require('../tests-tree-builder/gui');
+const {IDLE, SKIPPED, FAIL, SUCCESS, UPDATED} = require('../constants/test-statuses');
+const {hasFails, allSkipped, hasNoRefImageErrors} = require('../static/modules/utils');
 
 module.exports = class GuiReportBuilder extends StaticReportBuilder {
     static create(...args) {
@@ -16,7 +14,7 @@ module.exports = class GuiReportBuilder extends StaticReportBuilder {
     constructor(...args) {
         super(...args);
 
-        this._tree = {name: 'root'};
+        this._testsTree = GuiTestsTreeBuilder.create();
         this._skips = [];
         this._apiValues = {};
     }
@@ -54,17 +52,21 @@ module.exports = class GuiReportBuilder extends StaticReportBuilder {
         return this;
     }
 
+    reuseTestsTree(testsTree) {
+        this._testsTree.reuseTestsTree(testsTree);
+    }
+
     getResult() {
         const {
             defaultView, baseHost, scaleImages, lazyLoadOffset,
             errorPatterns, metaInfoBaseUrls, customGui, customScripts
         } = this._pluginConfig;
 
-        this._sortTree();
+        this._testsTree.sortTree();
 
         return {
+            suites: this._testsTree.convertToOldFormat().suites,
             skips: this._skips,
-            suites: this._tree.children,
             config: {
                 defaultView, baseHost, scaleImages, lazyLoadOffset,
                 errorPatterns, metaInfoBaseUrls, customGui, customScripts
@@ -75,119 +77,59 @@ module.exports = class GuiReportBuilder extends StaticReportBuilder {
     }
 
     getSuites() {
-        return this._tree.children;
+        return this._testsTree.convertToOldFormat().suites;
     }
 
     getCurrAttempt(formattedResult) {
-        const previousResult = this._getPreviousResult({formattedResult});
+        const {status, attempt} = this._testsTree.getLastResult(formattedResult);
 
-        return shouldUpdateAttempt(previousResult.status) ? previousResult.attempt + 1 : previousResult.attempt;
-    }
-
-    _getPreviousResult({formattedResult, stateInBrowser}) {
-        if (!stateInBrowser) {
-            const node = this._getResultNode(formattedResult);
-            stateInBrowser = this._getStateInBrowser(node, formattedResult);
-        }
-
-        return _.cloneDeep(stateInBrowser.result);
+        return [IDLE, SKIPPED].includes(status) ? attempt : attempt + 1;
     }
 
     _addTestResult(formattedResult, props) {
         super._addTestResult(formattedResult, props);
 
         const testResult = this._createTestResult(formattedResult, {...props, attempt: formattedResult.attempt});
-        const node = this._getResultNode(formattedResult);
-        const stateInBrowser = this._getStateInBrowser(node, formattedResult);
+        this._extendTestWithImagePaths(testResult, formattedResult);
 
-        if (!stateInBrowser) {
-            this._initNode(node, formattedResult, testResult);
-        } else {
-            this._updateNode({node, stateInBrowser, formattedResult, testResult});
+        if (testResult.status !== IDLE) {
+            this._updateTestResultStatus(testResult, formattedResult);
         }
+
+        this._testsTree.addTestResult(testResult, formattedResult);
 
         return formattedResult;
     }
 
-    _getResultNode(formattedResult) {
-        const {suite} = formattedResult;
-        const suitePath = suite.path.concat(formattedResult.state.name);
-        const node = findOrCreate(this._tree, suitePath);
-
-        node.browsers = Array.isArray(node.browsers) ? node.browsers : [];
-
-        return node;
-    }
-
-    _getStateInBrowser(node, formattedResult) {
-        const index = _.findIndex(node.browsers, {name: formattedResult.browserId});
-        return node.browsers[index];
-    }
-
-    _initNode(node, formattedResult, testResult) {
-        const {browserId} = formattedResult;
-        this._extendTestWithImagePaths(testResult, formattedResult);
+    _updateTestResultStatus(testResult, formattedResult) {
+        if (!hasFails({result: testResult}) && !allSkipped({result: testResult})) {
+            testResult.status = SUCCESS;
+            return;
+        }
 
         if (hasNoRefImageErrors(formattedResult)) {
             testResult.status = FAIL;
+            return;
         }
 
-        node.browsers.push({name: browserId, result: testResult, retries: []});
-        setStatusForBranch(this._tree, node.suitePath);
-    }
-
-    _updateNode({node, stateInBrowser, formattedResult, testResult}) {
-        const previousResult = this._getPreviousResult({formattedResult, stateInBrowser});
-        const {imagesInfo} = stateInBrowser.result;
-        const newResult = this._extendTestWithImagePaths(testResult, formattedResult, imagesInfo);
-        const shouldUpdateResult = this._shouldUpdateResult(formattedResult, previousResult);
-        const shouldAddRetry = this._shouldAddRetry(testResult, previousResult);
-
-        if (shouldAddRetry && !shouldUpdateResult) {
-            stateInBrowser.retries[formattedResult.attempt] = newResult;
-        }
-
-        if (shouldUpdateResult) {
-            if (shouldAddRetry) {
-                stateInBrowser.retries[previousResult.attempt] = previousResult;
-            }
-
-            const {status: currentStatus} = stateInBrowser.result;
-            stateInBrowser.result = newResult;
-
-            this._setResultStatus(stateInBrowser, currentStatus);
-        }
-
-        setStatusForBranch(this._tree, node.suitePath);
-    }
-
-    _shouldAddRetry(testResult, previousResult) {
-        return !statusesToSkip.includes(previousResult.status) && testResult.status !== UPDATED;
-    }
-
-    _shouldUpdateResult(formattedResult, previousResult) {
-        return formattedResult.attempt >= previousResult.attempt;
-    }
-
-    _setResultStatus(stateInBrowser, currentStatus) {
-        if (!hasFails(stateInBrowser) && !allSkipped(stateInBrowser)) {
-            stateInBrowser.result.status = SUCCESS;
-        } else if (hasNoRefImageErrors(stateInBrowser.result)) {
-            stateInBrowser.result.status = FAIL;
-        } else if (stateInBrowser.result.status === UPDATED) {
-            stateInBrowser.result.status = currentStatus;
+        if (testResult.status === UPDATED) {
+            const {status: prevStatus} = this._testsTree.getLastResult(formattedResult);
+            testResult.status = prevStatus;
         }
     }
 
-    _extendTestWithImagePaths(test, formattedResult, oldImagesInfo = []) {
+    _extendTestWithImagePaths(test, formattedResult) {
         const newImagesInfo = formattedResult.getImagesInfo(test.status);
 
         if (test.status !== UPDATED) {
             return _.set(test, 'imagesInfo', newImagesInfo);
         }
 
-        if (oldImagesInfo.length) {
-            test.imagesInfo = oldImagesInfo;
+        const prevImagesInfo = this._testsTree.getImagesInfo(formattedResult);
+
+        if (prevImagesInfo.length) {
+            test.imagesInfo = prevImagesInfo;
+
             newImagesInfo.forEach((imageInfo) => {
                 const {stateName} = imageInfo;
                 let index = _.findIndex(test.imagesInfo, {stateName});
@@ -195,37 +137,5 @@ module.exports = class GuiReportBuilder extends StaticReportBuilder {
                 test.imagesInfo[index] = imageInfo;
             });
         }
-
-        return test;
-    }
-
-    _sortTree(node = this._tree) {
-        if (node.children) {
-            node.children = _.sortBy(node.children, 'name');
-            node.children.forEach((node) => this._sortTree(node));
-        }
     }
 };
-
-function findOrCreate(node, statePath) {
-    if (statePath.length === 0) {
-        return node;
-    }
-
-    node.children = Array.isArray(node.children) ? node.children : [];
-
-    const pathPart = statePath.shift();
-    node.suitePath = node.suitePath || [];
-
-    let child = _.find(node.children, {name: pathPart});
-
-    if (!child) {
-        child = {
-            name: pathPart,
-            suitePath: node.suitePath.concat(pathPart)
-        };
-        node.children.push(child);
-    }
-
-    return findOrCreate(child, statePath);
-}

--- a/lib/static/components/suites.js
+++ b/lib/static/components/suites.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React, {Component} from 'react';
+import {find} from 'lodash';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import LazilyRender from '@gemini-testing/react-lazily-render';
@@ -17,18 +18,18 @@ class Suites extends Component {
     }
 
     render() {
-        const {suites, suiteIds, testNameFilter, strictMatchFilter, filteredBrowsers, lazyLoadOffset, errorGroupTests, viewMode} = this.props;
-
-        const visibleSuiteIds = suiteIds.filter(id =>
-            shouldSuiteBeShown({suite: suites[id], testNameFilter, strictMatchFilter, filteredBrowsers, errorGroupTests, viewMode})
+        const {rootSuites, testNameFilter, strictMatchFilter, filteredBrowsers, lazyLoadOffset, errorGroupTests, viewMode} = this.props;
+        const visibleRootSuites = rootSuites.filter((suite) =>
+            shouldSuiteBeShown({suite, testNameFilter, strictMatchFilter, filteredBrowsers, errorGroupTests, viewMode})
         );
 
         return (
             <div className="sections">
-                {visibleSuiteIds.map((suiteId) => {
+                {visibleRootSuites.map((suite) => {
+                    const suiteId = suite.name;
                     const sectionProps = {
                         key: suiteId,
-                        suite: suites[suiteId],
+                        suite: suite,
                         testNameFilter,
                         strictMatchFilter,
                         filteredBrowsers,
@@ -53,15 +54,16 @@ class Suites extends Component {
 export default connect(
     ({reporter: state}) => {
         const {testNameFilter, strictMatchFilter, filteredBrowsers, lazyLoadOffset, viewMode} = state.view;
+        const suiteIds = state.suiteIds[state.view.viewMode];
+        const rootSuites = suiteIds.map((id) => find(state.suites, {name: id}));
 
         return ({
-            suiteIds: state.suiteIds[state.view.viewMode],
             testNameFilter,
             filteredBrowsers,
             strictMatchFilter,
             lazyLoadOffset,
             viewMode,
-            suites: state.suites
+            rootSuites
         });
     }
 )(Suites);

--- a/lib/static/modules/database-utils.js
+++ b/lib/static/modules/database-utils.js
@@ -1,10 +1,15 @@
 'use strict';
 
-const {selectAllQuery, compareDatabaseRowsByTimestamp, dbColumnIndexes} = require('../../common-utils');
+const {isEmpty} = require('lodash');
+const {selectAllQuery, compareDatabaseRowsByTimestamp} = require('../../common-utils');
 const {DB_SUITES_TABLE_NAME} = require('../../constants/database');
 
 function getSuitesTableRows(db) {
     const databaseRows = getTableRows(db, DB_SUITES_TABLE_NAME);
+
+    if (isEmpty(databaseRows)) {
+        return;
+    }
 
     return databaseRows.values.sort(compareDatabaseRowsByTimestamp);
 }
@@ -21,47 +26,11 @@ function getTableRows(db, tableName) {
     return databaseRows;
 }
 
-function formatTestAttempt(attempt) {
-    const attemptSuitePath = JSON.parse(attempt[dbColumnIndexes.suitePath]);
-    return {
-        suitePath: attemptSuitePath,
-        name: attemptSuitePath[0],
-        children: [{
-            name: attempt[dbColumnIndexes.suiteName],
-            status: attempt[dbColumnIndexes.status],
-            suitePath: attemptSuitePath,
-            browsers: [
-                {
-                    name: attempt[dbColumnIndexes.name],
-                    result: {
-                        // timestamp corresponds to attempt number -- every next test retry will have bigger
-                        // timestamp (just like every next test retry has bigger attempt number)
-                        attempt: attempt[dbColumnIndexes.timestamp],
-                        description: attempt[dbColumnIndexes.description],
-                        imagesInfo: JSON.parse(attempt[dbColumnIndexes.imagesInfo]),
-                        metaInfo: JSON.parse(attempt[dbColumnIndexes.metaInfo]),
-                        multipleTabs: Boolean(attempt[dbColumnIndexes.multipleTabs]),
-                        name: attempt[dbColumnIndexes.name],
-                        screenshot: Boolean(attempt[dbColumnIndexes.screenshot]),
-                        status: attempt[dbColumnIndexes.status],
-                        suiteUrl: attempt[dbColumnIndexes.suiteUrl],
-                        skipReason: attempt[dbColumnIndexes.skipReason],
-                        error: JSON.parse(attempt[dbColumnIndexes.error])
-                    },
-                    retries: []
-                }
-            ]
-        }],
-        status: attempt[dbColumnIndexes.status]
-    };
-}
-
 function closeDatabase(db) {
     db.close();
 }
 
 module.exports = {
     getSuitesTableRows,
-    formatTestAttempt,
     closeDatabase
 };

--- a/lib/static/modules/reducers/reporter.js
+++ b/lib/static/modules/reducers/reporter.js
@@ -2,27 +2,25 @@
 
 import url from 'url';
 import _ from 'lodash';
+import {assign, clone, cloneDeep, filter, find, last, map, merge, reduce, isEmpty} from 'lodash';
+import StaticTestsTreeBuilder from '../../../tests-tree-builder/static';
 import actionNames from '../action-names';
 import defaultState from '../default-state';
-import {assign, clone, cloneDeep, filter, find, last, map, merge, reduce, isEmpty} from 'lodash';
 import {
     dateToLocaleString,
     findNode,
     isSuiteFailed,
     setStatusForBranch,
-    setStatusToAll,
-    updateSuitesStats
+    setStatusToAll
 } from '../utils';
 
 import {
-    closeDatabase,
-    formatTestAttempt,
-    getSuitesTableRows
+    getSuitesTableRows,
+    closeDatabase
 } from '../database-utils';
 import {groupErrors} from '../group-errors';
 import * as localStorageWrapper from './helpers/local-storage-wrapper';
 import {getViewQuery} from '../custom-queries';
-import testStatus from '../../../constants/test-statuses';
 import viewModes from '../../../constants/view-modes';
 import {versions as BrowserVersions} from '../../../constants/browser';
 import {CONTROL_TYPE_RADIOBUTTON} from '../../../gui/constants/custom-gui-control-types';
@@ -305,6 +303,7 @@ function reducer(state = getInitialState(compiledData), action) {
 
 function createTestResultsFromDb(state, action) {
     const {db, fetchDbDetails} = action.payload;
+    const testsTreeBuilder = StaticTestsTreeBuilder.create();
 
     if (fetchDbDetails.length === 0) {
         return {
@@ -322,9 +321,8 @@ function createTestResultsFromDb(state, action) {
     }
 
     const suitesRows = getSuitesTableRows(db);
-    const formattedSuites = formatSuitesDataFromDb(suitesRows);
-    const {suites, suitesStats, browsers} = formattedSuites;
-    const {failed, passed, retries, skipped, total, perBrowser} = suitesStats;
+    const {tree: {suites}, stats, skips, browsers} = testsTreeBuilder.build(suitesRows);
+    const {perBrowser, ...restStats} = stats;
     const suiteIds = {
         all: getSuiteIds(suites).sort(),
         failed: getFailedSuiteIds(suites).sort()
@@ -345,16 +343,10 @@ function createTestResultsFromDb(state, action) {
         suiteIds,
         fetchDbDetails,
         stats: {
-            all: {
-                failed,
-                passed,
-                retries,
-                skipped,
-                total
-            },
+            all: restStats,
             perBrowser
         },
-        skips: suitesStats.skippedTests,
+        skips,
         browsers,
         view: merge(state.view, {
             browsers,
@@ -363,104 +355,6 @@ function createTestResultsFromDb(state, action) {
                 : viewQuery.filteredBrowsers
         }),
         groupedErrors
-    };
-}
-
-function populateSuitesTree(attempt, node, suitePath, suitesStats) {
-    const pathPart = suitePath.shift();
-    if (!pathPart) {
-        node.browsers = Array.isArray(node.browsers) ? node.browsers : [];
-        const browserResult = attempt.children[0].browsers[0];
-
-        if (attempt.status === testStatus.SKIPPED) {
-            suitesStats.skippedTests.push({
-                browser: browserResult.name,
-                suite: attempt.suitePath.join(' '),
-                comment: browserResult.result.skipReason
-            });
-        }
-        updateSuitesStats(
-            suitesStats,
-            attempt.status,
-            {
-                suitePath: attempt.suitePath,
-                browserName: browserResult.name,
-                browserVersion: browserResult.result.metaInfo.browserVersion
-            }
-        );
-        const browser = find(node.browsers, {name: browserResult.name});
-        if (!browser) {
-            node.browsers.push(browserResult);
-            return;
-        }
-        browser.retries.push(browser.result);
-        browser.result = browserResult.result; //set the result to the latest attempt
-        return;
-    }
-    node.children = Array.isArray(node.children) ? node.children : [];
-    let child = find(node.children, {name: pathPart});
-    if (!child) {
-        child = {
-            name: pathPart,
-            suitePath: node.suitePath.concat(pathPart),
-            status: testStatus.SUCCESS,
-            failedIds: {},
-            parent: node
-        };
-        node.children.push(child);
-    }
-    populateSuitesTree(attempt, child, suitePath, suitesStats);
-}
-
-function populateBrowsers(browsers, attempt) {
-    const [child] = attempt.children;
-    const [browser] = child.browsers;
-    const {result} = browser;
-    const browserName = result.name;
-
-    if (!browsers[browserName]) {
-        browsers[browserName] = new Set();
-    }
-
-    const {browserVersion = BrowserVersions.UNKNOWN} = result.metaInfo;
-
-    browsers[browserName].add(browserVersion);
-}
-
-function formatSuitesDataFromDb(rows = []) {
-    const suitesStats = {
-        total: 0,
-        passed: 0,
-        failed: 0,
-        skipped: 0,
-        retries: 0,
-        perBrowser: {},
-        failedTestIds: {},
-        passedTestIds: {},
-        skippedTests: []
-    };
-    const browsers = {};
-    const suitesTree = {};
-    for (const attempt of rows) {
-        const formattedAttempt = formatTestAttempt(attempt);
-        const [suiteId, ...suitePath] = formattedAttempt.suitePath;
-        if (!suitesTree[suiteId]) {
-            suitesTree[suiteId] = {
-                name: suiteId,
-                suitePath: [suiteId],
-                status: testStatus.SUCCESS,
-                failedIds: {}
-            };
-        }
-
-        populateSuitesTree(formattedAttempt, suitesTree[suiteId], suitePath, suitesStats);
-        populateBrowsers(browsers, formattedAttempt);
-        setStatusForBranch(suitesTree, formattedAttempt.suitePath);
-    }
-    return {
-        suites: suitesTree,
-        suitesStats,
-        browsers: map(browsers, (versions, id) => ({id, versions: Array.from(versions)}))
     };
 }
 

--- a/lib/static/modules/utils.js
+++ b/lib/static/modules/utils.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const testStatus = require('../../constants/test-statuses');
 const {config: {defaultView}} = require('../../constants/defaults');
 const viewModes = require('../../constants/view-modes');
 const {versions: BrowserVersions} = require('../../constants/browser');
@@ -97,6 +96,7 @@ function setStatusToAll(node, status) {
 
 function findNode(node, suitePath) {
     suitePath = suitePath.slice();
+
     if (!node.children) {
         node = values(node);
         const tree = {
@@ -339,78 +339,6 @@ function isUrl(str) {
     return parsedUrl.host && parsedUrl.protocol;
 }
 
-function updateSuitesStats(stats, status, attemptInfo) {
-    const {suitePath, browserName, browserVersion} = attemptInfo;
-    const attemptId = suitePath.join('') + browserName;
-    const version = browserVersion || BrowserVersions.UNKNOWN;
-
-    if (!stats.perBrowser[browserName]) {
-        stats.perBrowser[browserName] = {};
-    }
-
-    if (!stats.perBrowser[browserName][version]) {
-        stats.perBrowser[browserName][version] = {
-            total: 0,
-            passed: 0,
-            failed: 0,
-            skipped: 0,
-            retries: 0
-        };
-    }
-
-    switch (status) {
-        case testStatus.FAIL:
-        case testStatus.ERROR: {
-            if (stats.failedTestIds[attemptId]) {
-                stats.retries++;
-                stats.perBrowser[browserName][version].retries++;
-                return;
-            }
-            stats.failedTestIds[attemptId] = true;
-            stats.failed++;
-            stats.total++;
-            stats.perBrowser[browserName][version].failed++;
-            stats.perBrowser[browserName][version].total++;
-            return;
-        }
-        case testStatus.SUCCESS: {
-            if (stats.passedTestIds[attemptId]) {
-                stats.retries++;
-                stats.perBrowser[browserName][version].retries++;
-                return;
-            }
-            if (stats.failedTestIds[attemptId]) {
-                delete stats.failedTestIds[attemptId];
-                stats.failed--;
-                stats.passed++;
-                stats.retries++;
-                stats.perBrowser[browserName][version].failed--;
-                stats.perBrowser[browserName][version].passed++;
-                stats.perBrowser[browserName][version].retries++;
-                return;
-            }
-            stats.passedTestIds[attemptId] = true;
-            stats.passed++;
-            stats.total++;
-            stats.perBrowser[browserName][version].passed++;
-            stats.perBrowser[browserName][version].total++;
-            return;
-        }
-        case testStatus.SKIPPED: {
-            stats.skipped++;
-            stats.perBrowser[browserName][version].skipped++;
-            if (stats.failedTestIds[attemptId]) {
-                delete stats.failedTestIds[attemptId];
-                stats.failed--;
-                stats.perBrowser[browserName][version].failed--;
-                return;
-            }
-            stats.total++;
-            stats.perBrowser[browserName][version].total++;
-        }
-    }
-}
-
 function isTestNameMatchFilters(testName, testNameFilter, strictMatchFilter) {
     if (!testNameFilter) {
         return true;
@@ -445,7 +373,6 @@ module.exports = {
     shouldSuiteBeShown,
     shouldBrowserBeShown,
     isUrl,
-    updateSuitesStats,
     filterSuites,
     isTestNameMatchFilters,
     getHttpErrorMessage,

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -236,6 +236,10 @@ module.exports = class TestAdapter {
         return {name: this._testResult.title};
     }
 
+    get testPath() {
+        return this._suite.path.concat(this._testResult.title);
+    }
+
     get screenshot() {
         return _.get(this._testResult, 'err.screenshot');
     }

--- a/lib/tests-tree-builder/base.js
+++ b/lib/tests-tree-builder/base.js
@@ -1,0 +1,265 @@
+'use strict';
+
+const _ = require('lodash');
+const {determineStatus} = require('../common-utils');
+
+module.exports = class ResultsTreeBuilder {
+    static create() {
+        return new this();
+    }
+
+    constructor() {
+        this._tree = {
+            suites: {byId: {}, allIds: [], allRootIds: []},
+            browsers: {byId: {}, allIds: []},
+            results: {byId: {}, allIds: []},
+            images: {byId: {}, allIds: []}
+        };
+    }
+
+    get tree() {
+        return this._tree;
+    }
+
+    sortTree() {
+        const sortChildSuites = (suiteId) => {
+            const childSuite = this._tree.suites.byId[suiteId];
+
+            if (childSuite.suiteIds) {
+                childSuite.suiteIds.sort().forEach(sortChildSuites);
+            }
+
+            if (childSuite.browserIds) {
+                childSuite.browserIds.sort();
+            }
+        };
+
+        this._tree.suites.allRootIds.sort().forEach(sortChildSuites);
+    }
+
+    addTestResult(testResult, formattedResult) {
+        const {testPath, browserId: browserName, attempt} = formattedResult;
+        const {imagesInfo} = testResult;
+
+        const suiteId = this._buildId(testPath);
+        const browserId = this._buildId(suiteId, browserName);
+        const testResultId = this._buildId(browserId, attempt);
+        const imageIds = imagesInfo
+            .map((image, i) => this._buildId(testResultId, image.stateName || `${image.status}_${i}`));
+
+        this._addSuites(testPath, browserId);
+        this._addBrowser({id: browserId, parentId: suiteId, name: browserName}, testResultId, attempt);
+        this._addResult({id: testResultId, parentId: browserId, result: testResult}, imageIds);
+        this._addImages(imageIds, {imagesInfo, parentId: testResultId});
+
+        this._setStatusForBranch(testPath);
+    }
+
+    _buildId(parentId = [], name = []) {
+        return [].concat(parentId, name).join(' ');
+    }
+
+    _addSuites(testPath, browserId) {
+        testPath.reduce((suites, name, ind, arr) => {
+            const isRoot = ind === 0;
+            const suitePath = isRoot ? [name] : arr.slice(0, ind + 1);
+            const id = this._buildId(suitePath);
+
+            if (!suites.byId[id]) {
+                const parentId = isRoot ? null : this._buildId(suitePath.slice(0, -1));
+                const suite = {id, parentId, name, suitePath, root: isRoot};
+
+                this._addSuite(suite);
+            }
+
+            if (ind !== arr.length - 1) {
+                const childSuiteId = this._buildId(id, arr[ind + 1]);
+                this._addChildSuiteId(id, childSuiteId);
+            } else {
+                this._addBrowserId(id, browserId);
+            }
+
+            return suites;
+        }, this._tree.suites);
+    }
+
+    _addSuite(suite) {
+        const {suites} = this._tree;
+
+        suites.byId[suite.id] = suite;
+        suites.allIds.push(suite.id);
+
+        if (suite.root) {
+            suites.allRootIds.push(suite.id);
+        }
+    }
+
+    _addChildSuiteId(parentSuiteId, childSuiteId) {
+        const {suites} = this._tree;
+
+        if (!suites.byId[parentSuiteId].suiteIds) {
+            suites.byId[parentSuiteId].suiteIds = [childSuiteId];
+            return;
+        }
+
+        if (!this._isChildSuiteIdExists(parentSuiteId, childSuiteId)) {
+            suites.byId[parentSuiteId].suiteIds.push(childSuiteId);
+        }
+    }
+
+    _isChildSuiteIdExists(parentSuiteId, childSuiteId) {
+        return _.includes(this._tree.suites.byId[parentSuiteId].suiteIds, childSuiteId);
+    }
+
+    _addBrowserId(parentSuiteId, browserId) {
+        const {suites} = this._tree;
+
+        if (!suites.byId[parentSuiteId].browserIds) {
+            suites.byId[parentSuiteId].browserIds = [browserId];
+            return;
+        }
+
+        if (!this._isBrowserIdExists(parentSuiteId, browserId)) {
+            suites.byId[parentSuiteId].browserIds.push(browserId);
+        }
+    }
+
+    _isBrowserIdExists(parentSuiteId, browserId) {
+        return _.includes(this._tree.suites.byId[parentSuiteId].browserIds, browserId);
+    }
+
+    _addBrowser({id, parentId, name}, testResultId, attempt) {
+        const {browsers} = this._tree;
+
+        if (!browsers.byId[id]) {
+            browsers.byId[id] = {id, parentId, name, resultIds: []};
+            browsers.allIds.push(id);
+        }
+
+        this._addResultIdToBrowser(id, testResultId, attempt);
+    }
+
+    _addResultIdToBrowser(browserId, testResultId, attempt) {
+        this._tree.browsers.byId[browserId].resultIds[attempt] = testResultId;
+    }
+
+    _addResult({id, parentId, result}, imageIds) {
+        const resultWithoutImagesInfo = _.omit(result, 'imagesInfo');
+
+        if (!this._tree.results.byId[id]) {
+            this._tree.results.allIds.push(id);
+        }
+
+        this._tree.results.byId[id] = {id, parentId, ...resultWithoutImagesInfo, imageIds};
+    }
+
+    _addImages(imageIds, {imagesInfo, parentId}) {
+        imageIds.forEach((id, ind) => {
+            this._tree.images.byId[id] = {id, parentId, ...imagesInfo[ind]};
+            this._tree.images.allIds.push(id);
+        });
+    }
+
+    _setStatusForBranch(testPath = []) {
+        const suiteId = this._buildId(testPath);
+
+        if (!suiteId) {
+            return;
+        }
+
+        const suite = this._tree.suites.byId[suiteId];
+
+        const resultStatuses = _.compact([].concat(suite.browserIds))
+            .map((browserId) => {
+                const browser = this._tree.browsers.byId[browserId];
+                const lastResultId = _.last(browser.resultIds);
+
+                return this._tree.results.byId[lastResultId].status;
+            });
+
+        const childrenSuiteStatuses = _.compact([].concat(suite.suiteIds))
+            .map((childSuiteId) => this._tree.suites.byId[childSuiteId].status);
+
+        const status = determineStatus([...resultStatuses, ...childrenSuiteStatuses]);
+
+        // if newly determined status is the same as current status, do nothing
+        if (suite.status === status) {
+            return;
+        }
+
+        suite.status = status;
+        this._setStatusForBranch(testPath.slice(0, -1));
+    }
+
+    convertToOldFormat() {
+        const tree = {children: []};
+        const {suites} = this._tree;
+
+        suites.allRootIds.forEach((rootSuiteId) => {
+            const suite = this._convertSuiteToOldFormat(_.clone(suites.byId[rootSuiteId]));
+            tree.children.push(suite);
+        });
+
+        return {suites: tree.children};
+    }
+
+    _convertSuiteToOldFormat(suite) {
+        if (suite.suiteIds) {
+            suite.children = suite.suiteIds.map((childSuiteId) => {
+                const childSuite = _.clone(this._tree.suites.byId[childSuiteId]);
+                const result = this._convertSuiteToOldFormat(childSuite);
+
+                return result;
+            });
+        }
+
+        if (suite.browserIds) {
+            suite.browsers = suite.browserIds.map((browserId) => {
+                const browser = _.clone(this._tree.browsers.byId[browserId]);
+                return this._convertBrowserToOldFormat(browser);
+            });
+        }
+
+        delete suite.suiteIds;
+        delete suite.browserIds;
+        delete suite.id;
+        delete suite.parentId;
+        delete suite.root;
+
+        return suite;
+    }
+
+    _convertBrowserToOldFormat(browser) {
+        browser.retries = browser.resultIds.slice(0, -1).map((resultId) => {
+            const result = _.clone(this._tree.results.byId[resultId]);
+            return this._convertImagesToOldFormat(result);
+        });
+
+        const resultId = _.last(browser.resultIds);
+        browser.result = _.clone(this._tree.results.byId[resultId]);
+        this._convertImagesToOldFormat(browser.result);
+
+        delete browser.resultIds;
+        delete browser.id;
+        delete browser.parentId;
+
+        return browser;
+    }
+
+    _convertImagesToOldFormat(result) {
+        result.imagesInfo = result.imageIds.map((imageId) => {
+            const image = _.clone(this._tree.images.byId[imageId]);
+
+            delete image.id;
+            delete image.parentId;
+
+            return image;
+        });
+
+        delete result.imageIds;
+        delete result.id;
+        delete result.parentId;
+
+        return result;
+    }
+};

--- a/lib/tests-tree-builder/gui.js
+++ b/lib/tests-tree-builder/gui.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const _ = require('lodash');
+const BaseTestsTreeBuilder = require('./base');
+
+module.exports = class GuiTestsTreeBuilder extends BaseTestsTreeBuilder {
+    getLastResult(formattedResult) {
+        const {testPath, browserId: browserName} = formattedResult;
+        const suiteId = this._buildId(testPath);
+        const browserId = this._buildId(suiteId, browserName);
+        const browser = this._tree.browsers.byId[browserId];
+        const testResultId = _.last(browser.resultIds);
+
+        return this._tree.results.byId[testResultId];
+    }
+
+    getImagesInfo(formattedResult) {
+        const {testPath, browserId: browserName, attempt} = formattedResult;
+        const suiteId = this._buildId(testPath);
+        const browserId = this._buildId(suiteId, browserName);
+        const testResultId = this._buildId(browserId, attempt);
+
+        return this._tree.results.byId[testResultId].imageIds.map((imageId) => {
+            return this._tree.images.byId[imageId];
+        });
+    }
+
+    reuseTestsTree(testsTree) {
+        this._tree.browsers.allIds.forEach((browserId) => this._reuseBrowser(testsTree, browserId));
+    }
+
+    _reuseBrowser(testsTree, browserId) {
+        const reuseBrowser = testsTree.browsers.byId[browserId];
+
+        if (!reuseBrowser) {
+            return;
+        }
+
+        this._tree.browsers.byId[browserId] = reuseBrowser;
+
+        reuseBrowser.resultIds.forEach((resultId) => this._reuseResults(testsTree, resultId));
+        this._reuseSuiteStatus(testsTree, this._tree.browsers.byId[browserId].parentId);
+    }
+
+    _reuseResults(testsTree, resultId) {
+        const reuseResult = testsTree.results.byId[resultId];
+
+        if (!this._tree.results.byId[resultId]) {
+            this._tree.results.allIds.push(resultId);
+        }
+
+        this._tree.results.byId[resultId] = reuseResult;
+
+        reuseResult.imageIds.forEach((imageId) => this._reuseImages(testsTree, imageId));
+    }
+
+    _reuseImages(testsTree, imageId) {
+        const reuseImage = testsTree.images.byId[imageId];
+
+        if (!this._tree.images.byId[imageId]) {
+            this._tree.images.allIds.push(imageId);
+        }
+
+        this._tree.images.byId[imageId] = reuseImage;
+    }
+
+    _reuseSuiteStatus(testsTree, suiteId) {
+        if (!suiteId) {
+            return;
+        }
+
+        const suite = this._tree.suites.byId[suiteId];
+        suite.status = testsTree.suites.byId[suiteId].status;
+
+        this._reuseSuiteStatus(testsTree, suite.parentId);
+    }
+};

--- a/lib/tests-tree-builder/static.js
+++ b/lib/tests-tree-builder/static.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const _ = require('lodash');
+const BaseTestsTreeBuilder = require('./base');
+const {dbColumnIndexes} = require('../common-utils');
+const testStatus = require('../constants/test-statuses');
+const {versions: browserVersions} = require('../constants/browser');
+
+module.exports = class StaticTestsTreeBuilder extends BaseTestsTreeBuilder {
+    constructor() {
+        super();
+
+        this._stats = {
+            ...initStats(),
+            perBrowser: {}
+        };
+        this._skips = [];
+        this._failedBrowserIds = {};
+        this._passedBrowserIds = {};
+    }
+
+    build(rows = [], opts = {convertToOldFormat: true}) {
+        // in order to sync attempts between gui tree and static tree
+        const attemptsMap = new Map();
+        const browsers = {};
+
+        for (const row of rows) {
+            const testPath = JSON.parse(row[dbColumnIndexes.suitePath]);
+            const browserName = row[dbColumnIndexes.name];
+
+            const testId = this._buildId(testPath);
+            const browserId = this._buildId(testId, browserName);
+
+            attemptsMap.set(browserId, attemptsMap.has(browserId) ? attemptsMap.get(browserId) + 1 : 0);
+            const attempt = attemptsMap.get(browserId);
+
+            const testResult = mkTestResult(row, {attempt});
+            const formattedResult = {browserId: browserName, testPath, attempt};
+
+            addBrowserVersion(browsers, testResult);
+
+            this.addTestResult(testResult, formattedResult);
+            this._calcStats(testResult, {testId, browserId, browserName});
+        }
+
+        this.sortTree();
+
+        return {
+            tree: opts.convertToOldFormat ? this.convertToOldFormat() : this.tree,
+            stats: this._stats,
+            skips: this._skips,
+            browsers: _.map(browsers, (versions, id) => ({id, versions: Array.from(versions)}))
+        };
+    }
+
+    _addResultIdToBrowser(browserId, testResultId) {
+        this._tree.browsers.byId[browserId].resultIds.push(testResultId);
+    }
+
+    _calcStats(testResult, {testId, browserId, browserName}) {
+        const {status} = testResult;
+        const {browserVersion} = testResult.metaInfo;
+        const version = browserVersion || browserVersions.UNKNOWN;
+
+        if (!this._stats.perBrowser[browserName]) {
+            this._stats.perBrowser[browserName] = {};
+        }
+
+        if (!this._stats.perBrowser[browserName][version]) {
+            this._stats.perBrowser[browserName][version] = initStats();
+        }
+
+        switch (status) {
+            case testStatus.FAIL:
+            case testStatus.ERROR: {
+                if (this._failedBrowserIds[browserId]) {
+                    this._stats.retries++;
+                    this._stats.perBrowser[browserName][version].retries++;
+                    return;
+                }
+
+                this._failedBrowserIds[browserId] = true;
+                this._stats.failed++;
+                this._stats.total++;
+                this._stats.perBrowser[browserName][version].failed++;
+                this._stats.perBrowser[browserName][version].total++;
+                return;
+            }
+
+            case testStatus.SUCCESS: {
+                if (this._passedBrowserIds[browserId]) {
+                    this._stats.retries++;
+                    this._stats.perBrowser[browserName][version].retries++;
+                    return;
+                }
+
+                if (this._failedBrowserIds[browserId]) {
+                    delete this._failedBrowserIds[browserId];
+                    this._stats.failed--;
+                    this._stats.passed++;
+                    this._stats.retries++;
+                    this._stats.perBrowser[browserName][version].failed--;
+                    this._stats.perBrowser[browserName][version].passed++;
+                    this._stats.perBrowser[browserName][version].retries++;
+
+                    return;
+                }
+
+                this._passedBrowserIds[browserId] = true;
+                this._stats.passed++;
+                this._stats.total++;
+                this._stats.perBrowser[browserName][version].passed++;
+                this._stats.perBrowser[browserName][version].total++;
+
+                return;
+            }
+
+            case testStatus.SKIPPED: {
+                this._skips.push({
+                    browser: browserName,
+                    suite: testId,
+                    comment: testResult.skipReason
+                });
+
+                this._stats.skipped++;
+                this._stats.perBrowser[browserName][version].skipped++;
+
+                if (this._failedBrowserIds[browserId]) {
+                    delete this._failedBrowserIds[browserId];
+                    this._stats.failed--;
+                    this._stats.perBrowser[browserName][version].failed--;
+                    return;
+                }
+
+                this._stats.total++;
+                this._stats.perBrowser[browserName][version].total++;
+            }
+        }
+    }
+};
+
+function initStats() {
+    return {
+        total: 0,
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        retries: 0
+    };
+}
+
+function mkTestResult(row, data = {}) {
+    return {
+        description: row[dbColumnIndexes.description],
+        imagesInfo: JSON.parse(row[dbColumnIndexes.imagesInfo]),
+        metaInfo: JSON.parse(row[dbColumnIndexes.metaInfo]),
+        multipleTabs: Boolean(row[dbColumnIndexes.multipleTabs]),
+        name: row[dbColumnIndexes.name],
+        screenshot: Boolean(row[dbColumnIndexes.screenshot]),
+        status: row[dbColumnIndexes.status],
+        suiteUrl: row[dbColumnIndexes.suiteUrl],
+        skipReason: row[dbColumnIndexes.skipReason],
+        error: JSON.parse(row[dbColumnIndexes.error]),
+        ...data
+    };
+}
+
+function addBrowserVersion(browsers, testResult) {
+    const browserId = testResult.name;
+
+    if (!browsers[browserId]) {
+        browsers[browserId] = new Set();
+    }
+
+    const {browserVersion = browserVersions.UNKNOWN} = testResult.metaInfo;
+    browsers[browserId].add(browserVersion);
+}

--- a/test/unit/lib/common-utils.js
+++ b/test/unit/lib/common-utils.js
@@ -2,7 +2,7 @@
 
 const sinon = require('sinon');
 const {determineStatus} = require('lib/common-utils');
-const {SUCCESS, IDLE} = require('lib/constants/test-statuses');
+const {RUNNING, QUEUED, ERROR, FAIL, UPDATED, SUCCESS, IDLE, SKIPPED} = require('lib/constants/test-statuses');
 
 describe('common-utils', () => {
     let sandbox;
@@ -16,10 +16,94 @@ describe('common-utils', () => {
     });
 
     describe('determineStatus', () => {
-        it(`should not rewrite suite status to ${IDLE} if some test already has final status`, () => {
+        it(`should not rewrite suite status to "${IDLE}" if some test already has final status`, () => {
             const status = determineStatus([SUCCESS, IDLE]);
 
             assert.equal(status, SUCCESS);
+        });
+
+        it(`should return "${SUCCESS}" if statuses is not passed`, () => {
+            const status = determineStatus([]);
+
+            assert.equal(status, SUCCESS);
+        });
+
+        describe('return the highest priority status from passed', () => {
+            it(`should return "${RUNNING}" regardless of order`, () => {
+                const statuses = [SKIPPED, IDLE, SUCCESS, UPDATED, FAIL, ERROR, QUEUED, RUNNING];
+
+                const statusInDirectOrder = determineStatus(statuses);
+                const statusInReverseOrder = determineStatus(statuses.reverse());
+
+                assert.equal(statusInDirectOrder, RUNNING);
+                assert.equal(statusInReverseOrder, RUNNING);
+            });
+
+            it(`should return "${QUEUED}" regardless of order`, () => {
+                const statuses = [SKIPPED, IDLE, SUCCESS, UPDATED, FAIL, ERROR, QUEUED];
+
+                const statusInDirectOrder = determineStatus(statuses);
+                const statusInReverseOrder = determineStatus(statuses.reverse());
+
+                assert.equal(statusInDirectOrder, QUEUED);
+                assert.equal(statusInReverseOrder, QUEUED);
+            });
+
+            it(`should return "${ERROR}" regardless of order`, () => {
+                const statuses = [SKIPPED, IDLE, SUCCESS, UPDATED, FAIL, ERROR];
+
+                const statusInDirectOrder = determineStatus(statuses);
+                const statusInReverseOrder = determineStatus(statuses.reverse());
+
+                assert.equal(statusInDirectOrder, ERROR);
+                assert.equal(statusInReverseOrder, ERROR);
+            });
+
+            it(`should return "${FAIL}" regardless of order`, () => {
+                const statuses = [SKIPPED, IDLE, SUCCESS, UPDATED, FAIL];
+
+                const statusInDirectOrder = determineStatus(statuses);
+                const statusInReverseOrder = determineStatus(statuses.reverse());
+
+                assert.equal(statusInDirectOrder, FAIL);
+                assert.equal(statusInReverseOrder, FAIL);
+            });
+
+            it(`should return "${UPDATED}" regardless of order`, () => {
+                const statuses = [SKIPPED, IDLE, SUCCESS, UPDATED];
+
+                const statusInDirectOrder = determineStatus(statuses);
+                const statusInReverseOrder = determineStatus(statuses.reverse());
+
+                assert.equal(statusInDirectOrder, UPDATED);
+                assert.equal(statusInReverseOrder, UPDATED);
+            });
+
+            it(`should return "${SUCCESS}" regardless of order`, () => {
+                const statuses = [SKIPPED, IDLE, SUCCESS];
+
+                const statusInDirectOrder = determineStatus(statuses);
+                const statusInReverseOrder = determineStatus(statuses.reverse());
+
+                assert.equal(statusInDirectOrder, SUCCESS);
+                assert.equal(statusInReverseOrder, SUCCESS);
+            });
+
+            it(`should return "${IDLE}" regardless of order`, () => {
+                const statuses = [SKIPPED, IDLE];
+
+                const statusInDirectOrder = determineStatus(statuses);
+                const statusInReverseOrder = determineStatus(statuses.reverse());
+
+                assert.equal(statusInDirectOrder, IDLE);
+                assert.equal(statusInReverseOrder, IDLE);
+            });
+
+            it(`should return "${SKIPPED}"`, () => {
+                const status = determineStatus([SKIPPED]);
+
+                assert.equal(status, SKIPPED);
+            });
         });
     });
 });

--- a/test/unit/lib/report-builder/gui.js
+++ b/test/unit/lib/report-builder/gui.js
@@ -4,10 +4,10 @@ const fs = require('fs-extra');
 const _ = require('lodash');
 const serverUtils = require('lib/server-utils');
 const TestAdapter = require('lib/test-adapter');
+const GuiTestsTreeBuilder = require('lib/tests-tree-builder/gui');
 const proxyquire = require('proxyquire');
 const {SUCCESS, FAIL, ERROR, SKIPPED, IDLE, UPDATED} = require('lib/constants/test-statuses');
-const {getCommonErrors} = require('lib/constants/errors');
-const {NO_REF_IMAGE_ERROR} = getCommonErrors();
+const {mkFormattedTest} = require('../../utils');
 
 describe('GuiReportBuilder', () => {
     const sandbox = sinon.sandbox.create();
@@ -28,8 +28,8 @@ describe('GuiReportBuilder', () => {
         return reportBuilder;
     };
 
-    const getReportBuilderResult_ = (reportBuilder) => reportBuilder.getSuites()[0].children[0].browsers[0].result;
-    const getReportBuilderRetries_ = (reportBuilder) => reportBuilder.getSuites()[0].children[0].browsers[0].retries;
+    const getTestResult_ = () => GuiTestsTreeBuilder.prototype.addTestResult.firstCall.args[0];
+    const getFormattedResult_ = () => GuiTestsTreeBuilder.prototype.addTestResult.firstCall.args[1];
 
     const stubTest_ = (opts = {}) => {
         const {imagesInfo = []} = opts;
@@ -67,505 +67,102 @@ describe('GuiReportBuilder', () => {
 
         hasImage = sandbox.stub().returns(true);
         GuiReportBuilder = proxyquire('lib/report-builder/gui', {
-            '../server-utils': {
-                hasImage
-            }
+            '../server-utils': {hasImage}
         });
+
+        sandbox.stub(GuiTestsTreeBuilder, 'create').returns(Object.create(GuiTestsTreeBuilder.prototype));
+        sandbox.stub(GuiTestsTreeBuilder.prototype, 'sortTree').returns({});
+        sandbox.stub(GuiTestsTreeBuilder.prototype, 'reuseTestsTree');
+        sandbox.stub(GuiTestsTreeBuilder.prototype, 'getImagesInfo').returns([]);
+        sandbox.stub(GuiTestsTreeBuilder.prototype, 'convertToOldFormat').returns({});
+        sandbox.stub(GuiTestsTreeBuilder.prototype, 'getLastResult').returns({});
+        sandbox.stub(GuiTestsTreeBuilder.prototype, 'addTestResult').returns({});
     });
 
     afterEach(() => sandbox.restore());
 
-    it('should contain "file" in "metaInfo"', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addSuccess(stubTest_({
-            suite: {file: '/path/file.js'}
-        }));
-
-        const metaInfo = getReportBuilderResult_(reportBuilder).metaInfo;
-
-        assert.equal(metaInfo.file, '/path/file.js');
-    });
-
-    it('should contain "url" in "metaInfo"', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addSuccess(stubTest_({
-            suite: {fullUrl: '/test/url'}
-        }));
-
-        const metaInfo = getReportBuilderResult_(reportBuilder).metaInfo;
-
-        assert.equal(metaInfo.url, '/test/url');
-    });
-
-    it('should contain values from meta in meta info', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addSuccess(stubTest_({
-            meta: {some: 'value'}
-        }));
-
-        const metaInfo = getReportBuilderResult_(reportBuilder).metaInfo;
-
-        assert.match(metaInfo, {some: 'value'});
-    });
-
-    it('should do not duplicate sessionId from meta in meta info', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        const test = stubTest_({
-            meta: {sessionId: 'sessionId-retry'},
-            hasDiff: () => false
-        });
-
-        reportBuilder.addRetry(test);
-
-        test.meta.sessionId = 'sessionId-fail';
-        reportBuilder.addFail(test);
-
-        const result = getReportBuilderResult_(reportBuilder);
-        const retry = getReportBuilderRetries_(reportBuilder)[0];
-
-        assert.equal(retry.metaInfo.sessionId, 'sessionId-retry');
-        assert.equal(result.metaInfo.sessionId, 'sessionId-fail');
-    });
-
-    it('should contain "name" for each suite', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addSuccess(stubTest_({
-            state: {name: 'some-state'},
-            suite: {path: ['root-suite']}
-        }));
-
-        const suiteResult = reportBuilder.getSuites()[0];
-        const stateResult = suiteResult.children[0];
-
-        assert.propertyVal(suiteResult, 'name', 'root-suite');
-        assert.propertyVal(stateResult, 'name', 'some-state');
-    });
-
-    it('should set values added through api', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.setApiValues({key: 'value'});
-
-        assert.deepEqual(reportBuilder.getResult().apiValues, {key: 'value'});
-    });
-
-    it('should add skipped test to result', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addSkipped(stubTest_({
-            browserId: 'bro1',
-            suite: {
-                skipComment: 'some skip comment',
-                fullName: 'suite-full-name'
-            }
-        }));
-
-        assert.deepEqual(reportBuilder.getResult().skips, [{
-            suite: 'suite-full-name',
-            browser: 'bro1',
-            comment: 'some skip comment'
-        }]);
-        assert.equal(getReportBuilderResult_(reportBuilder).status, SKIPPED);
-    });
-
-    it('should add success test to result', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addSuccess(stubTest_({
-            browserId: 'bro1'
-        }));
-
-        assert.match(getReportBuilderResult_(reportBuilder), {
-            status: SUCCESS,
-            name: 'bro1'
-        });
-    });
-
-    it('should add failed test to result', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addFail(stubTest_({
-            browserId: 'bro1',
-            imageDir: 'some-image-dir'
-        }));
-
-        assert.match(getReportBuilderResult_(reportBuilder), {
-            status: FAIL,
-            name: 'bro1'
-        });
-    });
-
-    it('should add error details to result if saveErrorDetails is set', async () => {
-        const reportBuilder = await mkGuiReportBuilder_({pluginConfig: {saveErrorDetails: true}});
-
-        reportBuilder.addFail(stubTest_({
-            errorDetails: {title: 'some-title', filePath: 'some-path'}
-        }));
-
-        assert.match(getReportBuilderResult_(reportBuilder), {
-            errorDetails: {
-                title: 'some-title', filePath: 'some-path'
-            }
-        });
-    });
-
-    it('should not add error details to result if saveErrorDetails is not set', async () => {
-        const reportBuilder = await mkGuiReportBuilder_({pluginConfig: {saveErrorDetails: false}});
-
-        reportBuilder.addFail(stubTest_({
-            errorDetails: {title: 'some-title', filePath: 'some-path'}
-        }));
-
-        assert.notDeepInclude(getReportBuilderResult_(reportBuilder), {
-            errorDetails: {
-                title: 'some-title', filePath: 'some-path'
-            }
-        });
-    });
-
-    it('should add error test to result', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addError(stubTest_({error: 'some-stack-trace'}));
-
-        assert.match(getReportBuilderResult_(reportBuilder), {
-            status: ERROR,
-            error: 'some-stack-trace'
-        });
-    });
-
-    it('should add base host to result with value from plugin parameter "baseHost"', async () => {
-        const reportBuilder = await mkGuiReportBuilder_({pluginConfig: {baseHost: 'some-host'}});
-
-        assert.equal(reportBuilder.getResult().config.baseHost, 'some-host');
-    });
-
-    it('should sort suites by name', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-        reportBuilder.addSuccess(stubTest_({state: {name: 'some-state'}}));
-        reportBuilder.addSuccess(stubTest_({state: {name: 'other-state'}}));
-
-        const names = _.map(reportBuilder.getResult().suites[0].children, 'name');
-
-        assert.sameOrderedMembers(names, ['other-state', 'some-state']);
-    });
-
-    it('should save retries order in the tree', async () => {
-        const reportBuilder = await mkGuiReportBuilder_();
-
-        reportBuilder.addRetry(stubTest_({attempt: 1, hasDiff: () => false}));
-        reportBuilder.addFail(stubTest_({attempt: 2, hasDiff: () => false}));
-        reportBuilder.addFail(stubTest_({attempt: 0, hasDiff: () => false}));
-        const testResult = reportBuilder.getSuites()[0].children[0].browsers[0];
-
-        assert.equal(testResult.result.attempt, 2);
-        assert.equal(testResult.retries[0].attempt, 0);
-        assert.equal(testResult.retries[1].attempt, 1);
-    });
-
-    describe('suite statuses', () => {
-        const getSuiteResult_ = (reportBuilder) => reportBuilder.getSuites()[0].children[0];
-
-        it('should set status for suite if suite status does not exist', async () => {
+    describe('"addIdle" method', () => {
+        it(`should add "${IDLE}" status to result`, async () => {
             const reportBuilder = await mkGuiReportBuilder_();
 
-            reportBuilder.addSuccess(stubTest_({browserId: 'bro'}));
+            reportBuilder.addIdle(stubTest_());
 
-            const suiteResult = getSuiteResult_(reportBuilder);
-            assert.equal(suiteResult.status, SUCCESS);
+            assert.equal(getTestResult_().status, IDLE);
         });
+    });
 
-        describe('for one browser', () => {
-            describe('should rewrite status to "skipped" if', () => {
-                it('first attempt was "idle"', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro'});
+    describe('"addSkipped" method', () => {
+        it('should add skipped test to results', async () => {
+            const reportBuilder = await mkGuiReportBuilder_();
 
-                    reportBuilder.addIdle(test);
-                    reportBuilder.addSkipped(test);
+            reportBuilder.addSkipped(stubTest_({
+                browserId: 'bro1',
+                suite: {
+                    skipComment: 'some skip comment',
+                    fullName: 'suite-full-name'
+                }
+            }));
 
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SKIPPED);
-                });
-
-                it('first attempt was "error"', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro', hasDiff: () => false});
-
-                    reportBuilder.addRetry(test);
-                    reportBuilder.addSkipped(test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SKIPPED);
-                });
-
-                it('first attempt was "fail"', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro', hasDiff: () => true});
-
-                    reportBuilder.addRetry(test);
-                    reportBuilder.addSkipped(test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SKIPPED);
-                });
-
-                it('first attempt was "updated"', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro', hasDiff: () => true});
-
-                    reportBuilder.addUpdated(test);
-                    reportBuilder.addSkipped(test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SKIPPED);
-                });
-
-                it('first attempt was "success"', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro', hasDiff: () => true});
-
-                    reportBuilder.addSuccess(test);
-                    reportBuilder.addSkipped(test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SKIPPED);
-                });
-            });
-
-            describe('should rewrite status to "success" if', async () => {
-                it('first attempt was "idle"', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro'});
-
-                    reportBuilder.addIdle(test);
-                    reportBuilder.addSuccess(test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SUCCESS);
-                });
-
-                it('first attempt was "error"', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro', hasDiff: () => false});
-
-                    reportBuilder.addRetry(test);
-                    reportBuilder.addSuccess(test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SUCCESS);
-                });
-
-                it('first attempt was "fail"', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro', hasDiff: () => true});
-
-                    reportBuilder.addRetry(test);
-                    reportBuilder.addSuccess(test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SUCCESS);
-                });
-
-                it('update test', async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test = stubTest_({browserId: 'bro', hasDiff: () => true});
-
-                    reportBuilder.addRetry(test);
-                    reportBuilder.addFail(test);
-                    reportBuilder.addUpdated(test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SUCCESS);
-                });
-            });
+            assert.equal(getTestResult_().status, SKIPPED);
+            assert.deepEqual(reportBuilder.getResult().skips, [{
+                suite: 'suite-full-name',
+                browser: 'bro1',
+                comment: 'some skip comment'
+            }]);
         });
+    });
 
-        describe('for several browsers', () => {
-            it('should not rewrite suite status to IDLE if some test still has such status', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
+    describe('"addSuccess" method', () => {
+        it('should add success test to result', async () => {
+            const reportBuilder = await mkGuiReportBuilder_();
 
-                reportBuilder.addFail(stubTest_({browserId: 'bro'}));
-                reportBuilder.addIdle(stubTest_({browserId: 'another-bro'}));
+            reportBuilder.addSuccess(stubTest_({
+                browserId: 'bro1'
+            }));
 
-                const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, FAIL);
-            });
-
-            it('should determine "error" if first test has "error"', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-
-                reportBuilder.addError(stubTest_({browserId: 'bro1'}));
-                reportBuilder.addFail(stubTest_({browserId: 'bro2'}));
-                reportBuilder.addUpdated(stubTest_({browserId: 'bro3'}));
-                reportBuilder.addSuccess(stubTest_({browserId: 'bro4'}));
-                reportBuilder.addSkipped(stubTest_({browserId: 'bro5'}));
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, ERROR);
-            });
-
-            it('should determine "error" if last test has "error"', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-
-                reportBuilder.addSkipped(stubTest_({browserId: 'bro5'}));
-                reportBuilder.addSuccess(stubTest_({browserId: 'bro4'}));
-                reportBuilder.addUpdated(stubTest_({browserId: 'bro3'}));
-                reportBuilder.addFail(stubTest_({browserId: 'bro2'}));
-                reportBuilder.addError(stubTest_({browserId: 'bro1'}));
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, ERROR);
-            });
-
-            it('should determine "fail" if first test has "fail"', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-
-                reportBuilder.addFail(stubTest_({browserId: 'bro1'}));
-                reportBuilder.addUpdated(stubTest_({browserId: 'bro2'}));
-                reportBuilder.addSuccess(stubTest_({browserId: 'bro3'}));
-                reportBuilder.addSkipped(stubTest_({browserId: 'bro4'}));
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, FAIL);
-            });
-
-            it('should determine "fail" if last test has "fail"', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-
-                reportBuilder.addSkipped(stubTest_({browserId: 'bro4'}));
-                reportBuilder.addSuccess(stubTest_({browserId: 'bro3'}));
-                reportBuilder.addUpdated(stubTest_({browserId: 'bro2'}));
-                reportBuilder.addFail(stubTest_({browserId: 'bro1'}));
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, FAIL);
-            });
-
-            it('should determine "success" if first test has "success"', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-
-                reportBuilder.addSuccess(stubTest_({browserId: 'bro1'}));
-                reportBuilder.addSkipped(stubTest_({browserId: 'bro2'}));
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, SUCCESS);
-            });
-
-            it('should determine "success" if last test has "success"', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-
-                reportBuilder.addSkipped(stubTest_({browserId: 'bro2'}));
-                reportBuilder.addSuccess(stubTest_({browserId: 'bro1'}));
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, SUCCESS);
-            });
-
-            it('should determine "success" if update failed test', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-
-                reportBuilder.addSkipped(stubTest_({browserId: 'bro1'}));
-                reportBuilder.addError(stubTest_({browserId: 'bro2'}));
-                reportBuilder.addUpdated(stubTest_({browserId: 'bro2'}));
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-                assert.equal(suiteResult.status, SUCCESS);
-            });
-        });
-
-        describe('for retried browsers', () => {
-            [
-                {status: 'failed', hasDiff: true},
-                {status: 'errored', hasDiff: false}
-            ].forEach(({status, hasDiff}) => {
-                it(`should rewrite suite status to "success" if it has ${status}, then skipped test`, async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-                    const test1 = stubTest_({browserId: 'bro', hasDiff: () => hasDiff});
-                    const test2 = stubTest_({browserId: 'bro', hasDiff: () => hasDiff});
-
-                    reportBuilder.addSuccess(stubTest_({browserId: 'another-bro'}));
-                    reportBuilder.addRetry(test1);
-                    reportBuilder.addSkipped(test2);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-                    assert.equal(suiteResult.status, SUCCESS);
-                });
-            });
-        });
-
-        describe('should rewrite suite status to "fail" if test failed with no reference image error', () => {
-            it('and test does not exist in tests tree', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-                const test = stubTest_({
-                    status: ERROR,
-                    imagesInfo: [{
-                        stateName: 'plain', status: ERROR,
-                        error: {stack: `${NO_REF_IMAGE_ERROR}: ...`}
-                    }]
-                });
-
-                reportBuilder.addError(test);
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-
-                assert.equal(suiteResult.status, FAIL);
-            });
-
-            it('and test exists in tests tree', async () => {
-                const reportBuilder = await mkGuiReportBuilder_();
-                const test = stubTest_({
-                    status: ERROR,
-                    imagesInfo: [{
-                        stateName: 'plain', status: ERROR,
-                        error: {stack: `${NO_REF_IMAGE_ERROR}: ...`}
-                    }]
-                });
-
-                reportBuilder.addIdle(test);
-                reportBuilder.addError(test);
-
-                const suiteResult = getSuiteResult_(reportBuilder);
-
-                assert.equal(suiteResult.status, FAIL);
-            });
-        });
-
-        describe('should not rewrite suite status to "success" if image comparison is successful, but test', () => {
-            [
-                {status: FAIL, methodName: 'addFail'},
-                {status: ERROR, methodName: 'addError'}
-            ].forEach(({status, methodName}) => {
-                it(`${status}ed`, async () => {
-                    const reportBuilder = await mkGuiReportBuilder_();
-
-                    const test = stubTest_({
-                        imagesInfo: [{stateName: 'plain', status: SUCCESS}]
-                    });
-
-                    reportBuilder.addIdle(test);
-                    reportBuilder[methodName](test);
-
-                    const suiteResult = getSuiteResult_(reportBuilder);
-
-                    assert.equal(suiteResult.status, status);
-                });
+            assert.match(getTestResult_(), {
+                status: SUCCESS,
+                name: 'bro1'
             });
         });
     });
 
-    describe('addRetry', () => {
+    describe('"addFail" method', () => {
+        it('should add failed test to result', async () => {
+            const reportBuilder = await mkGuiReportBuilder_();
+
+            reportBuilder.addFail(stubTest_({
+                browserId: 'bro1',
+                imageDir: 'some-image-dir'
+            }));
+
+            assert.match(getTestResult_(), {
+                status: FAIL,
+                name: 'bro1'
+            });
+        });
+    });
+
+    describe('"addError" method', () => {
+        it('should add error test to result', async () => {
+            const reportBuilder = await mkGuiReportBuilder_();
+
+            reportBuilder.addError(stubTest_({error: 'some-stack-trace'}));
+
+            assert.match(getTestResult_(), {
+                status: ERROR,
+                error: 'some-stack-trace'
+            });
+        });
+    });
+
+    describe('"addRetry" method', () => {
         it('should add "fail" status to result if test result has not equal images', async () => {
             const reportBuilder = await mkGuiReportBuilder_();
 
             reportBuilder.addRetry(stubTest_({hasDiff: () => true}));
 
-            assert.match(getReportBuilderResult_(reportBuilder), {status: FAIL});
+            assert.equal(getTestResult_().status, FAIL);
         });
 
         it('should add "error" status to result if test result has no image', async () => {
@@ -573,29 +170,17 @@ describe('GuiReportBuilder', () => {
 
             reportBuilder.addRetry(stubTest_({hasDiff: () => false}));
 
-            assert.match(getReportBuilderResult_(reportBuilder), {status: ERROR});
+            assert.equal(getTestResult_().status, ERROR);
         });
     });
 
-    describe('addIdle', () => {
-        it('should add "idle" status to result', async () => {
+    describe('"addUpdated" method', () => {
+        it(`should add "${SUCCESS}" status to result if all images updated`, async () => {
             const reportBuilder = await mkGuiReportBuilder_();
 
-            reportBuilder.addIdle(stubTest_(), 'some/url');
+            reportBuilder.addUpdated(stubTest_({imagesInfo: [{status: UPDATED}]}));
 
-            const result = getReportBuilderResult_(reportBuilder);
-            assert.propertyVal(result, 'status', IDLE);
-        });
-    });
-
-    describe('addUpdated', () => {
-        it('should add "updated" status to result', async () => {
-            const reportBuilder = await mkGuiReportBuilder_();
-
-            reportBuilder.addUpdated(stubTest_());
-
-            const result = getReportBuilderResult_(reportBuilder);
-            assert.propertyVal(result, 'status', UPDATED);
+            assert.equal(getTestResult_().status, SUCCESS);
         });
 
         it('should update test image for current state name', async () => {
@@ -607,6 +192,7 @@ describe('GuiReportBuilder', () => {
                     {stateName: 'plain2', status: FAIL}
                 ]
             });
+
             const updatedTest = stubTest_({
                 imagesInfo: [
                     {stateName: 'plain1', status: UPDATED}
@@ -614,35 +200,14 @@ describe('GuiReportBuilder', () => {
             });
 
             reportBuilder.addFail(failedTest);
+            GuiTestsTreeBuilder.prototype.getImagesInfo.returns(failedTest.imagesInfo);
             reportBuilder.addUpdated(updatedTest);
 
-            const {imagesInfo} = getReportBuilderResult_(reportBuilder);
+            const {imagesInfo} = getTestResult_();
 
             assert.match(imagesInfo[0], {stateName: 'plain1', status: UPDATED});
             assert.match(imagesInfo[1], {stateName: 'plain2', status: FAIL});
-        });
-
-        it('should not rewrite status to "updated" if test has failed states', async () => {
-            const reportBuilder = await mkGuiReportBuilder_();
-
-            const failedTest = stubTest_({
-                imagesInfo: [
-                    {stateName: 'plain1', status: FAIL},
-                    {stateName: 'plain2', status: FAIL}
-                ]
-            });
-            const updatedTest = stubTest_({
-                imagesInfo: [
-                    {stateName: 'plain1', status: UPDATED}
-                ]
-            });
-
-            reportBuilder.addFail(failedTest);
-            reportBuilder.addUpdated(updatedTest);
-
-            const {status} = getReportBuilderResult_(reportBuilder);
-
-            assert.equal(status, FAIL);
+            assert.equal(getTestResult_().status, FAIL);
         });
 
         it('should update last test image if state name was not passed', async () => {
@@ -661,12 +226,169 @@ describe('GuiReportBuilder', () => {
             });
 
             reportBuilder.addFail(failedTest);
+            GuiTestsTreeBuilder.prototype.getImagesInfo.returns(failedTest.imagesInfo);
             reportBuilder.addUpdated(updatedTest);
 
-            const {imagesInfo} = getReportBuilderResult_(reportBuilder);
+            const {imagesInfo} = getTestResult_();
 
             assert.match(imagesInfo[0], {status: FAIL});
             assert.match(imagesInfo[1], {status: UPDATED});
+        });
+    });
+
+    describe('"setApiValues" method', () => {
+        it('should set values added through api', async () => {
+            const reportBuilder = await mkGuiReportBuilder_();
+
+            reportBuilder.setApiValues({key: 'value'});
+
+            assert.deepEqual(reportBuilder.getResult().apiValues, {key: 'value'});
+        });
+    });
+
+    describe('"reuseTestsTree" method', () => {
+        it('should call "reuseTestsTree" from tests tree builder', async () => {
+            const reportBuilder = await mkGuiReportBuilder_();
+
+            reportBuilder.reuseTestsTree('some-tree');
+
+            assert.calledOnceWith(GuiTestsTreeBuilder.prototype.reuseTestsTree, 'some-tree');
+        });
+    });
+
+    describe('"getResult" method', () => {
+        it('should sort tests tree', async () => {
+            const reportBuilder = await mkGuiReportBuilder_();
+
+            reportBuilder.getResult();
+
+            assert.calledOnceWith(GuiTestsTreeBuilder.prototype.sortTree);
+        });
+
+        it('should add base host to result with value from plugin parameter "baseHost"', async () => {
+            const reportBuilder = await mkGuiReportBuilder_({pluginConfig: {baseHost: 'some-host'}});
+
+            assert.equal(reportBuilder.getResult().config.baseHost, 'some-host');
+        });
+    });
+
+    describe('"getSuites" method', () => {
+        it('should return suites from tests tree builder', async () => {
+            const suites = {some: 'suite'};
+            GuiTestsTreeBuilder.prototype.convertToOldFormat.returns({suites});
+
+            const reportBuilder = await mkGuiReportBuilder_();
+
+            assert.deepEqual(reportBuilder.getSuites(), suites);
+        });
+    });
+
+    describe('"getCurrAttempt" method', () => {
+        [IDLE, SKIPPED].forEach((status) => {
+            it(`should return attempt for last result if status is "${status}"`, async () => {
+                const formattedResult = {status, attempt: 100500};
+                GuiTestsTreeBuilder.prototype.getLastResult.returns(formattedResult);
+                const reportBuilder = await mkGuiReportBuilder_();
+
+                const currAttempt = reportBuilder.getCurrAttempt(formattedResult);
+
+                assert.equal(currAttempt, formattedResult.attempt);
+            });
+        });
+
+        [SUCCESS, FAIL, ERROR, UPDATED].forEach((status) => {
+            it(`should return attempt for next result if status is "${status}"`, async () => {
+                const formattedResult = {status, attempt: 100500};
+                GuiTestsTreeBuilder.prototype.getLastResult.returns(formattedResult);
+                const reportBuilder = await mkGuiReportBuilder_();
+
+                const currAttempt = reportBuilder.getCurrAttempt(formattedResult);
+
+                assert.equal(currAttempt, formattedResult.attempt + 1);
+            });
+        });
+    });
+
+    describe('add test result to tree', () => {
+        describe('should pass test result with', () => {
+            it('"suiteUrl" field', async () => {
+                const reportBuilder = await mkGuiReportBuilder_();
+
+                reportBuilder.addSuccess(stubTest_({
+                    suite: {
+                        url: 'some-url'
+                    }
+                }));
+
+                assert.equal(getTestResult_().suiteUrl, 'some-url');
+            });
+
+            it('"name" field as browser id', async () => {
+                const reportBuilder = await mkGuiReportBuilder_();
+
+                reportBuilder.addSuccess(stubTest_({browserId: 'yabro'}));
+
+                assert.equal(getTestResult_().name, 'yabro');
+            });
+
+            it('"metaInfo" field', async () => {
+                const reportBuilder = await mkGuiReportBuilder_();
+
+                reportBuilder.addSuccess(stubTest_({
+                    meta: {some: 'value', sessionId: '12345'},
+                    suite: {
+                        file: '/path/file.js',
+                        fullUrl: '/test/url'
+                    }
+                }));
+
+                const expectedMetaInfo = {some: 'value', sessionId: '12345', file: '/path/file.js', url: '/test/url'};
+
+                assert.deepEqual(getTestResult_().metaInfo, expectedMetaInfo);
+            });
+
+            [
+                {name: 'description', value: 'some-descr'},
+                {name: 'imagesInfo', value: ['some-images']},
+                {name: 'screenshot', value: false},
+                {name: 'multipleTabs', value: true}
+            ].forEach(({name, value}) => {
+                it(`add "${name}" field`, async () => {
+                    const reportBuilder = await mkGuiReportBuilder_();
+
+                    reportBuilder.addSuccess(stubTest_({[name]: value}));
+
+                    assert.deepEqual(getTestResult_()[name], value);
+                });
+            });
+        });
+
+        it('should pass test result without "errorDetails" if "saveErrorDetails" is not set', async () => {
+            const reportBuilder = await mkGuiReportBuilder_({pluginConfig: {saveErrorDetails: false}});
+            const errorDetails = {title: 'some-title', filePath: 'some-path'};
+
+            reportBuilder.addFail(stubTest_({errorDetails}));
+
+            assert.isUndefined(getTestResult_().errorDetails);
+        });
+
+        it('should pass test result with "errorDetails" if "saveErrorDetails" is set', async () => {
+            const reportBuilder = await mkGuiReportBuilder_({pluginConfig: {saveErrorDetails: true}});
+            const errorDetails = {title: 'some-title', filePath: 'some-path'};
+
+            reportBuilder.addFail(stubTest_({errorDetails}));
+
+            assert.deepEqual(getTestResult_().errorDetails, errorDetails);
+        });
+
+        it('should pass formatted result', async () => {
+            const reportBuilder = await mkGuiReportBuilder_();
+            const formattedTest = mkFormattedTest();
+            sandbox.stub(reportBuilder, 'format').returns(formattedTest);
+
+            reportBuilder.addSuccess(stubTest_());
+
+            assert.deepEqual(getFormattedResult_(), formattedTest);
         });
     });
 });

--- a/test/unit/lib/tests-tree-builder/base.js
+++ b/test/unit/lib/tests-tree-builder/base.js
@@ -1,0 +1,282 @@
+'use strict';
+
+const _ = require('lodash');
+const proxyquire = require('proxyquire');
+const {FAIL, ERROR, SUCCESS} = require('lib/constants/test-statuses');
+
+describe('ResultsTreeBuilder', () => {
+    const sandbox = sinon.sandbox.create();
+    let ResultsTreeBuilder, builder, determineStatus;
+
+    const mkTestResult_ = (result) => {
+        return _.defaults(result, {imagesInfo: []});
+    };
+
+    const mkFormattedResult_ = (result) => {
+        return _.defaults(result, {
+            testPath: ['default-parent-suite', 'default-child-suite'],
+            browserId: 'default-browser',
+            attempt: 0
+        });
+    };
+
+    beforeEach(() => {
+        determineStatus = sandbox.stub().returns(SUCCESS);
+        ResultsTreeBuilder = proxyquire('lib/tests-tree-builder/base', {
+            '../common-utils': {determineStatus}
+        });
+
+        builder = ResultsTreeBuilder.create();
+    });
+
+    afterEach(() => sandbox.restore());
+
+    describe('"sortTree" method', () => {
+        it('should sort ids of root suites', () => {
+            builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s2']}));
+            builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1']}));
+
+            builder.sortTree();
+
+            assert.deepEqual(builder.tree.suites.allRootIds, ['s1', 's2']);
+        });
+
+        it('should sort ids of child suites', () => {
+            builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1', 'ch2']}));
+            builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1', 'ch1']}));
+
+            builder.sortTree();
+
+            assert.deepEqual(builder.tree.suites.byId['s1'].suiteIds, ['s1 ch1', 's1 ch2']);
+        });
+
+        it('should sort ids of browsers', () => {
+            builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1'], browserId: 'b2'}));
+            builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1'], browserId: 'b1'}));
+
+            builder.sortTree();
+
+            assert.deepEqual(builder.tree.suites.byId['s1'].browserIds, ['s1 b1', 's1 b2']);
+        });
+    });
+
+    describe('"addTestResult" method', () => {
+        describe('"suites" field in the tree', () => {
+            it('should collect all suite root ids', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1', 's2']}));
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s3', 's4']}));
+
+                assert.deepEqual(builder.tree.suites.allRootIds, ['s1', 's3']);
+            });
+
+            it('should collect all suite ids', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1', 's2']}));
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s3', 's4']}));
+
+                assert.deepEqual(builder.tree.suites.allIds, ['s1', 's1 s2', 's3', 's3 s4']);
+            });
+
+            it('should correctly init root suite', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1', 's2']}));
+
+                assert.deepEqual(
+                    builder.tree.suites.byId['s1'],
+                    {
+                        id: 's1',
+                        name: 's1',
+                        parentId: null,
+                        root: true,
+                        suitePath: ['s1'],
+                        status: SUCCESS,
+                        suiteIds: ['s1 s2']
+                    }
+                );
+            });
+
+            it('should correctly init child suite', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1', 's2'], browserId: 'b1'}));
+
+                assert.deepEqual(
+                    builder.tree.suites.byId['s1 s2'],
+                    {
+                        id: 's1 s2',
+                        name: 's2',
+                        parentId: 's1',
+                        root: false,
+                        suitePath: ['s1', 's2'],
+                        status: SUCCESS,
+                        browserIds: ['s1 s2 b1']
+                    }
+                );
+            });
+        });
+
+        describe('"browsers" field in the tree', () => {
+            it('should collect all browser ids', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s1'], browserId: 'b1'}));
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({testPath: ['s2'], browserId: 'b2'}));
+
+                assert.deepEqual(builder.tree.browsers.allIds, ['s1 b1', 's2 b2']);
+            });
+
+            it('should correctly init browser', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({
+                    testPath: ['s1'], browserId: 'b1', attempt: 0
+                }));
+
+                assert.deepEqual(
+                    builder.tree.browsers.byId['s1 b1'],
+                    {
+                        id: 's1 b1',
+                        name: 'b1',
+                        parentId: 's1',
+                        resultIds: ['s1 b1 0']
+                    }
+                );
+            });
+
+            it('should collect all ids to test results in browser', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({
+                    testPath: ['s1'], browserId: 'b1', attempt: 0
+                }));
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({
+                    testPath: ['s1'], browserId: 'b1', attempt: 1
+                }));
+
+                assert.deepEqual(builder.tree.browsers.byId['s1 b1'].resultIds, ['s1 b1 0', 's1 b1 1']);
+            });
+        });
+
+        describe('"results" field in the tree', () => {
+            it('should collect all test result ids', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({
+                    testPath: ['s1'], browserId: 'b1', attempt: 0
+                }));
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_({
+                    testPath: ['s2'], browserId: 'b2', attempt: 0
+                }));
+
+                assert.deepEqual(builder.tree.results.allIds, ['s1 b1 0', 's2 b2 0']);
+            });
+
+            it('should correctly init test result', () => {
+                builder.addTestResult(mkTestResult_(), mkFormattedResult_(
+                    {testPath: ['s1'], browserId: 'b1', attempt: 0}
+                ));
+
+                assert.deepEqual(
+                    builder.tree.results.byId['s1 b1 0'],
+                    {
+                        id: 's1 b1 0',
+                        parentId: 's1 b1',
+                        imageIds: []
+                    }
+                );
+            });
+
+            it('should collect all ids to images in test result', () => {
+                builder.addTestResult(
+                    mkTestResult_({imagesInfo: [{stateName: 'img1'}, {stateName: 'img2'}]}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                assert.deepEqual(
+                    builder.tree.results.byId['s1 b1 0'].imageIds,
+                    ['s1 b1 0 img1', 's1 b1 0 img2']
+                );
+            });
+        });
+
+        describe('"images" field in the tree', () => {
+            it('should collect all images ids', () => {
+                builder.addTestResult(
+                    mkTestResult_({imagesInfo: [{stateName: 'img1'}]}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+                builder.addTestResult(
+                    mkTestResult_({imagesInfo: [{status: ERROR}]}),
+                    mkFormattedResult_({testPath: ['s2'], browserId: 'b2', attempt: 0})
+                );
+
+                assert.deepEqual(builder.tree.images.allIds, ['s1 b1 0 img1', `s2 b2 0 ${ERROR}_0`]);
+            });
+
+            it('should correctly init image results', () => {
+                const imagesInfo = [{stateName: 'img1', foo: 'bar'}, {status: ERROR, bar: 'baz'}];
+                builder.addTestResult(
+                    mkTestResult_({imagesInfo}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                assert.deepEqual(
+                    builder.tree.images.byId['s1 b1 0 img1'],
+                    {
+                        id: 's1 b1 0 img1',
+                        parentId: 's1 b1 0',
+                        ...imagesInfo[0]
+                    }
+                );
+                assert.deepEqual(
+                    builder.tree.images.byId[`s1 b1 0 ${ERROR}_1`],
+                    {
+                        id: `s1 b1 0 ${ERROR}_1`,
+                        parentId: 's1 b1 0',
+                        ...imagesInfo[1]
+                    }
+                );
+            });
+        });
+
+        describe('determine statuses for suites', () => {
+            it('should call "determineStatus" with test result status', () => {
+                builder.addTestResult(
+                    mkTestResult_({status: SUCCESS}),
+                    mkFormattedResult_({testPath: ['s1']})
+                );
+
+                assert.calledOnceWith(determineStatus, [SUCCESS]);
+            });
+
+            it('should call "determineStatus" with test result status from last attempt', () => {
+                builder.addTestResult(
+                    mkTestResult_({status: FAIL}),
+                    mkFormattedResult_({testPath: ['s1'], attempt: 0})
+                );
+                builder.addTestResult(
+                    mkTestResult_({status: SUCCESS}),
+                    mkFormattedResult_({testPath: ['s1'], attempt: 1})
+                );
+
+                assert.calledWith(determineStatus.lastCall, [SUCCESS]);
+            });
+
+            it('should call "determineStatus" with all test statuses from each browser', () => {
+                builder.addTestResult(
+                    mkTestResult_({status: FAIL}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1'})
+                );
+                builder.addTestResult(
+                    mkTestResult_({status: SUCCESS}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b2'})
+                );
+
+                assert.calledWith(determineStatus.secondCall, [FAIL, SUCCESS]);
+            });
+
+            it('should call "determineStatus" with statuses from child suites', () => {
+                determineStatus.withArgs([FAIL]).returns('s1 s2 status');
+                determineStatus.withArgs([ERROR]).returns('s1 s3 status');
+                builder.addTestResult(
+                    mkTestResult_({status: FAIL}),
+                    mkFormattedResult_({testPath: ['s1', 's2']})
+                );
+                builder.addTestResult(
+                    mkTestResult_({status: ERROR}),
+                    mkFormattedResult_({testPath: ['s1', 's3']})
+                );
+
+                assert.calledWith(determineStatus.getCall(3), ['s1 s2 status', 's1 s3 status']);
+            });
+        });
+    });
+});

--- a/test/unit/lib/tests-tree-builder/gui.js
+++ b/test/unit/lib/tests-tree-builder/gui.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const _ = require('lodash');
+const GuiResultsTreeBuilder = require('lib/tests-tree-builder/gui');
+const {FAIL, SUCCESS, IDLE} = require('lib/constants/test-statuses');
+
+describe('GuiResultsTreeBuilder', () => {
+    let builder;
+
+    const mkTestResult_ = (result) => {
+        return _.defaults(result, {status: IDLE, imagesInfo: []});
+    };
+
+    const mkFormattedResult_ = (result) => {
+        return _.defaults(result, {
+            testPath: ['default-parent-suite', 'default-child-suite'],
+            browserId: 'default-browser',
+            attempt: 0
+        });
+    };
+
+    beforeEach(() => {
+        builder = GuiResultsTreeBuilder.create();
+    });
+
+    describe('"getLastResult" method', () => {
+        it('should return last result from tree', () => {
+            const formattedRes1 = mkFormattedResult_({testPath: ['s'], browserId: 'b', attempt: 0});
+            const formattedRes2 = mkFormattedResult_({testPath: ['s'], browserId: 'b', attempt: 1});
+            builder.addTestResult(mkTestResult_(), formattedRes1);
+            builder.addTestResult(mkTestResult_(), formattedRes2);
+
+            const lastResult = builder.getLastResult({testPath: ['s'], browserId: 'b'});
+
+            assert.deepEqual(lastResult, builder.tree.results.byId['s b 1']);
+        });
+    });
+
+    describe('"getImagesInfo" method', () => {
+        it('should return images from tree for passed result', () => {
+            const formattedRes = mkFormattedResult_({testPath: ['s'], browserId: 'b', attempt: 0});
+            const imagesInfo = [{stateName: 'image-1'}, {stateName: 'image-2'}];
+            builder.addTestResult(mkTestResult_({imagesInfo}), formattedRes);
+
+            const gotImagesInfo = builder.getImagesInfo(formattedRes);
+
+            assert.deepEqual(
+                gotImagesInfo,
+                [
+                    builder.tree.images.byId['s b 0 image-1'],
+                    builder.tree.images.byId['s b 0 image-2']
+                ]
+            );
+        });
+    });
+
+    describe('"reuseTestsTree" method', () => {
+        describe('reuse browsers', () => {
+            it('should not reuse browser result if browser ids are not matched', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_(),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_(),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b2', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.notDeepEqual(builder.tree.browsers.byId['s1 b2'], srcBuilder.tree.browsers.byId['s1 b1']);
+                assert.isUndefined(builder.tree.results.byId['s1 b1']);
+            });
+
+            it('should reuse browser result from the passed tree if browser ids matched', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_(),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_(),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.deepEqual(builder.tree.browsers.byId['s1 b1'], srcBuilder.tree.browsers.byId['s1 b1']);
+            });
+        });
+
+        describe('reuse test results', () => {
+            it('should not reuse result if browser ids does not matched', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_({status: FAIL}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_({status: IDLE}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b2', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.notDeepEqual(builder.tree.results.byId['s1 b2 0'], srcBuilder.tree.results.byId['s1 b1 0']);
+                assert.isUndefined(builder.tree.results.byId['s1 b1 0']);
+            });
+
+            it('should reuse all results from the passed tree if browser ids matched', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_({status: FAIL}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+                srcBuilder.addTestResult(
+                    mkTestResult_({status: SUCCESS}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 1})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_({status: IDLE}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.deepEqual(builder.tree.results.byId['s1 b1 0'], srcBuilder.tree.results.byId['s1 b1 0']);
+                assert.deepEqual(builder.tree.results.byId['s1 b1 1'], srcBuilder.tree.results.byId['s1 b1 1']);
+            });
+
+            it('should register reused result ids', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_(),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 1})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_(),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.deepEqual(builder.tree.results.allIds, ['s1 b1 0', 's1 b1 1']);
+            });
+        });
+
+        describe('reuse images', () => {
+            it('should not reuse images if browser ids does not matched', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_({imagesInfo: [{stateName: 'img1'}]}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_({imagesInfo: [{stateName: 'img1'}]}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b2', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.notDeepEqual(builder.tree.images.byId['s1 b2 0 img1'], srcBuilder.tree.images.byId['s1 b1 0 img1']);
+                assert.isUndefined(builder.tree.results.byId['s1 b1 0']);
+            });
+
+            it('should reuse all images from the passed tree if browser ids matched', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_({imagesInfo: [{stateName: 'img1'}, {stateName: 'img2'}]}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_({imagesInfo: [{stateName: 'img1'}]}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.deepEqual(builder.tree.images.byId['s1 b1 0 img1'], srcBuilder.tree.images.byId['s1 b1 0 img1']);
+                assert.deepEqual(builder.tree.images.byId['s1 b1 0 img2'], srcBuilder.tree.images.byId['s1 b1 0 img2']);
+            });
+
+            it('should register reused images ids', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_({imagesInfo: [{stateName: 'img1'}, {stateName: 'img2'}]}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_(),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.deepEqual(builder.tree.images.allIds, ['s1 b1 0 img1', 's1 b1 0 img2']);
+            });
+        });
+
+        describe('reuse suite status', () => {
+            it('should not reuse suite status if browser ids does not matched', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_({status: FAIL}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_({status: IDLE}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b2', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.equal(builder.tree.suites.byId['s1'].status, IDLE);
+            });
+
+            it('should reuse suite status from passed tree with if browser ids matched', () => {
+                const srcBuilder = GuiResultsTreeBuilder.create();
+                srcBuilder.addTestResult(
+                    mkTestResult_({status: FAIL}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.addTestResult(
+                    mkTestResult_({status: IDLE}),
+                    mkFormattedResult_({testPath: ['s1'], browserId: 'b1', attempt: 0})
+                );
+
+                builder.reuseTestsTree(srcBuilder.tree);
+
+                assert.equal(builder.tree.suites.byId['s1'].status, FAIL);
+            });
+        });
+    });
+});

--- a/test/unit/lib/tests-tree-builder/static.js
+++ b/test/unit/lib/tests-tree-builder/static.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const _ = require('lodash');
+const StaticResultsTreeBuilder = require('lib/tests-tree-builder/static');
+const {SUCCESS} = require('lib/constants/test-statuses');
+const {versions: browserVersions} = require('lib/constants/browser');
+
+describe('StaticResultsTreeBuilder', () => {
+    const sandbox = sinon.sandbox.create();
+    let builder;
+
+    const mkDataFromDb_ = (data) => {
+        return _.defaults(data, {
+            suitePath: ['default-parent-suite', 'default-child-suite'],
+            suiteName: 'default-child-suite',
+            name: 'default-browser',
+            suiteUrl: 'default-url',
+            metaInfo: {},
+            description: 'default-descr',
+            error: null,
+            skipReason: '',
+            imagesInfo: [],
+            screenshot: true,
+            multipleTabs: true,
+            status: SUCCESS,
+            timestamp: 100500
+        });
+    };
+
+    const mkDataRowFromDb_ = (result = mkDataFromDb_()) => {
+        return [
+            JSON.stringify(result.suitePath),
+            result.suiteName,
+            result.name,
+            result.suiteUrl,
+            JSON.stringify(result.metaInfo),
+            result.description,
+            JSON.stringify(result.error),
+            result.skipReason,
+            JSON.stringify(result.imagesInfo),
+            Number(result.screenshot),
+            Number(result.multipleTabs),
+            result.status,
+            result.timestamp
+        ];
+    };
+
+    const formatToTestResult = (result, data = {}) => {
+        return {
+            description: result.description,
+            imagesInfo: result.imagesInfo,
+            metaInfo: result.metaInfo,
+            multipleTabs: result.multipleTabs,
+            name: result.name,
+            screenshot: result.screenshot,
+            status: result.status,
+            suiteUrl: result.suiteUrl,
+            skipReason: result.skipReason,
+            error: result.error,
+            ...data
+        };
+    };
+
+    beforeEach(() => {
+        sandbox.stub(StaticResultsTreeBuilder.prototype, 'addTestResult');
+        sandbox.stub(StaticResultsTreeBuilder.prototype, 'sortTree');
+        sandbox.stub(StaticResultsTreeBuilder.prototype, 'convertToOldFormat').returns({});
+
+        builder = StaticResultsTreeBuilder.create();
+    });
+
+    afterEach(() => sandbox.restore());
+
+    describe('"build" method', () => {
+        describe('should add test result for', () => {
+            it('each passed row', () => {
+                const dataFromDb1 = mkDataFromDb_({suitePath: ['s1'], name: 'yabro'});
+                const dataFromDb2 = mkDataFromDb_({suitePath: ['s2'], name: 'yabro'});
+                const rows = [mkDataRowFromDb_(dataFromDb1), mkDataRowFromDb_(dataFromDb2)];
+
+                builder.build(rows);
+
+                assert.calledWith(
+                    StaticResultsTreeBuilder.prototype.addTestResult.firstCall,
+                    formatToTestResult(dataFromDb1, {attempt: 0}),
+                    {browserId: 'yabro', testPath: ['s1'], attempt: 0}
+                );
+                assert.calledWith(
+                    StaticResultsTreeBuilder.prototype.addTestResult.secondCall,
+                    formatToTestResult(dataFromDb2, {attempt: 0}),
+                    {browserId: 'yabro', testPath: ['s2'], attempt: 0}
+                );
+            });
+
+            it('the same test with increase attempt', () => {
+                const dataFromDb1 = mkDataFromDb_({suitePath: ['s1'], name: 'yabro', timestamp: 10});
+                const dataFromDb2 = mkDataFromDb_({suitePath: ['s1'], name: 'yabro', timestamp: 20});
+                const rows = [mkDataRowFromDb_(dataFromDb1), mkDataRowFromDb_(dataFromDb2)];
+
+                builder.build(rows);
+
+                assert.calledWith(
+                    StaticResultsTreeBuilder.prototype.addTestResult.firstCall,
+                    formatToTestResult(dataFromDb1, {attempt: 0}),
+                    {browserId: 'yabro', testPath: ['s1'], attempt: 0}
+                );
+                assert.calledWith(
+                    StaticResultsTreeBuilder.prototype.addTestResult.secondCall,
+                    formatToTestResult(dataFromDb1, {attempt: 1}),
+                    {browserId: 'yabro', testPath: ['s1'], attempt: 1}
+                );
+            });
+        });
+
+        describe('should sort tree', () => {
+            it('after add test result', () => {
+                const rows = [mkDataRowFromDb_()];
+
+                builder.build(rows);
+
+                assert.callOrder(
+                    StaticResultsTreeBuilder.prototype.addTestResult,
+                    StaticResultsTreeBuilder.prototype.sortTree
+                );
+            });
+
+            it('only once even if a few tests are added', () => {
+                const rows = [mkDataRowFromDb_(), mkDataRowFromDb_()];
+
+                builder.build(rows);
+
+                assert.calledOnce(StaticResultsTreeBuilder.prototype.sortTree);
+            });
+        });
+
+        describe('should return tests tree', () => {
+            it('in old format by default', () => {
+                StaticResultsTreeBuilder.prototype.convertToOldFormat.returns('old-format-tree');
+
+                const {tree} = builder.build([]);
+
+                assert.equal(tree, 'old-format-tree');
+            });
+
+            it('without formatting', () => {
+                sandbox.stub(StaticResultsTreeBuilder.prototype, 'tree').get(() => 'tree');
+
+                const {tree} = builder.build([], {convertToOldFormat: false});
+
+                assert.notCalled(StaticResultsTreeBuilder.prototype.convertToOldFormat);
+                assert.equal(tree, 'tree');
+            });
+        });
+
+        describe('should return browsers', () => {
+            it('with unknown version if it is not specified in metaInfo', () => {
+                const dataFromDb = mkDataFromDb_({name: 'yabro', metaInfo: {}});
+                const rows = [mkDataRowFromDb_(dataFromDb)];
+
+                const {browsers} = builder.build(rows);
+
+                assert.deepEqual(browsers, [{id: 'yabro', versions: [browserVersions.UNKNOWN]}]);
+            });
+
+            it('with a few versions for the same browser', () => {
+                const dataFromDb1 = mkDataFromDb_({name: 'yabro', metaInfo: {browserVersion: '1'}});
+                const dataFromDb2 = mkDataFromDb_({name: 'yabro', metaInfo: {browserVersion: '2'}});
+                const rows = [mkDataRowFromDb_(dataFromDb1), mkDataRowFromDb_(dataFromDb2)];
+
+                const {browsers} = builder.build(rows);
+
+                assert.deepEqual(browsers, [{id: 'yabro', versions: ['1', '2']}]);
+            });
+
+            it('with versions for different browsers', () => {
+                const dataFromDb1 = mkDataFromDb_({name: 'yabro1', metaInfo: {browserVersion: '1'}});
+                const dataFromDb2 = mkDataFromDb_({name: 'yabro2', metaInfo: {browserVersion: '2'}});
+                const rows = [mkDataRowFromDb_(dataFromDb1), mkDataRowFromDb_(dataFromDb2)];
+
+                const {browsers} = builder.build(rows);
+
+                assert.deepEqual(browsers, [
+                    {id: 'yabro1', versions: ['1']},
+                    {id: 'yabro2', versions: ['2']}
+                ]);
+            });
+        });
+    });
+});

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -107,6 +107,26 @@ function mkStorage() {
     };
 }
 
+function mkFormattedTest(result) {
+    return _.defaultsDeep(result, {
+        browserId: 'bro1',
+        suite: {
+            fullName: 'suite-full-name',
+            path: ['suite'],
+            getUrl: function() {
+                return 'url';
+            }
+        },
+        state: {
+            name: 'name-default'
+        },
+        getImagesInfo: () => [],
+        getCurrImg: () => {
+            return {path: null};
+        }
+    });
+}
+
 module.exports = {
     stubConfig,
     stubTool,
@@ -116,5 +136,6 @@ module.exports = {
     mkTestResult,
     mkImagesInfo,
     mkSuiteTree,
-    mkStorage
+    mkStorage,
+    mkFormattedTest
 };


### PR DESCRIPTION
### What is done:
- implement results tree builder for gui and static mode in order to correctly create tests tree in one place. Before that we create tests tree in three different places (gui js, sqlite static, sqlite gui) and it was hard to support;
- implement temporary backward compatibility in order to make it easier to review and debug;
- implement sort nested suites and browsers;

Normalized tests tree looks like:
```
{
  suites: {byId: {}, allIds: [], allRootIds: []},
  browsers: {byId: {}, allIds: []},
  results: {byId: {}, allIds: []},
  images: {byId: {}, allIds: []}
}
```

`suites` - store all suites (describe and it) in `byId` field without deep nesting. Each suite knows about his parent id and child suite ids (describe) or browser ids (it). Moreover `allIds` and `allRootIds` is helpful to get only suite ids which will be used in react components;
`browsers` - store all browser results in `byId` field without deep nesting. Each browser knows about his suite parent id and result ids.
`results` - store all test results in `byId` field without deep nesting. Each result knows about his browser parent id and images ids if it present.
`images` - store all images in `byId` field. Each image knows about his result id.

Example:
```
{
  suites: { byId: { s1: [Object] }, allIds: [ 's1' ], allRootIds: [ 's1' ] },
  browsers: { byId: { 's1 b1': [Object] }, allIds: [ 's1 b1' ] },
  results: { byId: { 's1 b1 0': [Object] }, allIds: [ 's1 b1 0' ] },
  images: {
    byId: { 's1 b1 0 img1': [Object], 's1 b1 0 img2': [Object] },
    allIds: [ 's1 b1 0 img1', 's1 b1 0 img2' ]
  }
}
```

Normalized store gives us ability to easily and effectively walk on results tree and update one of it without the need to change parent suite/browser/result.

### What is left:
- remove temporary fallback to old format and use new normalized store in redux store and all react components