### PR TITLE
fix(html-reporter): update init state using filter browsers

### DIFF
--- a/lib/static/modules/reducers/index.js
+++ b/lib/static/modules/reducers/index.js
@@ -40,12 +40,13 @@ export default reduceReducers(
     closeIds,
     db,
     fetchDbDetails,
-    tree,
     browsers,
     config,
     stats,
     skips,
+    // important to specify `view` higher than `tree`
     view,
     groupedErrors,
+    tree,
     plugins
 );

--- a/lib/static/modules/reducers/tree.js
+++ b/lib/static/modules/reducers/tree.js
@@ -16,6 +16,9 @@ export default produce((state, action) => {
             state.tree.browsers.stateById = {};
             state.tree.images.stateById = {};
 
+            const filteredBrowsers = state.view.filteredBrowsers;
+            updateAllSuitesStatus(state, filteredBrowsers);
+
             break;
         }
 
@@ -94,12 +97,8 @@ export default produce((state, action) => {
 
         case actionNames.BROWSERS_SELECTED: {
             const filteredBrowsers = action.payload.browsers;
-            const childSuitesIds = _(state.tree.browsers.allIds)
-                .map((browserId) => state.tree.browsers.byId[browserId].parentId)
-                .uniq()
-                .value();
 
-            updateSuitesStatus(state, childSuitesIds, filteredBrowsers);
+            updateAllSuitesStatus(state, filteredBrowsers);
 
             break;
         }
@@ -130,6 +129,15 @@ function getChildSuitesStatus(state, suite, filteredBrowsers) {
     }
 
     return determineStatus(childStatuses);
+}
+
+function updateAllSuitesStatus(state, filteredBrowsers) {
+    const childSuitesIds = _(state.tree.browsers.allIds)
+        .map((browserId) => state.tree.browsers.byId[browserId].parentId)
+        .uniq()
+        .value();
+
+    return updateSuitesStatus(state, childSuitesIds, filteredBrowsers);
 }
 
 function updateSuitesStatus(state, suitesIds = [], filteredBrowsers) {


### PR DESCRIPTION
В пулл-реквесте https://github.com/gemini-testing/html-reporter/pull/359/files не учел, что нужно обновлять начальное состояние отчета с учетом выбранных браузеров.