### PR TITLE
fix: correct browser filter loading in 'gui' mode

### DIFF
--- a/lib/static/modules/reducers/browsers.js
+++ b/lib/static/modules/reducers/browsers.js
@@ -5,7 +5,8 @@ import {versions as BrowserVersions} from '../../../constants/browser';
 export default (state, action) => {
     switch (action.type) {
         case actionNames.INIT_GUI_REPORT: {
-            const browsers = extractBrowsers(state.tree.results);
+            const {tree} = action.payload;
+            const browsers = extractBrowsers(tree.results);
 
             return {...state, browsers};
         }


### PR DESCRIPTION
Вместо того, чтобы менять порядок подключения редьюсеров, я изменил место, в котором делаю обновление дерева на INIT. Теперь я делаю это во view, в момент, когда в состояние уже загружены браузеры фильтра.

**UPD**

Сделал проще, как советовал @DudaGod: мы не можем вытащить браузеры из state в момент инициализации gui, но можем вытащить их из action.payload