### PR TITLE
chore: add support of redux-devtools in development mode

### DIFF
--- a/lib/static/modules/store.js
+++ b/lib/static/modules/store.js
@@ -10,10 +10,16 @@ import localStorage from './middlewares/local-storage';
 
 const middlewares = [thunk, metrika(YandexMetrika), localStorage];
 
+let composeEnhancers = compose;
+
 if (process.env.NODE_ENV !== 'production') {
     middlewares.push(logger);
+
+    if (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
+        composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
+    }
 }
 
-const createStoreWithMiddlewares = compose(applyMiddleware(...middlewares))(createStore);
+const createStoreWithMiddlewares = composeEnhancers(applyMiddleware(...middlewares))(createStore);
 
 export default createStoreWithMiddlewares(reducer, {});


### PR DESCRIPTION
It makes easily to work with redux store (current state, diff, trigger `dispatch`, navigation by state's history)
https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup