### PR TITLE
Add 'failed tests' selector in plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ directory.
   The routes then can be called from the plugin React components defined in the `plugin.js`. For convenience the plugin name is always passed with options when function- or array-returning form is used to export plugin as the function options property `pluginName`:
 
   ```js
-  export default ['react', 'axios', function(React, axios, {pluginName, pluginConfig, actions}) {
+  export default ['react', 'axios', function(React, axios, {pluginName, pluginConfig, actions, selectors}) {
       class PluginComponent extends React.Component {
           // ... somewhere inside the component ...
           const result = await axios.get(`/plugin-routes/${pluginName}/plugin-route`);
@@ -273,7 +273,8 @@ directory.
   ```
 
   In the example you can also see another convenient properties:
-  - `actions` - all the html-reporter **Redux** actions;
+  - `actions` - the html-reporter **Redux** actions;
+  - `selectors` - the memoized html-reporter selectors which created using **reselect** library
   - `pluginConfig` - plugin configuration.
 
   #### Extension points

--- a/lib/static/.eslintrc.js
+++ b/lib/static/.eslintrc.js
@@ -2,7 +2,8 @@ module.exports = {
     extends: 'gemini-testing',
     env: {browser: true},
     plugins: [
-        'react'
+        'react',
+        'babel'
     ],
     parser: 'babel-eslint',
     parserOptions: {
@@ -14,6 +15,8 @@ module.exports = {
     rules: {
         'react/jsx-uses-react': 'error',
         'react/jsx-uses-vars': 'error',
-        'react/jsx-no-undef': ['error', { allowGlobals: true }]
+        'react/jsx-no-undef': ['error', { allowGlobals: true }],
+        'object-curly-spacing': 'off',
+        'babel/object-curly-spacing': 'error'
     }
 };

--- a/lib/static/modules/load-plugin.js
+++ b/lib/static/modules/load-plugin.js
@@ -10,6 +10,7 @@ import reduceReducers from 'reduce-reducers';
 import immer from 'immer';
 import * as reselect from 'reselect';
 import axios from 'axios';
+import * as selectors from './selectors';
 
 const whitelistedDeps = {
     'react': React,
@@ -80,7 +81,7 @@ async function initPlugin(plugin, pluginName, pluginConfig) {
             const depArgs = deps.map(dep => whitelistedDeps[dep]);
             // cyclic dep, resolve it dynamically
             const actions = await import('./actions');
-            return plugin(...depArgs, {pluginName, pluginConfig, actions});
+            return plugin(...depArgs, {pluginName, pluginConfig, actions, selectors});
         }
 
         return plugin;

--- a/lib/static/modules/selectors/index.js
+++ b/lib/static/modules/selectors/index.js
@@ -1,0 +1,3 @@
+export * as stats from './stats';
+export * as tree from './tree';
+export * as view from './view';

--- a/lib/static/modules/selectors/tree.js
+++ b/lib/static/modules/selectors/tree.js
@@ -34,7 +34,7 @@ export const getFailedTests = createSelector(
             const browserId = result.parentId;
             const {parentId: testName, name: browserName} = browsers[browserId];
 
-            return {testName, browserName};
+            return {testName, browserName, metaInfo: result.metaInfo};
         });
     }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6130,6 +6130,15 @@
       "integrity": "sha512-zp9yStBk+Yplm0QpeyvgLPZA12wzDsWpvzi/YiN+GLSrt9ilq0NbNvFOp5KEFvnJNh57s8SioeIbv+jJX2BBQA==",
       "dev": true
     },
+    "eslint-plugin-babel": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz",
+      "integrity": "sha512-VsQEr6NH3dj664+EyxJwO4FCYm/00JhYb3Sk3ft8o+fpKuIfQ9TaW6uVUfvwMXHcf/lsnRIoyFPsLMyiWCSL/g==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.14.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
@@ -6146,6 +6155,12 @@
         "prop-types": "^15.7.2",
         "resolve": "^1.10.1"
       }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "enzyme-adapter-react-16": "^1.15.4",
     "eslint": "^4.8.0",
     "eslint-config-gemini-testing": "^2.8.0",
+    "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-react": "^7.4.0",
     "extract-text-webpack-plugin": "^3.0.1",
     "hermione": "^3.11.0",

--- a/test/unit/lib/static/modules/load-plugin.js
+++ b/test/unit/lib/static/modules/load-plugin.js
@@ -3,6 +3,7 @@
 import axios from 'axios';
 import loadPlugin from 'lib/static/modules/load-plugin';
 import * as actions from 'lib/static/modules/actions';
+import * as selectors from 'lib/static/modules/selectors';
 
 describe('static/modules/load-plugin', () => {
     const sandbox = sinon.sandbox.create();
@@ -31,7 +32,7 @@ describe('static/modules/load-plugin', () => {
             await loadPlugin('plugin-a');
 
             assert.deepStrictEqual(plugin.args, [
-                [{actions, pluginName: 'plugin-a', pluginConfig: undefined}]
+                [{actions, selectors, pluginName: 'plugin-a', pluginConfig: undefined}]
             ]);
         });
 
@@ -40,7 +41,7 @@ describe('static/modules/load-plugin', () => {
             await loadPlugin('plugin-b', config);
 
             assert.deepStrictEqual(plugin.args, [
-                [{actions, pluginName: 'plugin-b', pluginConfig: config}]
+                [{actions, selectors, pluginName: 'plugin-b', pluginConfig: config}]
             ]);
         });
 
@@ -49,7 +50,7 @@ describe('static/modules/load-plugin', () => {
             await loadPlugin('plugin-c');
 
             assert.deepStrictEqual(plugin.args, [
-                [axios, {actions, pluginName: 'plugin-c', pluginConfig: undefined}]
+                [axios, {actions, selectors, pluginName: 'plugin-c', pluginConfig: undefined}]
             ]);
         });
 
@@ -58,7 +59,7 @@ describe('static/modules/load-plugin', () => {
             await loadPlugin('plugin-d');
 
             assert.deepStrictEqual(plugin.args, [
-                [undefined, {actions, pluginName: 'plugin-d', pluginConfig: undefined}]
+                [undefined, {actions, selectors, pluginName: 'plugin-d', pluginConfig: undefined}]
             ]);
         });
     });

--- a/test/unit/lib/static/modules/selectors/tree.js
+++ b/test/unit/lib/static/modules/selectors/tree.js
@@ -8,6 +8,7 @@ import {
 } from 'lib/static/modules/selectors/tree';
 import viewModes from 'lib/constants/view-modes';
 import {mkSuite, mkBrowser, mkResult, mkImage, mkStateTree, mkStateView} from '../../state-utils';
+import {getFailedTests} from '../../../../../../lib/static/modules/selectors/tree';
 
 describe('tree selectors', () => {
     const mkState = ({tree = mkStateTree(), view = mkStateView()} = {}) => ({tree, view});
@@ -386,6 +387,31 @@ describe('tree selectors', () => {
             const state = mkState({tree});
 
             assert.isFalse(areAllRootSuitesIdle(state));
+        });
+    });
+
+    describe('"getFailedTests" selector', () => {
+        it('should return failed tests with metaInfo', () => {
+            const suitesById = mkSuite({id: 's1', status: FAIL, browserIds: ['b']});
+            const browsersById = mkBrowser({id: 'b', name: 'browser', parentId: 'test', resultIds: ['r1']});
+            const resultsById = mkResult({id: 'r1', parentId: 'b', status: FAIL, metaInfo: {param: 'value'}});
+
+            const tree = mkStateTree({
+                suitesFailedRootIds: ['s1'],
+                suitesById,
+                browsersById,
+                resultsById
+            });
+            const state = mkState({tree});
+
+            assert.deepEqual(
+                getFailedTests(state),
+                [{
+                    'browserName': 'browser',
+                    'metaInfo': {param: 'value'},
+                    'testName': 'test'
+                }]
+            );
         });
     });
 });

--- a/test/unit/lib/static/state-utils.js
+++ b/test/unit/lib/static/state-utils.js
@@ -29,6 +29,7 @@ exports.mkResult = (opts) => {
     const result = defaults(opts, {
         id: 'default-result-id',
         parentId: 'default-bro-id',
+        metaInfo: {},
         status: SUCCESS,
         imageIds: []
     });
@@ -47,9 +48,18 @@ exports.mkImage = (opts) => {
     return {[image.id]: image};
 };
 
-exports.mkStateTree = ({suitesById = {}, suitesAllRootIds = [], browsersById = {}, resultsById = {}, imagesById = {}} = {}) => {
+exports.mkStateTree = (
+    {
+        suitesById = {},
+        suitesAllRootIds = [],
+        suitesFailedRootIds = [],
+        browsersById = {},
+        resultsById = {},
+        imagesById = {}
+    } = {}
+) => {
     return {
-        suites: {byId: suitesById, allRootIds: suitesAllRootIds},
+        suites: {byId: suitesById, allRootIds: suitesAllRootIds, failedRootIds: suitesFailedRootIds},
         browsers: {byId: browsersById, allIds: Object.keys(browsersById)},
         results: {byId: resultsById},
         images: {byId: imagesById, allIds: Object.keys(imagesById)}


### PR DESCRIPTION
I need to get all failed tests with metadata in my plugin.
For this reason, I want to reuse redux reselect selectors.

This PR add these selectors to plugins and extend failedTests selector.