### PR TITLE
feat(config): add reportMetaInfo property

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ directory.
   * *hint* of error pattern will be displayed after error *stack* field. Can be specified as html string. For example, `<div>some-useful-hint</div>`.
 
   In 'Group by error' mode test will be associated with group if test error matches on group error pattern. New group will be created if test cannot be associated with existing groups.
-
 * **metaInfoBaseUrls** (optional) `Object` - base paths for making link from Meta-info values. Object option must be Meta-info's key and value must be `String`. For example, {'file': 'base/path'}.
+* **reportMetaInfo** (optional) `Object` - additional report data.
 * **saveFormat** (**DEPRECATED**, optional) `String` - allows to specify the format, in which the results will be saved. Available values are:
   * `sqlite` - save tests results to Sqlite database. Default value.
 * **customGui** (optional) `Object` – allows to specify custom controls for gui-mode and define actions for them. `{}` is default value. Ordinarily custom controls should be split by sections depending on the purposes of the controls. At least one section should be specified.

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -27,6 +27,7 @@ const assertType = (name, validationFn, type) => {
 const assertString = (name) => assertType(name, _.isString, 'string');
 const assertBoolean = (name) => assertType(name, _.isBoolean, 'boolean');
 const assertNumber = (name) => assertType(name, _.isNumber, 'number');
+const assertObject = (name) => assertType(name, _.isObject, 'object');
 
 const assertSaveFormat = saveFormat => {
     const formats = Object.values(saveFormats);
@@ -58,9 +59,8 @@ const assertErrorPatterns = (errorPatterns) => {
 };
 
 const assertMetaInfoBaseUrls = (metaInfoBaseUrls) => {
-    if (!_.isObject(metaInfoBaseUrls)) {
-        throw new Error(`"metaInfoBaseUrls" option must be object, but got ${typeof metaInfoBaseUrls}`);
-    }
+    assertObject('metaInfoBaseUrls')(metaInfoBaseUrls);
+
     for (const key in metaInfoBaseUrls) {
         if (!_.isString(metaInfoBaseUrls[key])) {
             throw new Error(`Value of "${key}" in "metaInfoBaseUrls" option must be string, but got ${typeof metaInfoBaseUrls[key]}`);
@@ -173,6 +173,12 @@ const getParser = () => {
             parseEnv: JSON.parse,
             parseCli: JSON.parse,
             validate: assertMetaInfoBaseUrls
+        }),
+        reportMetaInfo: option({
+            defaultValue: configDefaults.reportMetaInfo,
+            parseEnv: JSON.parse,
+            parseCli: JSON.parse,
+            validate: assertObject('reportNameInfo')
         }),
         customGui: option({
             defaultValue: configDefaults.customGui,

--- a/lib/constants/defaults.js
+++ b/lib/constants/defaults.js
@@ -13,6 +13,7 @@ module.exports = {
         lazyLoadOffset: 800,
         errorPatterns: [],
         metaInfoBaseUrls: {},
+        reportMetaInfo: {},
         customGui: {},
         customScripts: [],
         yandexMetrika: {

--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -187,6 +187,7 @@ function getConfigForStaticFile(pluginConfig) {
             'lazyLoadOffset',
             'errorPatterns',
             'metaInfoBaseUrls',
+            'reportMetaInfo',
             'customScripts',
             'yandexMetrika',
             'pluginsEnabled',


### PR DESCRIPTION
Sometimes I need to store some additional data in report.
This PR add common meta info data for report.