### PR TITLE
fix(server-utils): fix empty directories creation in project root

### DIFF
--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -48,8 +48,8 @@ function createPath(kind, result, stateName) {
 }
 
 function copyFileAsync(srcPath, destPath, reportDir = '') {
-    return makeDirFor(destPath)
-        .then(() => fs.copy(srcPath, path.resolve(reportDir, destPath)));
+    const resolvedDestPath = path.resolve(reportDir, destPath);
+    return makeDirFor(resolvedDestPath).then(() => fs.copy(srcPath, resolvedDestPath));
 }
 
 /**

--- a/test/unit/lib/server-utils.js
+++ b/test/unit/lib/server-utils.js
@@ -108,12 +108,13 @@ describe('server-utils', () => {
         });
 
         it('should create directory and copy image', () => {
-            const fromPath = '/from/image.png',
-                toPath = '/to/image.png';
+            const fromPath = '/from/image.png';
+            const toPath = 'to/image.png';
+            const pathToReport = '/report-dir';
 
-            return utils.copyFileAsync(fromPath, toPath)
+            return utils.copyFileAsync(fromPath, toPath, pathToReport)
                 .then(() => {
-                    assert.calledWithMatch(fs.mkdirs, '/to');
+                    assert.calledWith(fs.mkdirs, '/report-dir/to');
                     assert.calledWithMatch(fs.copy, fromPath, toPath);
                 });
         });


### PR DESCRIPTION
В корне проекта, где используется hermione + html-reporter, всегда создается директория images с вложенными пустыми директориями под каждый тест.