### PR TITLE
feat: allow to set error screenshot with path

### DIFF
--- a/hermione.js
+++ b/hermione.js
@@ -39,7 +39,7 @@ async function prepare(hermione, reportBuilder, pluginConfig) {
         }
 
         if (formattedResult.screenshot) {
-            actions.push(formattedResult.saveBase64Screenshot(reportPath));
+            actions.push(formattedResult.saveErrorScreenshot(reportPath));
         }
 
         await Promise.all(actions);

--- a/lib/gui/tool-runner/report-subscriber.js
+++ b/lib/gui/tool-runner/report-subscriber.js
@@ -17,7 +17,7 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
         const actions = [formattedResult.saveTestImages(reportPath, workers)];
 
         if (formattedResult.screenshot) {
-            actions.push(formattedResult.saveBase64Screenshot(reportPath));
+            actions.push(formattedResult.saveErrorScreenshot(reportPath));
         }
 
         if (formattedResult.errorDetails) {

--- a/lib/static/components/state/state-error.js
+++ b/lib/static/components/state/state-error.js
@@ -8,7 +8,7 @@ import {isEmpty, map, isFunction} from 'lodash';
 import ReactHtmlParser from 'react-html-parser';
 import * as actions from '../../modules/actions';
 import Screenshot from './screenshot';
-import {isNoRefImageError} from '../../modules/utils';
+import {isNoRefImageError, isAssertViewError} from '../../modules/utils';
 import ErrorDetails from './error-details';
 import Details from '../details';
 import {ERROR_TITLE_TEXT_LENGTH} from '../../../constants/errors';
@@ -94,6 +94,10 @@ class StateError extends Component {
         });
     }
 
+    _shouldDrawErrorInfo(error) {
+        return !isAssertViewError(error);
+    }
+
     render() {
         const {error, errorDetails} = this.props;
         const errorPattern = this._getErrorPattern();
@@ -104,7 +108,7 @@ class StateError extends Component {
 
         return (
             <div className="image-box__image image-box__image_single">
-                <div className="error">{this._errorToElements(extendedError)}</div>
+                {this._shouldDrawErrorInfo(extendedError) && <div className="error">{this._errorToElements(extendedError)}</div>}
                 {errorDetails && <ErrorDetails errorDetails={errorDetails} />}
                 {this._drawImage()}
             </div>

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -123,17 +123,23 @@ module.exports = class TestAdapter {
         return {};
     }
 
-    async saveBase64Screenshot(reportPath) {
-        if (!this.screenshot.base64) {
+    async saveErrorScreenshot(reportPath) {
+        if (!this.screenshot.base64 && !this.screenshot.path) {
             utils.logger.warn('Cannot save screenshot on reject');
 
             return Promise.resolve();
         }
 
         const currPath = utils.getCurrentPath(this);
-        const localPath = path.resolve(tmp.tmpdir, currPath);
-        await utils.makeDirFor(localPath);
-        await fs.writeFile(localPath, new Buffer(this.screenshot.base64, 'base64'), 'base64');
+        let localPath;
+
+        if (this.screenshot.base64) {
+            localPath = path.resolve(tmp.tmpdir, currPath);
+            await utils.makeDirFor(localPath);
+            await fs.writeFile(localPath, new Buffer(this.screenshot.base64, 'base64'), 'base64');
+        } else {
+            localPath = this.screenshot.path;
+        }
 
         return this._saveImg(localPath, currPath, reportPath);
     }


### PR DESCRIPTION
Что сделано:
* добавил возможность сохранять скриншот снятый при падении теста не только в формате `base64`, но и по пути, по которому он сохранен. Это нужно, так как для снятия скриншота при падении в гермионе будет использоваться скриншотер из `gemini-core`, который умеет лишь сохранять его на файловую систему.
* убрал плашку с информацией об ошибке в поле `page screenshot`, так как ошибка указанная там более общая, чем та с которой упал тест.

Связанные пулл-реквесты:
* [hermione#622](https://github.com/gemini-testing/hermione/pull/622)