### PR TITLE
fix(remove-unused-screens): temporary remove "silent" from read tests

### DIFF
--- a/lib/cli-commands/remove-unused-screens/utils.js
+++ b/lib/cli-commands/remove-unused-screens/utils.js
@@ -15,7 +15,7 @@ exports.getTestsFromFs = async (hermione) => {
         screenPatterns: []
     };
 
-    const testCollection = await hermione.readTests([], {silent: true});
+    const testCollection = await hermione.readTests();
 
     testCollection.eachTest((test, browserId) => {
         const id = `${test.fullTitle()} ${browserId}`;

--- a/test/unit/lib/cli-commands/remove-unused-screens/utils.js
+++ b/test/unit/lib/cli-commands/remove-unused-screens/utils.js
@@ -66,12 +66,12 @@ describe('lib/cli-commands/remove-unused-screens/utils', () => {
             getScreenshotPath = sandbox.stub();
         });
 
-        it('should read all hermione tests silently', async () => {
+        it('should read all hermione tests', async () => {
             const hermione = mkHermione_();
 
             await utils.getTestsFromFs(hermione);
 
-            assert.calledOnceWith(hermione.readTests, [], {silent: true});
+            assert.calledOnceWith(hermione.readTests);
         });
 
         it('should add test tests tree with its screen info', async () => {


### PR DESCRIPTION
I will return `silent` flag after Hermione can to add user commands to the parser, regardless of the use `silent` flag.