### PR TITLE
fix: correct working with screenshot on assert view fail

### DIFF
--- a/hermione.js
+++ b/hermione.js
@@ -39,7 +39,7 @@ async function prepare(hermione, reportBuilder, pluginConfig) {
         }
 
         if (formattedResult.screenshot) {
-            actions.push(formattedResult.saveBase64Screenshot(reportPath));
+            actions.push(formattedResult.saveErrorScreenshot(reportPath));
         }
 
         await Promise.all(actions);

--- a/lib/gui/tool-runner/report-subscriber.js
+++ b/lib/gui/tool-runner/report-subscriber.js
@@ -17,7 +17,7 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
         const actions = [formattedResult.saveTestImages(reportPath, workers)];
 
         if (formattedResult.screenshot) {
-            actions.push(formattedResult.saveBase64Screenshot(reportPath));
+            actions.push(formattedResult.saveErrorScreenshot(reportPath));
         }
 
         if (formattedResult.errorDetails) {

--- a/lib/static/components/state/index.js
+++ b/lib/static/components/state/index.js
@@ -70,6 +70,10 @@ class State extends Component {
         const isAcceptDisabled = !isAcceptable(node);
         const isFindSameDiffDisabled = !isFailStatus(node.status);
 
+        if (isAcceptDisabled && isFindSameDiffDisabled && isScreenshotAccepterDisabled) {
+            return null;
+        }
+
         return (
             <div className="state-controls">
                 <ControlButton

--- a/lib/static/components/state/state-error.js
+++ b/lib/static/components/state/state-error.js
@@ -8,7 +8,7 @@ import {isEmpty, map, isFunction} from 'lodash';
 import ReactHtmlParser from 'react-html-parser';
 import * as actions from '../../modules/actions';
 import Screenshot from './screenshot';
-import {isNoRefImageError} from '../../modules/utils';
+import {isNoRefImageError, isAssertViewError} from '../../modules/utils';
 import ErrorDetails from './error-details';
 import Details from '../details';
 import {ERROR_TITLE_TEXT_LENGTH} from '../../../constants/errors';
@@ -94,6 +94,10 @@ class StateError extends Component {
         });
     }
 
+    _shouldDrawErrorInfo(error) {
+        return !isAssertViewError(error);
+    }
+
     render() {
         const {error, errorDetails} = this.props;
         const errorPattern = this._getErrorPattern();
@@ -104,7 +108,7 @@ class StateError extends Component {
 
         return (
             <div className="image-box__image image-box__image_single">
-                <div className="error">{this._errorToElements(extendedError)}</div>
+                {this._shouldDrawErrorInfo(extendedError) && <div className="error">{this._errorToElements(extendedError)}</div>}
                 {errorDetails && <ErrorDetails errorDetails={errorDetails} />}
                 {this._drawImage()}
             </div>

--- a/lib/static/modules/utils.js
+++ b/lib/static/modules/utils.js
@@ -10,7 +10,7 @@ const {NO_REF_IMAGE_ERROR, ASSERT_VIEW_ERROR} = getCommonErrors();
 function hasFailedImages(result) {
     const {imagesInfo = []} = result;
 
-    return imagesInfo.some(({status}) => isErroredStatus(status) || isFailStatus(status));
+    return imagesInfo.some(({error, status}) => !isAssertViewError(error) && (isErroredStatus(status) || isFailStatus(status)));
 }
 
 function isNoRefImageError(error) {

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -124,7 +124,7 @@ module.exports = class TestAdapter {
         return {};
     }
 
-    async saveBase64Screenshot(reportPath) {
+    async saveErrorScreenshot(reportPath) {
         if (!this.screenshot.base64) {
             logger.warn('Cannot save screenshot on reject');
 

--- a/test/unit/lib/test-adapter.js
+++ b/test/unit/lib/test-adapter.js
@@ -497,7 +497,7 @@ describe('hermione test adapter', () => {
         });
     });
 
-    describe('saveBase64Screenshot', () => {
+    describe('saveErrorScreenshot', () => {
         beforeEach(() => {
             sandbox.stub(logger, 'warn');
             sandbox.stub(utils, 'makeDirFor').resolves();
@@ -512,7 +512,7 @@ describe('hermione test adapter', () => {
                 });
                 const hermioneTestAdapter = mkHermioneTestResultAdapter(testResult);
 
-                return hermioneTestAdapter.saveBase64Screenshot()
+                return hermioneTestAdapter.saveErrorScreenshot()
                     .then(() => assert.notCalled(fs.writeFile));
             });
 
@@ -522,7 +522,7 @@ describe('hermione test adapter', () => {
                 });
                 const hermioneTestAdapter = mkHermioneTestResultAdapter(testResult);
 
-                return hermioneTestAdapter.saveBase64Screenshot()
+                return hermioneTestAdapter.saveErrorScreenshot()
                     .then(() => assert.calledWith(logger.warn, 'Cannot save screenshot on reject'));
             });
         });
@@ -534,7 +534,7 @@ describe('hermione test adapter', () => {
             utils.getCurrentPath.returns('dest/path');
             const hermioneTestAdapter = mkHermioneTestResultAdapter(testResult);
 
-            return hermioneTestAdapter.saveBase64Screenshot()
+            return hermioneTestAdapter.saveErrorScreenshot()
                 .then(() => assert.calledOnceWith(utils.makeDirFor, sinon.match('dest/path')));
         });
 
@@ -551,7 +551,7 @@ describe('hermione test adapter', () => {
                 }
             });
 
-            await hermioneTestAdapter.saveBase64Screenshot('report/path');
+            await hermioneTestAdapter.saveErrorScreenshot('report/path');
 
             assert.calledOnceWith(fs.writeFile, sinon.match('dest/path'), bufData, 'base64');
             assert.calledWith(imagesSaver.saveImg, sinon.match('dest/path'), {destPath: 'dest/path', reportDir: 'report/path'});


### PR DESCRIPTION
What is done:
* rename function `saveBase64Screenshot` to more correct `saveErrorScreenshot`
* fix screenshot accepting if there is error screenshot
* hide error info for "AssertViewError" errors
* hide screenshot accepting buttons for not "AssertViewError" errors