### PR TITLE
Implement TEST_SCREENSHOTS_SAVED event

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ Property name              | Description
 Event                     | Description
 ------------------------- | -------------
 `DATABASE_CREATED`        | Will be triggered after sqlite database is created. The handler accepts a database instance. The event is synchronous.
+`TEST_SCREENSHOTS_SAVED`       | Will be triggered after test screenshots were saved. The handler accepts test id and screenshots info. The event is synchronous.
 
 ### events
 
@@ -552,6 +553,29 @@ module.exports = (hermione, opts) => {
         });
     });
 };
+```
+
+Example of a subscription to an event `TEST_SCREENSHOTS_SAVED`:
+
+```js
+hermione.htmlReporter.on(hermione.htmlReporter.events.TEST_SCREENSHOTS_SAVED, ({testId, attempt, imagesInfo}) => {
+    console.log(`Screenshots for test "${testId}" (attempt #${attempt}) were saved:`, imagesInfo);
+    /* Expected output:
+    Screenshots for test "Feature Test.chrome-desktop" (attempt #0) were saved:
+    [
+        {
+            stateName: 'plain',
+            refImg: { path: '...', size: { width: 400, height: 200 } },
+            status: 'fail',
+            error: undefined,
+            diffClusters: [...],
+            expectedImg: { path: '...', size: { width: 400, height: 200 } }
+            actualImg: { path: '...', size: { width: 400, height: 200 } }
+            diffImg: { path: '...', size: { width: 400, height: 200 } }
+        }
+    ]
+    */
+});
 ```
 
 ### addExtraItem

--- a/lib/constants/plugin-events.js
+++ b/lib/constants/plugin-events.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const getSyncEvents = () => ({
-    DATABASE_CREATED: 'databaseCreated'
+    DATABASE_CREATED: 'databaseCreated',
+    TEST_SCREENSHOTS_SAVED: 'testScreenshotsSaved'
 });
 
 const events = getSyncEvents();

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -330,8 +330,8 @@ module.exports = class TestAdapter {
         await fs.writeFile(detailsFilePath, detailsData);
     }
 
-    saveTestImages(reportPath, workers) {
-        return Promise.map(this.assertViewResults, async (assertResult) => {
+    async saveTestImages(reportPath, workers) {
+        const result = await Promise.map(this.assertViewResults, async (assertResult) => {
             const {stateName} = assertResult;
             const destRefPath = utils.getReferencePath(this, stateName);
             const srcRefPath = this.getRefImg(stateName).path;
@@ -363,6 +363,15 @@ module.exports = class TestAdapter {
 
             return Promise.all(actions);
         });
+
+        const htmlReporter = this._hermione.htmlReporter;
+        htmlReporter.emit(htmlReporter.events.TEST_SCREENSHOTS_SAVED, {
+            testId: this._testId,
+            attempt: this.attempt,
+            imagesInfo: this.getImagesInfo()
+        });
+
+        return result;
     }
 
     //parallelize and cache of 'gemini-core.Image.buildDiff' (because it is very slow)


### PR DESCRIPTION
This PR adds TEST_REPORT_READY event which gets fired after test has finished running and its screenshots have been saved.

Besides that, minor tweaks were made to make certain fields accessible from other hermione plugins.