### PR TITLE
fix: wait for test screenshots and page screenshot on error to be saved

### DIFF
--- a/hermione.js
+++ b/hermione.js
@@ -38,10 +38,6 @@ async function prepare(hermione, reportBuilder, pluginConfig) {
             actions.push(formattedResult.saveErrorDetails(reportPath));
         }
 
-        if (formattedResult.screenshot) {
-            actions.push(formattedResult.saveErrorScreenshot(reportPath));
-        }
-
         await Promise.all(actions);
 
         return formattedResult;

--- a/lib/gui/tool-runner/report-subscriber.js
+++ b/lib/gui/tool-runner/report-subscriber.js
@@ -16,10 +16,6 @@ module.exports = (hermione, reportBuilder, client, reportPath) => {
     function failHandler(formattedResult) {
         const actions = [formattedResult.saveTestImages(reportPath, workers)];
 
-        if (formattedResult.screenshot) {
-            actions.push(formattedResult.saveErrorScreenshot(reportPath));
-        }
-
         if (formattedResult.errorDetails) {
             actions.push(formattedResult.saveErrorDetails(reportPath));
         }

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('bluebird');
 const _ = require('lodash');
 const fs = require('fs-extra');
 const path = require('path');
@@ -124,7 +123,7 @@ module.exports = class TestAdapter {
         return {};
     }
 
-    async saveErrorScreenshot(reportPath) {
+    async _saveErrorScreenshot(reportPath) {
         if (!this.screenshot.base64) {
             logger.warn('Cannot save screenshot on reject');
 
@@ -331,7 +330,7 @@ module.exports = class TestAdapter {
     }
 
     async saveTestImages(reportPath, workers) {
-        const result = await Promise.map(this.assertViewResults, async (assertResult) => {
+        const result = await Promise.all(this.assertViewResults.map(async (assertResult) => {
             const {stateName} = assertResult;
             const destRefPath = utils.getReferencePath(this, stateName);
             const srcRefPath = this.getRefImg(stateName).path;
@@ -362,7 +361,11 @@ module.exports = class TestAdapter {
             }
 
             return Promise.all(actions);
-        });
+        }));
+
+        if (this.screenshot) {
+            await this._saveErrorScreenshot(reportPath);
+        }
 
         const htmlReporter = this._hermione.htmlReporter;
         htmlReporter.emit(htmlReporter.events.TEST_SCREENSHOTS_SAVED, {


### PR DESCRIPTION
This PR fixes the following bug:
- we didn't wait for error screenshot to be saved (i.e. page screenshot) at all, because this was implemented in a different method – `saveErrorScreenshot`

Due to this, page screenshots were displayed incorrectly and `TEST_SCREENSHOTS_SAVED` event was being emitted with inconsistent screenshot data.