### PR TITLE
feat: add REPORT_SAVED event

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,8 @@ Property name              | Description
 Event                     | Description
 ------------------------- | -------------
 `DATABASE_CREATED`        | Will be triggered after sqlite database is created. The handler accepts a database instance. The event is synchronous.
-`TEST_SCREENSHOTS_SAVED`       | Will be triggered after test screenshots were saved. The handler accepts test id and screenshots info. The event is synchronous.
+`TEST_SCREENSHOTS_SAVED`  | Will be triggered after test screenshots were saved. The handler accepts test id and screenshots info. The event is asynchronous, so your handler can return a promise.
+`REPORT_SAVED`            | Will be triggered after all test files were saved. The event is asynchronous, so your handler can return a promise.
 
 ### events
 
@@ -558,7 +559,7 @@ module.exports = (hermione, opts) => {
 Example of a subscription to an event `TEST_SCREENSHOTS_SAVED`:
 
 ```js
-hermione.htmlReporter.on(hermione.htmlReporter.events.TEST_SCREENSHOTS_SAVED, ({testId, attempt, imagesInfo}) => {
+hermione.htmlReporter.on(hermione.htmlReporter.events.TEST_SCREENSHOTS_SAVED, async ({testId, attempt, imagesInfo}) => {
     console.log(`Screenshots for test "${testId}" (attempt #${attempt}) were saved:`, imagesInfo);
     /* Expected output:
     Screenshots for test "Feature Test.chrome-desktop" (attempt #0) were saved:
@@ -575,6 +576,13 @@ hermione.htmlReporter.on(hermione.htmlReporter.events.TEST_SCREENSHOTS_SAVED, ({
         }
     ]
     */
+});
+```
+
+Example of a subscription to an event `REPORT_SAVED`:
+```js
+hermione.htmlReporter.on(hermione.htmlReporter.events.REPORT_SAVED, async ({reportPath}) => {
+    await uploadDirToS3(reportPath);
 });
 ```
 

--- a/lib/constants/plugin-events.js
+++ b/lib/constants/plugin-events.js
@@ -2,7 +2,8 @@
 
 const getSyncEvents = () => ({
     DATABASE_CREATED: 'databaseCreated',
-    TEST_SCREENSHOTS_SAVED: 'testScreenshotsSaved'
+    TEST_SCREENSHOTS_SAVED: 'testScreenshotsSaved',
+    REPORT_SAVED: 'reportSaved'
 });
 
 const events = getSyncEvents();

--- a/lib/merge-reports/index.js
+++ b/lib/merge-reports/index.js
@@ -9,6 +9,8 @@ module.exports = async (pluginConfig, hermione, srcPaths, {destination: destPath
         serverUtils.saveStaticFilesToReportDir(hermione, pluginConfig, destPath),
         serverUtils.writeDatabaseUrlsFile(destPath, srcPaths)
     ]);
+
+    await hermione.htmlReporter.emitAsync(hermione.htmlReporter.events.REPORT_SAVED, {reportPath: destPath});
 };
 
 function validateOpts(srcPaths, destPath) {

--- a/lib/plugin-adapter.js
+++ b/lib/plugin-adapter.js
@@ -55,7 +55,12 @@ module.exports = class PluginAdapter {
                 staticReportBuilder.saveStaticFiles(),
                 prepareData(this._hermione, staticReportBuilder, this._config)
             ])
-            .then(() => staticReportBuilder.finalize());
+            .then(() => staticReportBuilder.finalize())
+            .then(async () => {
+                const htmlReporter = this._hermione.htmlReporter;
+
+                await htmlReporter.emitAsync(htmlReporter.events.REPORT_SAVED, {reportPath: this._config.path});
+            });
     }
 
     async _run(prepareData) {

--- a/lib/plugin-api.js
+++ b/lib/plugin-api.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const EventsEmitter = require('events');
+const EventsEmitter2 = require('eventemitter2');
 const pluginEvents = require('./constants/plugin-events');
 const {downloadDatabases, mergeDatabases, getTestsTreeFromDatabase} = require('./db-utils/server');
 
-module.exports = class HtmlReporter extends EventsEmitter {
+module.exports = class HtmlReporter extends EventsEmitter2 {
     static create(config) {
         return new this(config);
     }

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -368,7 +368,7 @@ module.exports = class TestAdapter {
         }
 
         const htmlReporter = this._hermione.htmlReporter;
-        htmlReporter.emit(htmlReporter.events.TEST_SCREENSHOTS_SAVED, {
+        await htmlReporter.emitAsync(htmlReporter.events.TEST_SCREENSHOTS_SAVED, {
             testId: this._testId,
             attempt: this.attempt,
             imagesInfo: this.getImagesInfo()

--- a/test/unit/lib/merge-reports/index.js
+++ b/test/unit/lib/merge-reports/index.js
@@ -7,6 +7,7 @@ const serverUtils = require('lib/server-utils');
 
 describe('lib/merge-reports', () => {
     const sandbox = sinon.sandbox.create();
+    let htmlReporter;
 
     const execMergeReports_ = async ({pluginConfig = stubConfig(), hermione = stubTool(stubConfig()), paths = [], opts = {}}) => {
         opts = _.defaults(opts, {destination: 'default-dest-report/path'});
@@ -17,6 +18,10 @@ describe('lib/merge-reports', () => {
     beforeEach(() => {
         sandbox.stub(serverUtils, 'saveStaticFilesToReportDir').resolves();
         sandbox.stub(serverUtils, 'writeDatabaseUrlsFile').resolves();
+
+        htmlReporter = sinon.stub();
+        htmlReporter.events = {REPORT_SAVED: 'reportSaved'};
+        htmlReporter.emitAsync = sinon.stub();
     });
 
     afterEach(() => sandbox.restore());
@@ -39,7 +44,7 @@ describe('lib/merge-reports', () => {
 
     it('should merge reports', async () => {
         const pluginConfig = stubConfig();
-        const hermione = stubTool(pluginConfig);
+        const hermione = stubTool(pluginConfig, {}, {}, htmlReporter);
         const paths = ['src-report/path-1', 'src-report/path-2'];
         const destination = 'dest-report/path';
 
@@ -47,5 +52,14 @@ describe('lib/merge-reports', () => {
 
         assert.calledOnceWith(serverUtils.saveStaticFilesToReportDir, hermione, pluginConfig, destination);
         assert.calledOnceWith(serverUtils.writeDatabaseUrlsFile, destination, paths);
+    });
+
+    it('should emit REPORT_SAVED event', async () => {
+        const hermione = stubTool({}, {}, {}, htmlReporter);
+        const destination = 'dest-report/path';
+
+        await execMergeReports_({pluginConfig: {}, hermione, paths: [''], opts: {destination}});
+
+        assert.calledOnceWith(hermione.htmlReporter.emitAsync, 'reportSaved', {reportPath: destination});
     });
 });

--- a/test/unit/lib/plugin-adapter.js
+++ b/test/unit/lib/plugin-adapter.js
@@ -174,6 +174,15 @@ describe('lib/plugin-adapter', () => {
                 });
         });
 
+        it('should emit REPORT_SAVED event', async () => {
+            await initCliReporter_({path: '/some/report/path'}, {});
+
+            tool.emit(tool.events.END);
+            await tool.emitAsync(tool.events.RUNNER_END);
+
+            assert.calledOnceWith(tool.htmlReporter.emitAsync, 'reportSaved', {reportPath: '/some/report/path'});
+        });
+
         it('should log correct path to html report', () => {
             return initCliReporter_({path: 'some/path'}, {})
                 .then(() => {

--- a/test/unit/lib/test-adapter.js
+++ b/test/unit/lib/test-adapter.js
@@ -32,7 +32,7 @@ describe('hermione test adapter', () => {
             Object.assign({
                 imagesSaver: {saveImg: sandbox.stub()},
                 events: {TEST_SCREENSHOTS_SAVED: 'testScreenshotsSaved'},
-                emit: sinon.stub()
+                emitAsync: sinon.stub()
             }, htmlReporter)
         );
 
@@ -308,7 +308,7 @@ describe('hermione test adapter', () => {
             const htmlReporterEmitStub = sinon.stub();
             const hermioneTestAdapter = mkHermioneTestResultAdapter(testResult, {
                 htmlReporter: {
-                    emit: htmlReporterEmitStub
+                    emitAsync: htmlReporterEmitStub
                 }
             });
             sinon.stub(hermioneTestAdapter, 'getImagesInfo').returns([{test: 123}]);

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -31,6 +31,10 @@ function stubTool(config = stubConfig(), events = {}, errors = {}, htmlReporter)
     tool.run = sinon.stub().resolves(false);
     tool.readTests = sinon.stub().resolves(stubTestCollection());
     tool.htmlReporter = htmlReporter || sinon.stub();
+    _.defaultsDeep(tool.htmlReporter, {
+        emitAsync: sinon.stub(),
+        events: {REPORT_SAVED: 'reportSaved'}
+    });
     tool.isWorker = () => {
         return false;
     };


### PR DESCRIPTION
This PR adds a new event `REPORT_SAVED` which gets fired after all report files were saved. Report path is passed to the event's listeners.