### PR TITLE
Корректно обрабатывать promise rejections при сохранении результатов

### DIFF
--- a/hermione.js
+++ b/hermione.js
@@ -55,19 +55,23 @@ async function prepare(hermione, reportBuilder, pluginConfig) {
 
         hermione.on(hermione.events.TEST_PASS, testResult => {
             promises.push(queue.add(async () => {
-                const formattedResult = reportBuilder.format(testResult);
-                await formattedResult.saveTestImages(reportPath, workers);
+                try {
+                    const formattedResult = reportBuilder.format(testResult);
+                    await formattedResult.saveTestImages(reportPath, workers);
 
-                return reportBuilder.addSuccess(formattedResult);
-            }).catch(reject));
+                    return reportBuilder.addSuccess(formattedResult);
+                } catch (e) {
+                    reject(e);
+                }
+            }));
         });
 
         hermione.on(hermione.events.RETRY, testResult => {
-            promises.push(queue.add(() => failHandler(testResult).then(addFail)).catch(reject));
+            promises.push(queue.add(() => failHandler(testResult).then(addFail).catch(reject)));
         });
 
         hermione.on(hermione.events.TEST_FAIL, testResult => {
-            promises.push(queue.add(() => failHandler(testResult).then(addFail)).catch(reject));
+            promises.push(queue.add(() => failHandler(testResult).then(addFail).catch(reject)));
         });
 
         hermione.on(hermione.events.TEST_PENDING, testResult => {


### PR DESCRIPTION
PR добавляет корректную обработку исключений при сохранении результатов прогонов тестов.

PR нацелен на исправление случайных зависаний при проблемах с воркерами и исправляет warning `PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 1)`.

Каким станет поведение html-reporter:
- при проблемах с воркерами/воспроизведении ошибки html-reporter как и раньше завершится неудачно, задача прокрасится в красный, если будет хотя бы одна картинка с ошибкой ProcessTerminated. Но теперь эти ошибки обрабатываются(пробрасываются) корректно
- неизвестно, будет ли исправлено само зависание – т.к. оно не вопроизводится на minimal-case, нужно тестировать на реальных проектах