### PR TITLE
feat: screenshot-accepter progress bar

### DIFF
--- a/lib/static/components/modals/screenshot-accepter/header.js
+++ b/lib/static/components/modals/screenshot-accepter/header.js
@@ -3,6 +3,7 @@ import {GlobalHotKeys} from 'react-hotkeys';
 import PropTypes from 'prop-types';
 import {uniqBy} from 'lodash';
 
+import ProgressBar from '../../progress-bar';
 import Arrow from '../../icons/arrow';
 import ArrowsClose from '../../icons/arrows-close';
 import ControlButton from '../../controls/control-button';
@@ -18,6 +19,8 @@ export default class ScreenshotAccepterHeader extends Component {
         retryIndex: PropTypes.number,
         activeImageIndex: PropTypes.number,
         showMeta: PropTypes.bool.isRequired,
+        totalImages: PropTypes.number.isRequired,
+        acceptedImages: PropTypes.number.isRequired,
         onClose: PropTypes.func.isRequired,
         onRetryChange: PropTypes.func.isRequired,
         onActiveImageChange: PropTypes.func.isRequired,
@@ -94,7 +97,10 @@ export default class ScreenshotAccepterHeader extends Component {
     }
 
     render() {
-        const {images, stateNameImageIds, retryIndex, showMeta, onClose, onRetryChange, onShowMeta} = this.props;
+        const {images, stateNameImageIds, retryIndex,
+            showMeta, onClose, onRetryChange, onShowMeta,
+            totalImages, acceptedImages
+        } = this.props;
         const resultIds = uniqBy(images, 'id').map((image) => image.parentId);
         const isArrowControlDisabed = stateNameImageIds.length <= 1;
 
@@ -152,6 +158,7 @@ export default class ScreenshotAccepterHeader extends Component {
                             extendClassNames="screenshot-accepter__arrows-close-btn"
                             handler={onClose}
                         />
+                        <ProgressBar done={acceptedImages} total={totalImages}/>
                     </div>
                 </header>
             </Fragment>

--- a/lib/static/components/modals/screenshot-accepter/index.js
+++ b/lib/static/components/modals/screenshot-accepter/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import PropTypes from 'prop-types';
-import {isEmpty, isNumber, findIndex} from 'lodash';
+import {isEmpty, isNumber, size, findIndex} from 'lodash';
 
 import * as actions from '../../../modules/actions';
 import ScreenshotAccepterHeader from './header';
@@ -31,7 +31,7 @@ class ScreenshotAccepter extends Component {
     constructor(props) {
         super(props);
 
-        const {image, activeImageIndex, stateNameImageIds} = this.props;
+        const {image, activeImageIndex, stateNameImageIds, imagesByStateName} = this.props;
         const images = this._getActiveImages(activeImageIndex, stateNameImageIds);
         const retryIndex = findIndex(images, {id: image.id});
 
@@ -42,6 +42,8 @@ class ScreenshotAccepter extends Component {
             retryIndex,
             showMeta: false
         };
+
+        this.totalImagesCount = size(imagesByStateName);
     }
 
     componentDidUpdate() {
@@ -116,6 +118,7 @@ class ScreenshotAccepter extends Component {
         const {retryIndex, stateNameImageIds, activeImageIndex, showMeta} = this.state;
         const images = this._getActiveImages();
         const currImage = isNumber(retryIndex) ? images[retryIndex] : null;
+        const acceptedImagesCount = this.totalImagesCount - stateNameImageIds.length;
 
         return (
             <Fragment>
@@ -126,6 +129,8 @@ class ScreenshotAccepter extends Component {
                     activeImageIndex={activeImageIndex}
                     showMeta={showMeta}
                     onClose={this.onClose}
+                    totalImages={this.totalImagesCount}
+                    acceptedImages={acceptedImagesCount}
                     onRetryChange={this.onRetryChange}
                     onActiveImageChange={this.onActiveImageChange}
                     onScreenshotAccept={this.onScreenshotAccept}

--- a/lib/static/components/modals/screenshot-accepter/style.css
+++ b/lib/static/components/modals/screenshot-accepter/style.css
@@ -15,6 +15,17 @@
     background-color: #fff;
 }
 
+.screenshot-accepter__controls.state-controls .progress-bar {
+    margin-left: auto;
+    margin-bottom: 20px;
+}
+
+.screenshot-accepter__controls.state-controls .progress-bar::after {
+    content: "Accepted: " attr(data-content);
+    font-size: 13px;
+    line-height: 18px;
+}
+
 .state-controls.screenshot-accepter__controls {
     display: flex;
     flex-wrap: wrap;

--- a/lib/static/components/progress-bar/index.js
+++ b/lib/static/components/progress-bar/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import './index.styl';
+
+export default ({done, total}) => {
+    const percent = (done / total).toFixed(2) * 100;
+
+    return (
+        <span className="progress-bar" data-content={`${done}/${total}`}>
+            <span className="progress-bar__container" style={{width: `${percent}%`}}/>
+        </span>
+    );
+};

--- a/lib/static/components/progress-bar/index.styl
+++ b/lib/static/components/progress-bar/index.styl
@@ -1,0 +1,24 @@
+.progress-bar {
+    position: relative;
+    display: flex;
+    outline: 1px solid #ccc;
+    border-radius: 5px;
+
+    &__container {
+        position: absolute;
+        height: 100%;
+        z-index: -1;
+        background-color: #fc0;
+        transition: width .25s ease-in-out,
+                    margin-right .25s ease-in-out;
+    }
+
+    &::after {
+        box-sizing: border-box;
+        width: 100%;
+        padding-left: 10px;
+        padding-right: 10px;
+        text-align: center;
+        align-self: center;
+    }
+}

--- a/test/unit/lib/static/components/modals/screenshot-accepter/header.js
+++ b/test/unit/lib/static/components/modals/screenshot-accepter/header.js
@@ -13,6 +13,8 @@ describe('<ScreenshotAccepterHeader/>', () => {
 
     const mkHeaderComponent = (props = {}) => {
         props = defaults(props, {
+            totalImages: 2,
+            acceptedImages: 0,
             images: [{
                 id: 'default-image-id',
                 parentId: 'default-result-id'

--- a/test/unit/lib/static/components/modals/screenshot-accepter/index.js
+++ b/test/unit/lib/static/components/modals/screenshot-accepter/index.js
@@ -94,6 +94,8 @@ describe('<ScreenshotAccepter/>', () => {
                     retryIndex: 0,
                     activeImageIndex: 0,
                     showMeta: false,
+                    acceptedImages: 0,
+                    totalImages: 1,
                     onClose: sinon.match.func,
                     onRetryChange: sinon.match.func,
                     onActiveImageChange: sinon.match.func,


### PR DESCRIPTION
Создал от ветки `HERMIONE-565.perf_screenshot_accepter`, так и планировалось

`screenshot-accepter progress bar` по этому коммиту: https://github.com/gemini-testing/html-reporter/pull/461/commits/b2b8a556b6431461e37a3467ef6d9dc77cd11620