### PR TITLE
fix: test objects should be cloned with clone method if exists

### DIFF
--- a/lib/gui/tool-runner/index.js
+++ b/lib/gui/tool-runner/index.js
@@ -207,7 +207,12 @@ module.exports = class ToolRunner {
             return _.extend(imageInfo, {expectedImg: refImg});
         });
 
-        return _.merge({}, testResult, {assertViewResults, imagesInfo, sessionId, attempt, origAttempt: attempt, meta: {url}, updated: true});
+        // Test.clone() available only with hermione@7+
+        const res = testResult && testResult.clone
+            ? testResult.clone()
+            : _.merge({}, testResult);
+
+        return _.merge(res, {assertViewResults, imagesInfo, sessionId, attempt, origAttempt: attempt, meta: {url}, updated: true});
     }
 
     _emitUpdateReference({refImg}, state) {


### PR DESCRIPTION
Related to https://github.com/gemini-testing/hermione/pull/720