### PR TITLE
fix: avoid saved test extension

### DIFF
--- a/lib/gui/tool-runner/index.js
+++ b/lib/gui/tool-runner/index.js
@@ -193,13 +193,13 @@ module.exports = class ToolRunner {
         const {browserId, attempt} = test;
         const fullTitle = mkFullTitle(test);
         const testId = formatId(getShortMD5(fullTitle), browserId);
-        const testResult = this._tests[testId];
+        const rawTest = this._tests[testId];
         const {sessionId, url} = test.metaInfo;
         const assertViewResults = [];
 
         const imagesInfo = test.imagesInfo.map((imageInfo) => {
             const {stateName, actualImg} = imageInfo;
-            const path = this._hermione.config.browsers[browserId].getScreenshotPath(testResult, stateName);
+            const path = this._hermione.config.browsers[browserId].getScreenshotPath(rawTest, stateName);
             const refImg = {path, size: actualImg.size};
 
             assertViewResults.push({stateName, refImg, currImg: actualImg});
@@ -207,12 +207,13 @@ module.exports = class ToolRunner {
             return _.extend(imageInfo, {expectedImg: refImg});
         });
 
-        // Test.clone() available only with hermione@7+
-        const res = testResult && testResult.clone
-            ? testResult.clone()
-            : _.merge({}, testResult);
+        const res = _.merge({}, rawTest, {assertViewResults, imagesInfo, sessionId, attempt, origAttempt: attempt, meta: {url}, updated: true});
 
-        return _.merge(res, {assertViewResults, imagesInfo, sessionId, attempt, origAttempt: attempt, meta: {url}, updated: true});
+        // _.merge can't fully clone test object since hermione@7+
+        // TODO: use separate object to represent test results. Do not extend test object with test results
+        return rawTest && rawTest.clone
+            ? Object.assign(rawTest.clone(), res)
+            : res;
     }
 
     _emitUpdateReference({refImg}, state) {


### PR DESCRIPTION
`test.clone` performs shallow clone of test object. We need deep clone of some properties.