### PR TITLE
feat: use test object id property instead of id() method

### DIFF
--- a/lib/gui/tool-runner/index.js
+++ b/lib/gui/tool-runner/index.js
@@ -170,7 +170,7 @@ module.exports = class ToolRunner {
                 return;
             }
 
-            const testId = formatId(test.id(), browserId);
+            const testId = formatId(test.id, browserId);
             this._tests[testId] = _.extend(test, {browserId});
 
             test.pending

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -96,7 +96,7 @@ module.exports = class TestAdapter {
     }
 
     _getExpectedKey(stateName) {
-        return this._testResult.id() + '#' + stateName;
+        return this._testResult.id + '#' + stateName;
     }
 
     _getExpectedPath(stateName, status) {
@@ -274,7 +274,7 @@ module.exports = class TestAdapter {
     }
 
     get imageDir() {
-        return this._testResult.id();
+        return this._testResult.id;
     }
 
     get state() {

--- a/test/unit/lib/test-adapter.js
+++ b/test/unit/lib/test-adapter.js
@@ -41,7 +41,7 @@ describe('hermione test adapter', () => {
     };
 
     const mkTestResult_ = (result) => _.defaults(result, {
-        id: () => 'some-id',
+        id: 'some-id',
         fullTitle: () => 'default-title'
     });
 
@@ -276,7 +276,6 @@ describe('hermione test adapter', () => {
         it('should build diff to tmp dir', async () => {
             tmp.tmpdir = 'tmp/dir';
             const testResult = mkTestResult_({
-                id: () => '',
                 assertViewResults: [err]
             });
             utils.getDiffPath.returns('diff/report/path');
@@ -291,7 +290,6 @@ describe('hermione test adapter', () => {
         it('should save diff in report from tmp dir using external storage', async () => {
             tmp.tmpdir = 'tmp/dir';
             const testResult = mkTestResult_({
-                id: () => '',
                 assertViewResults: [err]
             });
             utils.getDiffPath.returns('diff/report/path');
@@ -314,7 +312,6 @@ describe('hermione test adapter', () => {
         it('should emit TEST_SCREENSHOTS_SAVED event', async () => {
             tmp.tmpdir = 'tmp/dir';
             const testResult = mkTestResult_({
-                id: () => '',
                 browserId: 'chrome',
                 assertViewResults: [err]
             });
@@ -431,7 +428,7 @@ describe('hermione test adapter', () => {
     });
 
     it('should return image dir', () => {
-        const testResult = mkTestResult_({id: () => 'some-id'});
+        const testResult = mkTestResult_({id: 'some-id'});
 
         const hermioneTestAdapter = mkHermioneTestResultAdapter(testResult);
 


### PR DESCRIPTION
Due to https://github.com/gemini-testing/hermione/pull/742