### PR TITLE
fix: support "id" field from test for old hermione versions

### DIFF
--- a/lib/gui/tool-runner/index.js
+++ b/lib/gui/tool-runner/index.js
@@ -170,7 +170,8 @@ module.exports = class ToolRunner {
                 return;
             }
 
-            const testId = formatId(test.id, browserId);
+            // TODO: remove toString after publish major version
+            const testId = formatId(test.id.toString(), browserId);
             this._tests[testId] = _.extend(test, {browserId});
 
             test.pending

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -96,7 +96,8 @@ module.exports = class TestAdapter {
     }
 
     _getExpectedKey(stateName) {
-        return this._testResult.id + '#' + stateName;
+        // TODO: remove toString after publish major version
+        return this._testResult.id.toString() + '#' + stateName;
     }
 
     _getExpectedPath(stateName, status) {
@@ -274,7 +275,8 @@ module.exports = class TestAdapter {
     }
 
     get imageDir() {
-        return this._testResult.id;
+        // TODO: remove toString after publish major version
+        return this._testResult.id.toString();
     }
 
     get state() {


### PR DESCRIPTION
Temporary solution to support old hermione versions. Will be removed after publish major version.