### PR TITLE
fix: undo with remote images

### DIFF
--- a/lib/gui/server.js
+++ b/lib/gui/server.js
@@ -74,7 +74,7 @@ exports.start = async ({paths, hermione, guiApi, configs}) => {
         }
     });
 
-    server.post('/get-update-reference-data', (req, res) => {
+    server.post('/reference-data-to-update', (req, res) => {
         try {
             const data = app.getTestsDataToUpdateRefs(req.body);
             res.json(data);

--- a/lib/gui/tool-runner/index.js
+++ b/lib/gui/tool-runner/index.js
@@ -97,7 +97,7 @@ module.exports = class ToolRunner {
 
     updateReferenceImage(tests) {
         return Promise.map(tests, (test) => {
-            const updateResult = this._prepareUpdateResult(test);
+            const updateResult = this._prepareTestResult(test);
             const formattedResult = this._reportBuilder.format(updateResult, UPDATED);
             const failResultId = formattedResult.id;
             const updateAttempt = this._reportBuilder.getUpdatedAttempt(formattedResult);
@@ -121,17 +121,43 @@ module.exports = class ToolRunner {
         });
     }
 
-    async undoAcceptImages(imageIds) {
-        const {
-            referencesToRemove,
-            referencesToUpdate,
-            ...rest
-        } = await this._reportBuilder.undoAcceptImages(imageIds, this._reportPath);
+    async undoAcceptImages(tests) {
+        const updatedImages = [], removedResults = [];
 
-        await reporterHelper.overwriteReferenceImage(referencesToUpdate, this._reportPath);
-        await reporterHelper.removeReferenceImage(referencesToRemove);
+        await Promise.map(tests, async (test) => {
+            const updateResult = this._prepareTestResult(test);
+            const formattedResult = this._reportBuilder.format(updateResult);
 
-        return rest;
+            formattedResult.attempt = updateResult.attempt;
+
+            await Promise.map(updateResult.imagesInfo, async (imageInfo) => {
+                const {stateName} = imageInfo;
+                const {
+                    updatedImage,
+                    removedResult,
+                    previousExpectedPath,
+                    shouldRemoveReference,
+                    shouldRevertReference
+                } = await this._reportBuilder.undoAcceptImage(formattedResult, stateName);
+
+                updatedImage && updatedImages.push(updatedImage);
+                removedResult && removedResults.push(removedResult);
+
+                if (shouldRemoveReference) {
+                    await reporterHelper.removeReferenceImage(formattedResult, stateName);
+                }
+
+                if (shouldRevertReference) {
+                    await reporterHelper.revertReferenceImage(formattedResult, stateName);
+                }
+
+                if (previousExpectedPath) {
+                    formattedResult.updateCacheExpectedPath(stateName, previousExpectedPath);
+                }
+            });
+        });
+
+        return {updatedImages, removedResults};
     }
 
     async findEqualDiffs(images) {
@@ -204,7 +230,7 @@ module.exports = class ToolRunner {
         subscribeOnToolEvents(this._hermione, this._reportBuilder, this._eventSource, this._reportPath);
     }
 
-    _prepareUpdateResult(test) {
+    _prepareTestResult(test) {
         const {browserId, attempt} = test;
         const fullTitle = mkFullTitle(test);
         const testId = formatId(getShortMD5(fullTitle), browserId);

--- a/lib/local-images-saver.js
+++ b/lib/local-images-saver.js
@@ -4,7 +4,7 @@ const utils = require('./server-utils');
 
 module.exports = {
     saveImg: async (srcCurrPath, {destPath, reportDir}) => {
-        await utils.copyFileAsync(srcCurrPath, destPath, reportDir);
+        await utils.copyFileAsync(srcCurrPath, destPath, {reportDir});
 
         return destPath;
     }

--- a/lib/report-builder/gui.js
+++ b/lib/report-builder/gui.js
@@ -106,63 +106,33 @@ module.exports = class GuiReportBuilder extends StaticReportBuilder {
         return isUpdated ? attempt : attempt + 1;
     }
 
-    async undoAcceptImages(imageIds, reportPath) {
-        const updatedImages = [], removedResults = [], referencesToRemove = [], referencesToUpdate = [];
-
-        for (const imageId of imageIds) {
-            const {
-                updatedImage,
-                removedResult,
-                referenceToRemove,
-                referenceToUpdate
-            } = await this._undoAcceptImage(imageId, reportPath);
-
-            updatedImage && updatedImages.push(updatedImage);
-            removedResult && removedResults.push(removedResult);
-            referenceToRemove && referencesToRemove.push(referenceToRemove);
-            referenceToUpdate && referencesToUpdate.push(referenceToUpdate);
-        }
-
-        return {updatedImages, removedResults, referencesToRemove, referencesToUpdate};
-    }
-
-    async _undoAcceptImage(imageId, reportPath) {
+    async undoAcceptImage(formattedResult, stateName) {
+        const resultId = formattedResult.id;
+        const suitePath = formattedResult.testPath;
+        const browserName = formattedResult.browserId;
         const {
-            suitePath,
-            browserName,
-            stateName,
+            imageId,
             status,
             timestamp,
-            image,
             previousImage,
-            resultIdToRemove
-        } = this._testsTree.getResultDataToUnacceptImage(imageId);
+            shouldRemoveResult
+        } = this._testsTree.getResultDataToUnacceptImage(resultId, stateName);
 
         if (!isUpdatedStatus(status)) {
             return {};
         }
 
-        const fullTitle = suitePath.join(' ');
-        const previousExpectedImgPath = _.get(previousImage, 'expectedImg.path', null);
-        const refImgPath = previousImage.refImg.path;
-        const currentExpectedImgPath = image.expectedImg.path;
+        const previousExpectedPath = _.get(previousImage, 'expectedImg.path', null);
         const shouldRemoveReference = _.isNull(previousImage.refImg.size);
-        let updatedImage, removedResult, referenceToRemove, referenceToUpdate;
+        const shouldRevertReference = !shouldRemoveReference;
 
-        await this._removeImageFromReport(reportPath, currentExpectedImgPath);
-        this._updateTestExpectedPath(fullTitle, browserName, stateName, previousExpectedImgPath);
+        let updatedImage, removedResult;
 
-        if (shouldRemoveReference) {
-            referenceToRemove = refImgPath;
-        } else {
-            referenceToUpdate = {path: refImgPath, source: previousExpectedImgPath};
-        }
+        if (shouldRemoveResult) {
+            this._testsTree.removeTestResult(resultId);
+            formattedResult.decreaseAttemptNumber();
 
-        if (resultIdToRemove) {
-            this._testsTree.removeTestResult(resultIdToRemove);
-            this._decreaseTestAttemptNumber(fullTitle, browserName);
-
-            removedResult = resultIdToRemove;
+            removedResult = resultId;
         } else {
             updatedImage = this._testsTree.updateImageInfo(imageId, previousImage);
         }
@@ -175,7 +145,7 @@ module.exports = class GuiReportBuilder extends StaticReportBuilder {
             `json_extract(${DB_COLUMNS.IMAGES_INFO}, '$[0].stateName') = ?`
         ].join(' AND ')}, JSON.stringify(suitePath), browserName, status, timestamp, stateName);
 
-        return {updatedImage, removedResult, referenceToRemove, referenceToUpdate};
+        return {updatedImage, removedResult, previousExpectedPath, shouldRemoveReference, shouldRevertReference};
     }
 
     _addTestResult(formattedResult, props, opts = {}) {

--- a/lib/report-builder/static.js
+++ b/lib/report-builder/static.js
@@ -147,14 +147,6 @@ module.exports = class StaticReportBuilder {
         this._sqliteAdapter.delete({where, orderBy, orderDescending, limit}, ...args);
     }
 
-    _updateTestExpectedPath(fullTitle, browserId, stateName, expectedPath) {
-        TestAdapter.updateCacheExpectedPath(fullTitle, browserId, stateName, expectedPath);
-    }
-
-    _decreaseTestAttemptNumber(fullTitle, browserName) {
-        TestAdapter.decreaseAttemptNumber(fullTitle, browserName);
-    }
-
     async finalize() {
         this._sqliteAdapter.close();
 

--- a/lib/reporter-helpers.js
+++ b/lib/reporter-helpers.js
@@ -1,28 +1,42 @@
 'use strict';
 
 const path = require('path');
+const tmp = require('tmp');
 const Promise = require('bluebird');
+const {getShortMD5} = require('./common-utils');
 const utils = require('./server-utils');
 
-exports.updateReferenceImage = (testResult, reportPath, stateName) => {
+const mkReferenceId = (testId, stateName) => getShortMD5(`${testId}#${stateName}`);
+
+exports.updateReferenceImage = async (testResult, reportPath, stateName) => {
     const currImg = testResult.getCurrImg(stateName);
 
     const src = currImg.path
         ? path.resolve(reportPath, currImg.path)
         : utils.getCurrentAbsolutePath(testResult, reportPath, stateName);
 
+    const referencePath = testResult.getRefImg(stateName).path;
+
+    if (utils.fileExists(referencePath)) {
+        const referenceId = mkReferenceId(testResult.id, stateName);
+        const oldReferencePath = path.resolve(tmp.tmpdir, referenceId);
+        await utils.copyFileAsync(referencePath, oldReferencePath);
+    }
+
     return Promise.all([
-        utils.copyFileAsync(src, testResult.getRefImg(stateName).path),
+        utils.copyFileAsync(src, referencePath),
         utils.copyFileAsync(src, utils.getReferenceAbsolutePath(testResult, reportPath, stateName))
     ]);
 };
 
-exports.removeReferenceImage = (refImgPaths) => {
-    return Promise.map([].concat(refImgPaths), (refImgPath) => utils.deleteFile(refImgPath));
+exports.revertReferenceImage = (testResult, stateName) => {
+    const referenceId = mkReferenceId(testResult.id, stateName);
+    const oldReferencePath = path.resolve(tmp.tmpdir, referenceId);
+    const referencePath = testResult.getRefImg(stateName).path;
+
+    return utils.copyFileAsync(oldReferencePath, referencePath);
 };
 
-exports.overwriteReferenceImage = (referencesToUpdate, reportPath) => {
-    return Promise.map([].concat(referencesToUpdate), (referenceToUpdate) => {
-        return utils.copyFileAsync(path.resolve(reportPath, referenceToUpdate.source), referenceToUpdate.path);
-    });
+exports.removeReferenceImage = (testResult, stateName) => {
+    return utils.deleteFile(testResult.getRefImg(stateName).path);
 };

--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -47,9 +47,9 @@ function createPath(kind, result, stateName) {
     return path.join.apply(null, components);
 }
 
-function copyFileAsync(srcPath, destPath, reportDir = '') {
+function copyFileAsync(srcPath, destPath, {reportDir = '', overwrite = true} = {}) {
     const resolvedDestPath = path.resolve(reportDir, destPath);
-    return makeDirFor(resolvedDestPath).then(() => fs.copy(srcPath, resolvedDestPath));
+    return makeDirFor(resolvedDestPath).then(() => fs.copy(srcPath, resolvedDestPath, {overwrite}));
 }
 
 /**
@@ -65,6 +65,10 @@ function deleteFile(filePath) {
  */
 function makeDirFor(destPath) {
     return fs.mkdirs(path.dirname(destPath));
+}
+
+function fileExists(path) {
+    return fs.existsSync(path);
 }
 
 function logPathToHtmlReport(pluginConfig) {
@@ -278,6 +282,7 @@ module.exports = {
     copyFileAsync,
     deleteFile,
     makeDirFor,
+    fileExists,
 
     logPathToHtmlReport,
     logError,

--- a/lib/static/modules/actions.js
+++ b/lib/static/modules/actions.js
@@ -168,8 +168,9 @@ export const undoAcceptImages = (imageIds, {skipTreeUpdate = false} = {}) => {
         dispatch({type: actionNames.PROCESS_BEGIN});
 
         try {
-            const {data} = await axios.post('/undo-accept-images', imageIds);
-            const payload = {...data, skipTreeUpdate};
+            const {data} = await axios.post('/get-update-reference-data', imageIds);
+            const {data: updatedData} = await axios.post('/undo-accept-images', data);
+            const payload = {...updatedData, skipTreeUpdate};
 
             dispatch({type: actionNames.UNDO_ACCEPT_IMAGES, payload});
         } catch (e) {

--- a/lib/static/modules/actions.js
+++ b/lib/static/modules/actions.js
@@ -135,7 +135,7 @@ export const acceptOpened = (imageIds, type = actionNames.ACCEPT_OPENED_SCREENSH
         dispatch({type: actionNames.PROCESS_BEGIN});
 
         try {
-            const {data} = await axios.post('/get-update-reference-data', imageIds);
+            const {data} = await axios.post('/reference-data-to-update', imageIds);
             const {data: updatedData} = await axios.post('/update-reference', data);
             dispatch({type, payload: updatedData});
 
@@ -168,7 +168,7 @@ export const undoAcceptImages = (imageIds, {skipTreeUpdate = false} = {}) => {
         dispatch({type: actionNames.PROCESS_BEGIN});
 
         try {
-            const {data} = await axios.post('/get-update-reference-data', imageIds);
+            const {data} = await axios.post('/reference-data-to-update', imageIds);
             const {data: updatedData} = await axios.post('/undo-accept-images', data);
             const payload = {...updatedData, skipTreeUpdate};
 

--- a/lib/test-adapter.js
+++ b/lib/test-adapter.js
@@ -39,7 +39,7 @@ module.exports = class TestAdapter {
         this._errors = this._hermione.errors;
         this._suite = SuiteAdapter.create(this._testResult);
         this._imagesSaver = this._hermione.htmlReporter.imagesSaver;
-        this._testId = TestAdapter._mkTestId(this._testResult.fullTitle(), this._testResult.browserId);
+        this._testId = this._mkTestId();
         this._errorDetails = undefined;
         this._timestamp = this._testResult.timestamp;
 
@@ -93,14 +93,6 @@ module.exports = class TestAdapter {
 
         const imagesInfo = imagesInfoResult && JSON.parse(imagesInfoResult[DB_COLUMNS.IMAGES_INFO]) || [];
         return imagesInfo.find(info => info.stateName === stateName);
-    }
-
-    _getExpectedKey(stateName) {
-        return TestAdapter._getExpectedKey(
-            this._testResult.fullTitle(),
-            this._testResult.browserId,
-            stateName
-        );
     }
 
     _getExpectedPath(stateName, status, cacheExpectedPaths) {
@@ -433,6 +425,38 @@ module.exports = class TestAdapter {
         return result;
     }
 
+    updateCacheExpectedPath(stateName, expectedPath) {
+        const key = this._getExpectedKey(stateName);
+
+        if (expectedPath) {
+            globalCacheExpectedPaths.set(key, expectedPath);
+        } else {
+            globalCacheExpectedPaths.delete(key);
+        }
+    }
+
+    decreaseAttemptNumber() {
+        const testId = this._mkTestId();
+        const currentTestAttempt = testsAttempts.get(testId);
+        const previousTestAttempt = currentTestAttempt - 1;
+
+        if (previousTestAttempt) {
+            testsAttempts.set(testId, previousTestAttempt);
+        } else {
+            testsAttempts.delete(testId);
+        }
+    }
+
+    _mkTestId() {
+        return this._testResult.fullTitle() + '.' + this._testResult.browserId;
+    }
+
+    _getExpectedKey(stateName) {
+        const shortTestId = getShortMD5(this._mkTestId());
+
+        return shortTestId + '#' + stateName;
+    }
+
     //parallelize and cache of 'looks-same.createDiff' (because it is very slow)
     async _saveDiffInWorker(imageDiffError, destPath, workers, cacheDiffImages = globalCacheDiffImages) {
         await utils.makeDirFor(destPath);
@@ -457,28 +481,5 @@ module.exports = class TestAdapter {
         await workers.saveDiffTo(imageDiffError, destPath);
 
         cacheDiffImages.set(hash, destPath);
-    }
-
-    static _mkTestId(fullTitle, browserId) {
-        return fullTitle + '.' + browserId;
-    }
-
-    static _getExpectedKey(fullTitle, browserId, stateName) {
-        const shortTestId = getShortMD5(this._mkTestId(fullTitle, browserId));
-
-        return shortTestId + '#' + stateName;
-    }
-
-    static updateCacheExpectedPath(fullTitle, browserId, stateName, expectedPath) {
-        const key = this._getExpectedKey(fullTitle, browserId, stateName);
-
-        globalCacheExpectedPaths.set(key, expectedPath);
-    }
-
-    static decreaseAttemptNumber(fullTitle, browserName) {
-        const testId = this._mkTestId(fullTitle, browserName);
-        const currentTestAttempt = testsAttempts.get(testId);
-
-        testsAttempts.set(testId, currentTestAttempt - 1);
     }
 };

--- a/lib/tests-tree-builder/gui.js
+++ b/lib/tests-tree-builder/gui.js
@@ -84,11 +84,13 @@ module.exports = class GuiTestsTreeBuilder extends BaseTestsTreeBuilder {
         });
     }
 
-    getResultDataToUnacceptImage(imageId) {
+    getResultDataToUnacceptImage(resultId, stateName) {
+        const imageId = this._tree.results.byId[resultId].imageIds.find(imageId => {
+            return this._tree.images.byId[imageId].stateName === stateName;
+        });
         const image = this._tree.images.byId[imageId];
         const result = this._tree.results.byId[image.parentId];
         const browser = this._tree.browsers.byId[result.parentId];
-        const suite = this.tree.suites.byId[browser.parentId];
 
         const previousResultId = browser.resultIds.find((_, ind, resultIds) => resultIds[ind + 1] === result.id);
         const previousResult = previousResultId ? this._tree.results.byId[previousResultId] : null;
@@ -104,17 +106,14 @@ module.exports = class GuiTestsTreeBuilder extends BaseTestsTreeBuilder {
             return acc + isUpdatedStatus(this._tree.images.byId[currImageId].status);
         }, 0);
         const shouldRemoveResult = isUpdatedStatus(image.status) && countUpdated === 1;
-        const resultIdToRemove = shouldRemoveResult ? result.id : null;
 
         return {
-            suitePath: suite.suitePath,
-            browserName: browser.name,
-            stateName: image.stateName,
+            imageId,
             status: image.status,
             timestamp: result.timestamp,
-            image,
             previousImage,
-            resultIdToRemove
+            previousImageId,
+            shouldRemoveResult
         };
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "html-reporter",
-      "version": "9.7.6",
+      "version": "9.8.3",
       "license": "MIT",
       "dependencies": {
         "@gemini-testing/sql.js": "^1.0.1",

--- a/test/unit/hermione.js
+++ b/test/unit/hermione.js
@@ -222,7 +222,7 @@ describe('lib/hermione', () => {
         hermione.emit(events.TEST_PASS, testData);
         await hermione.emitAsync(events.RUNNER_END);
 
-        assert.calledOnceWith(utils.copyFileAsync, 'ref/path', 'report/plain', '/absolute');
+        assert.calledOnceWith(utils.copyFileAsync, 'ref/path', 'report/plain', {reportDir: '/absolute'});
     });
 
     it('should save image from assert view error', async () => {
@@ -235,7 +235,7 @@ describe('lib/hermione', () => {
         hermione.emit(events.RETRY, mkStubResult_({assertViewResults: [err]}));
         await hermione.emitAsync(events.RUNNER_END);
 
-        assert.calledOnceWith(utils.copyFileAsync, 'current/path', 'report/plain', '/absolute');
+        assert.calledOnceWith(utils.copyFileAsync, 'current/path', 'report/plain', {reportDir: '/absolute'});
     });
 
     it('should save reference image from assert view fail', async () => {
@@ -250,7 +250,7 @@ describe('lib/hermione', () => {
         hermione.emit(events.TEST_FAIL, mkStubResult_({assertViewResults: [err]}));
         await hermione.emitAsync(events.RUNNER_END);
 
-        assert.calledWith(utils.copyFileAsync, 'reference/path', 'report/plain', '/absolute');
+        assert.calledWith(utils.copyFileAsync, 'reference/path', 'report/plain', {reportDir: '/absolute'});
     });
 
     it('should save current image from assert view fail', async () => {
@@ -268,7 +268,7 @@ describe('lib/hermione', () => {
         hermione.emit(events.TEST_FAIL, mkStubResult_({assertViewResults: [err]}));
         await hermione.emitAsync(events.RUNNER_END);
 
-        assert.calledWith(utils.copyFileAsync, 'current/path', 'report/plain', '/absolute');
+        assert.calledWith(utils.copyFileAsync, 'current/path', 'report/plain', {reportDir: '/absolute'});
     });
 
     it('should save current diff image from assert view fail', async () => {

--- a/test/unit/lib/local-images-saver.js
+++ b/test/unit/lib/local-images-saver.js
@@ -15,7 +15,7 @@ describe('local-images-saver', () => {
     it('should save image', async () => {
         await imagesSaver.saveImg('local/path/img.png', {destPath: 'dest/path/img.png', reportDir: 'rep/dir'});
 
-        assert.calledWith(utils.copyFileAsync, 'local/path/img.png', 'dest/path/img.png', 'rep/dir');
+        assert.calledWith(utils.copyFileAsync, 'local/path/img.png', 'dest/path/img.png', {reportDir: 'rep/dir'});
     });
 
     it('should return dest path', async () => {

--- a/test/unit/lib/server-utils.js
+++ b/test/unit/lib/server-utils.js
@@ -112,7 +112,7 @@ describe('server-utils', () => {
             const toPath = 'to/image.png';
             const pathToReport = '/report-dir';
 
-            return utils.copyFileAsync(fromPath, toPath, pathToReport)
+            return utils.copyFileAsync(fromPath, toPath, {reportDir: pathToReport})
                 .then(() => {
                     assert.calledWith(fs.mkdirs, '/report-dir/to');
                     assert.calledWithMatch(fs.copy, fromPath, toPath);

--- a/test/unit/lib/static/modules/actions.js
+++ b/test/unit/lib/static/modules/actions.js
@@ -112,15 +112,16 @@ describe('lib/static/modules/actions', () => {
     describe('undoAcceptImages', () => {
         it('should cancel update of accepted image', async () => {
             const imageIds = ['img-id-1', 'img-id-2'];
-            const data = {updatedImages: [{id: 'img-id-1'}], removedResults: ['img-id-2']};
-            axios.post.withArgs('/undo-accept-images', imageIds).returns({data});
+            const images = [{id: 'img-id-1'}, {id: 'img-id-2'}];
+            axios.post.withArgs('/get-update-reference-data', imageIds).returns({data: images});
 
             await undoAcceptImages(imageIds)(dispatch);
 
-            assert.calledOnceWith(axios.post, '/undo-accept-images', imageIds);
+            assert.calledWith(axios.post.firstCall, '/get-update-reference-data', imageIds);
+            assert.calledWith(axios.post.secondCall, '/undo-accept-images', images);
             assert.calledWith(dispatch, {
                 type: actionNames.UNDO_ACCEPT_IMAGES,
-                payload: {...data, skipTreeUpdate: false}
+                payload: {skipTreeUpdate: false}
             });
         });
 
@@ -133,7 +134,7 @@ describe('lib/static/modules/actions', () => {
 
             assert.calledWith(dispatch, {
                 type: actionNames.UNDO_ACCEPT_IMAGES,
-                payload: {...data, skipTreeUpdate: true}
+                payload: {skipTreeUpdate: true}
             });
         });
     });

--- a/test/unit/lib/static/modules/actions.js
+++ b/test/unit/lib/static/modules/actions.js
@@ -100,11 +100,11 @@ describe('lib/static/modules/actions', () => {
         it('should update opened images', async () => {
             const imageIds = ['img-id-1', 'img-id-2'];
             const images = [{id: 'img-id-1'}, {id: 'img-id-2'}];
-            axios.post.withArgs('/get-update-reference-data', imageIds).returns({data: images});
+            axios.post.withArgs('/reference-data-to-update', imageIds).returns({data: images});
 
             await acceptOpened(imageIds)(dispatch);
 
-            assert.calledWith(axios.post.firstCall, '/get-update-reference-data', imageIds);
+            assert.calledWith(axios.post.firstCall, '/reference-data-to-update', imageIds);
             assert.calledWith(axios.post.secondCall, '/update-reference', images);
         });
     });
@@ -113,11 +113,11 @@ describe('lib/static/modules/actions', () => {
         it('should cancel update of accepted image', async () => {
             const imageIds = ['img-id-1', 'img-id-2'];
             const images = [{id: 'img-id-1'}, {id: 'img-id-2'}];
-            axios.post.withArgs('/get-update-reference-data', imageIds).returns({data: images});
+            axios.post.withArgs('/reference-data-to-update', imageIds).returns({data: images});
 
             await undoAcceptImages(imageIds)(dispatch);
 
-            assert.calledWith(axios.post.firstCall, '/get-update-reference-data', imageIds);
+            assert.calledWith(axios.post.firstCall, '/reference-data-to-update', imageIds);
             assert.calledWith(axios.post.secondCall, '/undo-accept-images', images);
             assert.calledWith(dispatch, {
                 type: actionNames.UNDO_ACCEPT_IMAGES,

--- a/test/unit/lib/tests-tree-builder/gui.js
+++ b/test/unit/lib/tests-tree-builder/gui.js
@@ -272,18 +272,18 @@ describe('GuiResultsTreeBuilder', () => {
     });
 
     describe('"getResultDataToUnacceptImage" method', () => {
-        it('should return "resultIdToRemove" if it is the only updated image in result', () => {
+        it('should return "shouldRemoveResult: true" if it is the only updated image in result', () => {
             const formattedRes1 = mkFormattedResult_({testPath: ['s'], browserId: 'b', attempt: 0});
             const formattedRes2 = mkFormattedResult_({testPath: ['s'], browserId: 'b', attempt: 1});
             builder.addTestResult(mkTestResult_({imagesInfo: [{stateName: 'foo', status: FAIL}]}), formattedRes1);
             builder.addTestResult(mkTestResult_({imagesInfo: [{stateName: 'foo', status: UPDATED}]}), formattedRes2);
 
-            const {resultIdToRemove} = builder.getResultDataToUnacceptImage('s b 1 foo');
+            const {shouldRemoveResult} = builder.getResultDataToUnacceptImage('s b 1', 'foo');
 
-            assert.equal(resultIdToRemove, 's b 1');
+            assert.isTrue(shouldRemoveResult);
         });
 
-        it('should not return "resultIdToRemove" if it is not the only updated image in result', () => {
+        it('should return "shouldRemoveResult: false" if it is not the only updated image in result', () => {
             const imagesInfo1 = [{stateName: 'foo', status: FAIL}, {stateName: 'bar', status: FAIL}];
             const imagesInfo2 = [{stateName: 'foo', status: UPDATED}, {stateName: 'bar', status: UPDATED}];
             const formattedRes1 = mkFormattedResult_({testPath: ['s'], browserId: 'b', attempt: 0});
@@ -291,9 +291,9 @@ describe('GuiResultsTreeBuilder', () => {
             builder.addTestResult(mkTestResult_({imagesInfo: imagesInfo1}), formattedRes1);
             builder.addTestResult(mkTestResult_({imagesInfo: imagesInfo2}), formattedRes2);
 
-            const {resultIdToRemove} = builder.getResultDataToUnacceptImage('s b 1 foo');
+            const {shouldRemoveResult} = builder.getResultDataToUnacceptImage('s b 1', 'foo');
 
-            assert.equal(resultIdToRemove, null);
+            assert.isFalse(shouldRemoveResult);
         });
     });
 });


### PR DESCRIPTION
## Что сделано

Переписал логику с отменой обновления референсов, убрал логику с удалением отмененных референсов из отчета

## Зачем

- Потому что пути к картинкам могут быть ссылками на ресурсы, из-за этого возникают проблемы при попытке обновить/удалить такие референсы. То, что такие картинки не удаляются, ничему не мешает
- (ну и потому что так лучше смотрится)

## Как тестировал

Локально + на скачанном отчете с путями до картинок в виде ссылок на удаленные ресурсы