### PR TITLE
fix: 3-up scaled to fit diff bubble

### DIFF
--- a/lib/static/components/state/screenshot/diff-circle.js
+++ b/lib/static/components/state/screenshot/diff-circle.js
@@ -7,6 +7,7 @@ import {CIRCLE_RADIUS} from '../../../../constants/defaults';
 
 export default class DiffCircle extends Component {
     static propTypes = {
+        originalImageWidth: PropTypes.number.isRequired,
         diffTarget: PropTypes.object.isRequired,
         diffBounds: PropTypes.object.isRequired,
         display: PropTypes.bool.isRequired,
@@ -14,9 +15,9 @@ export default class DiffCircle extends Component {
     };
 
     _getRect() {
-        const {diffBounds, diffTarget} = this.props;
+        const {originalImageWidth, diffBounds, diffTarget} = this.props;
         const targetRect = diffTarget.getBoundingClientRect();
-        const sizeCoeff = diffTarget.offsetWidth / parseInt(diffTarget.style.width);
+        const sizeCoeff = diffTarget.offsetWidth / originalImageWidth;
 
         const rectHeight = Math.ceil(sizeCoeff * (diffBounds.bottom - diffBounds.top + 1));
         const rectWidth = Math.ceil(sizeCoeff * (diffBounds.right - diffBounds.left + 1));

--- a/lib/static/components/state/screenshot/resized.js
+++ b/lib/static/components/state/screenshot/resized.js
@@ -33,6 +33,7 @@ class ResizedScreenshot extends Component {
     _getScreenshotComponent(elem, diffClusters) {
         return <Fragment>
             {diffClusters && diffClusters.map((c, id) => <DiffCircle
+                originalImageWidth={this.props.image.size.width}
                 diffTarget={this.state.diffTarget}
                 display={this.state.showDiffCircle}
                 toggleDiff={this.toggleDiff}

--- a/test/unit/lib/static/components/state/screenshot/diff-circle.js
+++ b/test/unit/lib/static/components/state/screenshot/diff-circle.js
@@ -10,7 +10,8 @@ describe('DiffCircle component', () => {
     it('should set "debounce" option', () => {
         const stateComponent = mkConnectedComponent(
             <DiffCircle
-                diffTarget = {{offsetWidth: 10, style: {width: 10}, getBoundingClientRect: () => ({left: 10, top: 10})}}
+                originalImageWidth = {10}
+                diffTarget = {{offsetWidth: 10, getBoundingClientRect: () => ({left: 10, top: 10})}}
                 diffBounds = {{left: 5, top: 5, right: 5, bottom: 5}}
                 display = {true}
                 toggleDiff = {() => {}}
@@ -26,7 +27,8 @@ describe('DiffCircle component', () => {
         const toggleDiff = sandbox.stub();
         const stateComponent = mkConnectedComponent(
             <DiffCircle
-                diffTarget = {{offsetWidth: 30, style: {width: 10}, getBoundingClientRect: () => ({left: 10, top: 10})}}
+                originalImageWidth = {10}
+                diffTarget = {{offsetWidth: 30, getBoundingClientRect: () => ({left: 10, top: 10})}}
                 diffBounds = {{left: 5, top: 5, right: 5, bottom: 5}}
                 display = {true}
                 toggleDiff = {toggleDiff}


### PR DESCRIPTION
## Что сделано

Текущая имплементация достает исходный размер картинки из `target.style.width`, вместо прокидывания напрямую, из-за чего при использовании `3-up scaled to fit` `sizeCoeff`, считающийся в `diff-circle`, считается неправильно, и всегда равен единице (потому что в `3-up scaled to fit` `width`, передающийся в `style` - это уже размер уменьшенной картинки). В этом PR - фикс