### PR TITLE
perf: use diffBuffer, provided from hermione

### DIFF
--- a/lib/test-adapter.ts
+++ b/lib/test-adapter.ts
@@ -501,6 +501,14 @@ export class TestAdapter {
     protected async _saveDiffInWorker(imageDiffError: ImageDiffError, destPath: string, workers: typeof Workers, cacheDiffImages = globalCacheDiffImages): Promise<void> {
         await utils.makeDirFor(destPath);
 
+        if (imageDiffError.diffBuffer) { // new versions of hermione provide `diffBuffer`
+            const pngBuffer = Buffer.from(imageDiffError.diffBuffer);
+
+            await fs.writeFile(destPath, pngBuffer);
+
+            return;
+        }
+
         const currPath = imageDiffError.currImg.path;
         const refPath = imageDiffError.refImg.path;
 

--- a/lib/test-adapter.ts
+++ b/lib/test-adapter.ts
@@ -365,16 +365,16 @@ export class TestAdapter {
         return this._errorDetails;
     }
 
-    getRefImg(stateName?: string): ImageData | undefined {
-        return _.get(_.find(this.assertViewResults, {stateName}), 'refImg');
+    getRefImg(stateName?: string): ImageData | Record<string, never> {
+        return _.get(_.find(this.assertViewResults, {stateName}), 'refImg', {});
     }
 
-    getCurrImg(stateName?: string): ImageData | undefined {
-        return _.get(_.find(this.assertViewResults, {stateName}), 'currImg');
+    getCurrImg(stateName?: string): ImageData | Record<string, never> {
+        return _.get(_.find(this.assertViewResults, {stateName}), 'currImg', {});
     }
 
-    getErrImg(): ImageBase64 | undefined {
-        return this.screenshot;
+    getErrImg(): ImageBase64 | Record<string, never> {
+        return this.screenshot || {};
     }
 
     prepareTestResult(): PrepareTestResultData {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,6 +84,7 @@ export interface ImageDiffError {
     currImg: ImageData;
     refImg: ImageData;
     diffClusters: CoordBounds[];
+    diffBuffer?: ArrayBuffer;
 }
 
 export type AssertViewResult = ImageDiffError;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "inquirer": "^8.2.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.4",
-        "looks-same": "^8.1.0",
+        "looks-same": "^8.2.1",
         "nested-error-stacks": "^2.1.0",
         "opener": "^1.4.3",
         "ora": "^5.4.1",
@@ -20063,9 +20063,9 @@
       }
     },
     "node_modules/looks-same": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-8.1.0.tgz",
-      "integrity": "sha512-gdMgCSCvhpR2/AA15CamZD7Ch+gx8sOqWyRzz3j1Gs8+2VBCyHm3CRMS8EK+5rNvpwf9AGEnDunredVM5+f46w==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-8.2.1.tgz",
+      "integrity": "sha512-55u5dWPWc/9cIFRtDjqbH/J3h0nyar1gqFrDIDQSpqYDDd19dZUQtTMxLj0hvsxzp/qzQ0EV0HChtXRWylY2Pg==",
       "dependencies": {
         "color-diff": "^1.1.0",
         "fs-extra": "^8.1.0",
@@ -47515,9 +47515,9 @@
       "dev": true
     },
     "looks-same": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-8.1.0.tgz",
-      "integrity": "sha512-gdMgCSCvhpR2/AA15CamZD7Ch+gx8sOqWyRzz3j1Gs8+2VBCyHm3CRMS8EK+5rNvpwf9AGEnDunredVM5+f46w==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-8.2.1.tgz",
+      "integrity": "sha512-55u5dWPWc/9cIFRtDjqbH/J3h0nyar1gqFrDIDQSpqYDDd19dZUQtTMxLj0hvsxzp/qzQ0EV0HChtXRWylY2Pg==",
       "requires": {
         "color-diff": "^1.1.0",
         "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "inquirer": "^8.2.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",
-    "looks-same": "^8.1.0",
+    "looks-same": "^8.2.1",
     "nested-error-stacks": "^2.1.0",
     "opener": "^1.4.3",
     "ora": "^5.4.1",


### PR DESCRIPTION
## Что сделано
- Добавил возможность не считать дифф, если он уже посчитан и передан от `hermione`
- Оставил существующую логику для обеспечения обратной совместимости
- Обновил `looks-same`, чтобы ускорить расчет диффа на новых версиях `html-reporter` со старыми версиями `hermione`