### PR TITLE
fix: handle absence of error message correctly

### DIFF
--- a/lib/static/components/state/state-error.jsx
+++ b/lib/static/components/state/state-error.jsx
@@ -33,7 +33,7 @@ class StateError extends Component {
     _getErrorPattern() {
         const {errorPatterns, error} = this.props;
 
-        return errorPatterns.find(({regexp}) => error.message.match(regexp));
+        return errorPatterns.find(({regexp}) => error.message?.match(regexp));
     }
 
     _drawImage() {


### PR DESCRIPTION
Sometimes, sqlite database may contain `{}` in error column. In that case the whole report will crash due to trying to read property of undefined.