### PR TITLE
fix: fix merge-reports command

### DIFF
--- a/lib/merge-reports/index.js
+++ b/lib/merge-reports/index.js
@@ -6,7 +6,7 @@ module.exports = async (pluginConfig, hermione, srcPaths, {destination: destPath
     validateOpts(srcPaths, destPath);
 
     await Promise.all([
-        serverUtils.saveStaticFilesToReportDir(hermione, pluginConfig, destPath),
+        serverUtils.saveStaticFilesToReportDir(hermione.htmlReporter, pluginConfig, destPath),
         serverUtils.writeDatabaseUrlsFile(destPath, srcPaths)
     ]);
 

--- a/test/unit/lib/merge-reports/index.js
+++ b/test/unit/lib/merge-reports/index.js
@@ -56,7 +56,7 @@ describe('lib/merge-reports', () => {
 
         await execMergeReports_({pluginConfig, hermione, paths, opts: {destination}});
 
-        assert.calledOnceWith(serverUtils.saveStaticFilesToReportDir, hermione, pluginConfig, destination);
+        assert.calledOnceWith(serverUtils.saveStaticFilesToReportDir, hermione.htmlReporter, pluginConfig, destination);
         assert.calledOnceWith(serverUtils.writeDatabaseUrlsFile, destination, paths);
     });
 


### PR DESCRIPTION
Due to a `saveStaticFilesToReportDir`'s signature change during refactoring, the merge-reports command started working incorrectly. This PR addresses this issue.