### PR TITLE
perf: resolve jsonurls while merging reports

### DIFF
--- a/lib/merge-reports/index.js
+++ b/lib/merge-reports/index.js
@@ -1,13 +1,17 @@
 'use strict';
 
+const axios = require('axios');
+const _ = require('lodash');
 const serverUtils = require('../server-utils');
 
 module.exports = async (pluginConfig, hermione, srcPaths, {destination: destPath}) => {
     validateOpts(srcPaths, destPath);
 
+    const resolvedUrls = await tryResolveUrls(srcPaths);
+
     await Promise.all([
         serverUtils.saveStaticFilesToReportDir(hermione.htmlReporter, pluginConfig, destPath),
-        serverUtils.writeDatabaseUrlsFile(destPath, srcPaths)
+        serverUtils.writeDatabaseUrlsFile(destPath, resolvedUrls)
     ]);
 
     await hermione.htmlReporter.emitAsync(hermione.htmlReporter.events.REPORT_SAVED, {reportPath: destPath});
@@ -21,4 +25,43 @@ function validateOpts(srcPaths, destPath) {
     if (srcPaths.includes(destPath)) {
         throw new Error(`Destination report path: ${destPath}, exists in source report paths`);
     }
+}
+
+async function tryResolveUrls(urls) {
+    const resolvedUrls = [];
+    const results = await Promise.all(urls.map(tryResolveUrl));
+
+    results.forEach(({jsonUrls, dbUrls}) => {
+        resolvedUrls.push(...jsonUrls.concat(dbUrls));
+    });
+
+    return resolvedUrls;
+}
+
+async function tryResolveUrl(url) {
+    const jsonUrls = [];
+    const dbUrls = [];
+
+    if (serverUtils.isDbUrl(url)) {
+        dbUrls.push(url);
+    } else if (serverUtils.isJsonUrl(url)) {
+        try {
+            const {data} = await axios.get(url);
+            const currentDbUrls = _.get(data, 'dbUrls', []);
+            const currentJsonUrls = _.get(data, 'jsonUrls', []);
+
+            const responses = await Promise.all(currentJsonUrls.map(tryResolveUrl));
+
+            dbUrls.push(...currentDbUrls);
+
+            responses.forEach(response => {
+                dbUrls.push(...response.dbUrls);
+                jsonUrls.push(...response.jsonUrls);
+            });
+        } catch (e) {
+            jsonUrls.push(url);
+        }
+    }
+
+    return {jsonUrls, dbUrls};
 }

--- a/lib/server-utils.ts
+++ b/lib/server-utils.ts
@@ -171,9 +171,17 @@ export function urlPathNameEndsWith(currentUrl: string, searchString: string): b
     }
 }
 
+export function isJsonUrl(url: string): boolean {
+    return urlPathNameEndsWith(url, '.json');
+}
+
+export function isDbUrl(url: string): boolean {
+    return urlPathNameEndsWith(url, '.db');
+}
+
 export async function writeDatabaseUrlsFile(destPath: string, srcPaths: string[]): Promise<void> {
-    const jsonUrls = srcPaths.filter(p => urlPathNameEndsWith(p, '.json'));
-    const dbUrls = srcPaths.filter(p => urlPathNameEndsWith(p, '.db'));
+    const jsonUrls = srcPaths.filter(isJsonUrl);
+    const dbUrls = srcPaths.filter(isDbUrl);
     const data = {
         dbUrls,
         jsonUrls


### PR DESCRIPTION
## Что сделано

Если скачанный json с базами данных содержит ссылки на другие json-ы, на этапе слияния отчетов скачиваем их тоже, чтобы получить их содержимое. После чего ссылки на базы данных кладем в список ссылок на базы данных, а с ссылками на json делаем рекурсивно так же. Если json скачать не удалось, фоллбэкаем на текущую схему (кладем его в список json-ов)