### PR TITLE
fix(css): change color for failed tests

### DIFF
--- a/lib/static/variables.css
+++ b/lib/static/variables.css
@@ -1,5 +1,5 @@
 :root {
-    --report-color-fail: rgba(255, 4, 0, 0.9);
+    --report-color-fail: #d00;
     --report-color-skip: #8c8c8c;
     --report-color-success: #169737;
 }


### PR DESCRIPTION
<img width="409" alt="image" src="https://github.com/gemini-testing/html-reporter/assets/1658415/8c65991e-727c-44a8-ad5c-539ddd22cf5c">
