### PR TITLE
fix: normalize urls while merging reports

### DIFF
--- a/lib/db-utils/server.ts
+++ b/lib/db-utils/server.ts
@@ -18,6 +18,8 @@ import {SqliteAdapter} from '../sqlite-adapter';
 
 export * from './common';
 
+export const prepareUrls = (urls: string[], baseUrl: string): string[] => isUrl(baseUrl) ? normalizeUrls(urls, baseUrl) : urls;
+
 export async function downloadDatabases(dbJsonUrls: string[], opts: HandleDatabasesOptions): Promise<(string | DbLoadResult)[]> {
     const loadDbJsonUrl = async (dbJsonUrl: string): Promise<{data: DbUrlsJsonData | null}> => {
         if (isUrl(dbJsonUrl)) {
@@ -28,7 +30,6 @@ export async function downloadDatabases(dbJsonUrls: string[], opts: HandleDataba
         return {data};
     };
 
-    const prepareUrls = (urls: string[], baseUrl: string): string[] => isUrl(baseUrl) ? normalizeUrls(urls, baseUrl) : urls;
     const loadDbUrl = (dbUrl: string, opts: HandleDatabasesOptions): Promise<string> => downloadSingleDatabase(dbUrl, opts);
 
     return commonSqliteUtils.handleDatabases(dbJsonUrls, {...opts, loadDbJsonUrl, prepareUrls, loadDbUrl});

--- a/lib/merge-reports/index.js
+++ b/lib/merge-reports/index.js
@@ -3,6 +3,7 @@
 const axios = require('axios');
 const _ = require('lodash');
 const serverUtils = require('../server-utils');
+const dbServerUtils = require('../db-utils/server');
 
 module.exports = async (pluginConfig, hermione, srcPaths, {destination: destPath}) => {
     validateOpts(srcPaths, destPath);
@@ -50,9 +51,12 @@ async function tryResolveUrl(url) {
             const currentDbUrls = _.get(data, 'dbUrls', []);
             const currentJsonUrls = _.get(data, 'jsonUrls', []);
 
-            const responses = await Promise.all(currentJsonUrls.map(tryResolveUrl));
+            const preparedDbUrls = dbServerUtils.prepareUrls(currentDbUrls, url);
+            const preparedJsonUrls = dbServerUtils.prepareUrls(currentJsonUrls, url);
 
-            dbUrls.push(...currentDbUrls);
+            const responses = await Promise.all(preparedJsonUrls.map(tryResolveUrl));
+
+            dbUrls.push(...preparedDbUrls);
 
             responses.forEach(response => {
                 dbUrls.push(...response.dbUrls);

--- a/test/unit/lib/merge-reports/index.js
+++ b/test/unit/lib/merge-reports/index.js
@@ -78,6 +78,20 @@ describe('lib/merge-reports', () => {
         assert.calledOnceWith(serverUtils.writeDatabaseUrlsFile, destination, ['path-1.db', 'path-2.db', 'path-3.db', 'path-4.db']);
     });
 
+    it('should normalize urls while merging reports', async () => {
+        const pluginConfig = stubConfig();
+        const hermione = stubTool(pluginConfig, {}, {}, htmlReporter);
+        const paths = ['src-report/path-1.json'];
+        const destination = 'dest-report/path';
+
+        axiosStub.get.withArgs('src-report/path-1.json').resolves({data: {jsonUrls: ['https://foo.bar/path-2.json']}});
+        axiosStub.get.withArgs('https://foo.bar/path-2.json').resolves({data: {jsonUrls: [], dbUrls: ['sqlite.db']}});
+
+        await execMergeReports_({pluginConfig, hermione, paths, opts: {destination}});
+
+        assert.calledOnceWith(serverUtils.writeDatabaseUrlsFile, destination, ['https://foo.bar/sqlite.db']);
+    });
+
     it('should fallback to json url while merging reports', async () => {
         const pluginConfig = stubConfig();
         const hermione = stubTool(pluginConfig, {}, {}, htmlReporter);


### PR DESCRIPTION
## Что сделано
Учтен случай, когда `*.json` возвращает локальную `sqlite` базу