### PR TITLE
fix: correctly handle baseUrl when generating test result

### DIFF
--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -46,11 +46,24 @@ export const determineStatus = (statuses: TestStatus[]): TestStatus | null => {
     return null;
 };
 
-export const getAbsoluteUrl = (url: string | undefined, baseUrl: string | undefined): string => {
+export const getAbsoluteUrl = (url: string | undefined, base: string | undefined): string => {
     try {
-        return new URL(url ?? '', isEmpty(baseUrl) ? undefined : baseUrl).href;
+        const userUrl = new URL(url ?? '', base);
+
+        if (!isEmpty(base)) {
+            const baseUrl = new URL(base as string);
+
+            if (baseUrl.host) {
+                userUrl.host = baseUrl.host;
+            }
+            if (baseUrl.protocol) {
+                userUrl.protocol = baseUrl.protocol;
+            }
+        }
+
+        return userUrl.href;
     } catch {
-        return baseUrl || url || '';
+        return url || base || '';
     }
 };
 

--- a/test/unit/lib/common-utils.ts
+++ b/test/unit/lib/common-utils.ts
@@ -1,8 +1,34 @@
-import {determineStatus, buildUrl, getError, hasDiff} from 'lib/common-utils';
+import {determineStatus, buildUrl, getError, hasDiff, getAbsoluteUrl} from 'lib/common-utils';
 import {RUNNING, QUEUED, ERROR, FAIL, UPDATED, SUCCESS, IDLE, SKIPPED} from 'lib/constants/test-statuses';
 import {ErrorName} from 'lib/errors';
 
 describe('common-utils', () => {
+    describe('getAbsoluteUrl', () => {
+        it('should change host of the url', () => {
+            const userUrl = 'https://example.com/test/123?a=1#hello';
+            const baseUrl = 'https://some.site.xyz';
+
+            const result = getAbsoluteUrl(userUrl, baseUrl);
+
+            assert.equal(result, 'https://some.site.xyz/test/123?a=1#hello');
+        });
+
+        it('should work with relative urls', () => {
+            const userUrl = '/test/123?a=1#hello';
+            const baseUrl = 'https://example.com';
+
+            const result = getAbsoluteUrl(userUrl, baseUrl);
+
+            assert.equal(result, 'https://example.com/test/123?a=1#hello');
+        });
+
+        it('should work without baseUrl', () => {
+            const result = getAbsoluteUrl('some-url', '');
+
+            assert.equal(result, 'some-url');
+        });
+    });
+
     describe('getError', () => {
         it('should return test error with "message", "stack" and "stateName"', () => {
             const error = {


### PR DESCRIPTION
This PR addresses an issue when the "view in browser" button doesn't respect the baseHost setting.