### PR TITLE
fix: fix skipped/total tests counters when there are retried skipped tests

### DIFF
--- a/test/func/fixtures/playwright/tests/success-describe.spec.ts
+++ b/test/func/fixtures/playwright/tests/success-describe.spec.ts
@@ -1,13 +1,7 @@
-import {test, expect} from '@playwright/test';
+import {test} from '@playwright/test';
 
 test.describe('success describe', () => {
     test('successfully passed test', async ({page, baseURL}) => {
         await page.goto(baseURL as string);
     });
-
-    // test('test with screenshot', async ({page, baseURL}) => {
-    //     await page.goto(baseURL as string);
-    //
-    //     await expect(page.locator('header')).toHaveScreenshot('header.png');
-    // });
 });


### PR DESCRIPTION
### What's done?

Before, each retry of a skipped test was counted as a separate test in the top header in static report. This PR addresses this issue.