### PR TITLE
fix: fix import after refactoring

### DIFF
--- a/lib/static/components/modals/screenshot-accepter/body.jsx
+++ b/lib/static/components/modals/screenshot-accepter/body.jsx
@@ -3,7 +3,7 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import ResizedScreenshot from '../../state/screenshot/resized';
 import StateFail from '../../state/state-fail';
-import {isNoRefImageError} from '../../../modules/utils';
+import {isNoRefImageError} from '../../../../common-utils';
 import ViewInBrowserIcon from '../../icons/view-in-browser';
 
 class ScreenshotAccepterBody extends Component {


### PR DESCRIPTION
During refactoring, the isNoRefImageError function was moved to common-utils, but import in screenshot-accepter remained intact. This PR addresses this issue.