### PR TITLE
fix(playwright): display provided image on screenshot match

### DIFF
--- a/lib/test-adapter/playwright.ts
+++ b/lib/test-adapter/playwright.ts
@@ -88,7 +88,7 @@ const extractImageError = (result: PlaywrightTestResult, {state, expectedAttachm
     const snapshotName = state + '.png';
 
     if (expectedAttachment && diffAttachment && actualAttachment) {
-        const errors = result.errors as PwtImageDiffError[];
+        const errors = (result.errors || []) as PwtImageDiffError[];
         const imageDiffError = errors.find(err => {
             return err.meta?.type === ErrorName.IMAGE_DIFF && err.meta.snapshotName === snapshotName;
         });
@@ -97,7 +97,7 @@ const extractImageError = (result: PlaywrightTestResult, {state, expectedAttachm
     }
 
     // only supports toMatchScreenshot
-    const errors = result.errors as PwtNoRefImageError[];
+    const errors = (result.errors || []) as PwtNoRefImageError[];
     const noRefImageError = errors.find(err => {
         return err.meta?.type === ErrorName.NO_REF_IMAGE && err.meta.snapshotName === snapshotName;
     });
@@ -168,6 +168,11 @@ export class PlaywrightTestAdapter implements ReporterTestResult {
                     stack: error.stack,
                     stateName: state,
                     currImg
+                };
+            } else if (!error && refImg) {
+                return {
+                    stateName: state,
+                    refImg
                 };
             }
 

--- a/test/unit/lib/test-adapter/playwright.ts
+++ b/test/unit/lib/test-adapter/playwright.ts
@@ -141,6 +141,23 @@ describe('PlaywrightTestAdapter', () => {
             assert.deepEqual(results[0].name, 'ImageDiffError');
             assert.deepEqual(results[1].name, 'NoRefImageError');
         });
+
+        it('should return refImg, if provided', () => {
+            const testCaseStub = mkTestCase();
+            const testResultStub = {
+                status: 'success',
+                attachments: [createAttachment('state1' + ImageTitleEnding.Expected)],
+                steps: []
+            } as unknown as TestResult;
+            const adapter = new PlaywrightTestAdapter(testCaseStub, testResultStub, mkAdapterOptions());
+
+            const results = adapter.assertViewResults as ImageDiffError[];
+
+            assert.lengthOf(results, 1);
+            assert.isUndefined(results[0].name);
+            assert.strictEqual(results[0].stateName, 'state1');
+            assert.strictEqual(results[0].refImg?.path, 'state1' + ImageTitleEnding.Expected);
+        });
     });
 
     describe('attempt', () => {


### PR DESCRIPTION
## Что сделано
- Добавил возможность отображения результата успешного сравнения в отчете (если передается)

## Подробности реализации
- Прокидывается `refImg`. В отчете отображается именно он (https://github.com/gemini-testing/html-reporter/blob/master/lib/static/components/state/index.jsx#L161. В коде `expectedImg`, но он получается из `refImg`) 