### PR TITLE
fix: align the menu icon with the rest of the items

### DIFF
--- a/lib/static/styles.css
+++ b/lib/static/styles.css
@@ -105,6 +105,8 @@ main.container {
 
 .menu-bar .icon {
     margin: 0;
+    height: 25px;
+    line-height: 25px;
 }
 
 .menu-bar .ui.dropdown .menu>.item,


### PR DESCRIPTION
Before:

<img width="383" alt="image" src="https://github.com/gemini-testing/html-reporter/assets/1658415/b8e44a63-b763-4b2d-a5b9-3a7f7607a3b5">


After:
<img width="377" alt="image" src="https://github.com/gemini-testing/html-reporter/assets/1658415/42ae9cfd-d311-4e8f-a70c-701933c15f24">
