### PR TITLE
fix(pwt): ignore private report options from pwt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "html-reporter",
-      "version": "9.19.0",
+      "version": "10.0.0",
       "license": "MIT",
       "workspaces": [
         "test/func/fixtures/*",
@@ -53,7 +53,7 @@
         "@babel/preset-react": "^7.22.5",
         "@babel/preset-typescript": "^7.22.5",
         "@gemini-testing/commander": "^2.15.3",
-        "@playwright/test": "^1.37.1",
+        "@playwright/test": "^1.44.1",
         "@swc/core": "^1.3.64",
         "@types/better-sqlite3": "^7.6.4",
         "@types/bluebird": "^3.5.3",
@@ -164,7 +164,7 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "hermione": ">=6.0.0",
+        "hermione": ">=8.0.0",
         "testplane": "*"
       },
       "peerDependenciesMeta": {
@@ -3419,12 +3419,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
-      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.38.1"
+        "playwright": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -22398,12 +22398,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -22416,9 +22416,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -33813,12 +33813,12 @@
       "optional": true
     },
     "@playwright/test": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
-      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
       "dev": true,
       "requires": {
-        "playwright": "1.38.1"
+        "playwright": "1.44.1"
       }
     },
     "@puppeteer/browsers": {
@@ -48469,19 +48469,19 @@
       }
     },
     "playwright": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.44.1"
       }
     },
     "playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
       "dev": true
     },
     "playwright-fixture-report": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@gemini-testing/commander": "^2.15.3",
-    "@playwright/test": "^1.37.1",
+    "@playwright/test": "^1.44.1",
     "@swc/core": "^1.3.64",
     "@types/better-sqlite3": "^7.6.4",
     "@types/bluebird": "^3.5.3",

--- a/playwright.ts
+++ b/playwright.ts
@@ -31,7 +31,9 @@ class MyReporter implements Reporter {
     protected _initPromise: Promise<void>;
 
     constructor(opts: Partial<ReporterConfig>) {
-        this._config = parseConfig(_.omit(opts, ['configDir']));
+        const reporterOpts = _.omitBy(opts, (_value, key) => key === 'configDir' || key.startsWith('_'));
+
+        this._config = parseConfig(reporterOpts);
         this._htmlReporter = HtmlReporter.create(this._config, {toolName: ToolName.Playwright});
         this._staticReportBuilder = null;
         this._workerFarm = workerFarm(require.resolve('./lib/workers/worker'), ['saveDiffTo']);


### PR DESCRIPTION
## What is done

The static report has stopped working with the new version of the playwright (checked with version 1.44.1). the problem is that playwright has started transferring some of its private fields (`_mode`, `_isTestServer` and `_commandHash` to all connected reports) and this leads to an error:
```
UnknownKeysError: Unknown options: root._mode, root._isTestServer, root._commandHash
```

So I ignore them and everything works fine.