### PR TITLE
fix: escape regexp chars when copying a test link

### DIFF
--- a/lib/static/components/controls/test-name-filter-input.jsx
+++ b/lib/static/components/controls/test-name-filter-input.jsx
@@ -25,7 +25,7 @@ const TestNameFilterInput = ({actions, testNameFilter: testNameFilterProp}) => {
         <input
             className="filter__input-name"
             value={testNameFilter}
-            placeholder="filter by test name"
+            placeholder="Filter by test name or regexp"
             onChange={onChange}
             data-test-id="header-test-name-filter"
         />

--- a/lib/static/components/section/title/browser.jsx
+++ b/lib/static/components/section/title/browser.jsx
@@ -3,7 +3,7 @@ import ClipboardButton from 'react-clipboard.js';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import {get} from 'lodash';
+import {get, escapeRegExp} from 'lodash';
 import * as actions from '../../../modules/actions';
 import {appendQuery} from '../../../modules/query-params';
 import {ViewMode} from '../../../../constants/view-modes';
@@ -15,8 +15,8 @@ import Bullet from '../../bullet';
 const BrowserTitle = (props) => {
     const getTestUrl = () => {
         return appendQuery(window.location.href, {
-            browser: props.browserName,
-            testNameFilter: props.testName,
+            browser: escapeRegExp(props.browserName),
+            testNameFilter: escapeRegExp(props.testName),
             strictMatchFilter: true,
             retryIndex: props.retryIndex,
             viewModes: ViewMode.ALL,


### PR DESCRIPTION
If test name contains brackets or other special characters, copied link becomes invalid because our search starts treating those brackets as part of a regexp.