### PR TITLE
feat: add relativePath to refImg

### DIFF
--- a/lib/gui/tool-runner/index.ts
+++ b/lib/gui/tool-runner/index.ts
@@ -42,7 +42,7 @@ import type {
     TestplaneTestResult,
     ImageFile,
     ImageInfoDiff, ImageInfoUpdated, ImageInfoWithState,
-    ReporterConfig, TestSpecByPath
+    ReporterConfig, TestSpecByPath, RefImageFile
 } from '../../types';
 
 export type ToolRunnerTree = GuiReportBuilderResult & Pick<GuiCliOptions, 'autoRun'>;
@@ -324,8 +324,9 @@ export class ToolRunner {
             .filter(({stateName, actualImg}) => Boolean(stateName) && Boolean(actualImg))
             .forEach((imageInfo) => {
                 const {stateName, actualImg} = imageInfo as {stateName: string, actualImg: ImageFile};
-                const path = this._toolAdapter.config.browsers[browserId].getScreenshotPath(testplaneTest, stateName);
-                const refImg = {path, size: actualImg.size};
+                const absoluteRefImgPath = this._toolAdapter.config.browsers[browserId].getScreenshotPath(testplaneTest, stateName);
+                const relativeRefImgPath = absoluteRefImgPath && path.relative(process.cwd(), absoluteRefImgPath);
+                const refImg: RefImageFile = {path: absoluteRefImgPath, relativePath: relativeRefImgPath, size: actualImg.size};
 
                 assertViewResults.push({stateName, refImg, currImg: actualImg, isUpdated: isUpdatedStatus(imageInfo.status)});
             });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,6 +41,13 @@ export interface ImageFile {
     size: ImageSize;
 }
 
+export interface RefImageFile extends ImageFile {
+    /**
+     * @note defined if testplane >= 8.13.0
+     */
+    relativePath?: string;
+}
+
 export interface ImageBuffer {
     buffer: Buffer;
 }
@@ -59,7 +66,10 @@ export interface DiffOptions extends LooksSameOptions {
 export interface TestError {
     name: string;
     message: string;
-    snippet?: string; // defined if testplane >= 8.11.0
+    /**
+     * @note defined if testplane >= 8.11.0
+     */
+    snippet?: string;
     stack?: string;
     stateName?: string;
     details?: ErrorDetails
@@ -69,27 +79,37 @@ export interface TestError {
 export interface ImageInfoDiff {
     status: TestStatus.FAIL;
     stateName: string;
-    // Ref image is absent in pwt test results
-    refImg?: ImageFile;
+    /**
+     * @note Ref image is absent in pwt test results
+     */
+    refImg?: RefImageFile;
     diffClusters?: CoordBounds[];
     expectedImg: ImageFile;
     actualImg: ImageFile;
     diffImg?: ImageFile | ImageBuffer;
     diffOptions: DiffOptions;
-    differentPixels?: number; // defined if hermione >= 8.2.0
-    diffRatio?: number; // defined if hermione >= 8.2.0
+    /**
+     * @note defined if hermione >= 8.2.0
+     */
+    differentPixels?: number;
+    /**
+     * @note defined if hermione >= 8.2.0
+     */
+    diffRatio?: number;
 }
 
 interface AssertViewSuccess {
     stateName: string;
-    refImg: ImageFile;
+    refImg: RefImageFile;
 }
 
 export interface ImageInfoSuccess {
     status: TestStatus.SUCCESS;
     stateName: string;
-    // Ref image may be absent in pwt test results
-    refImg?: ImageFile;
+    /**
+     * @note Ref image is absent in pwt test results
+     */
+    refImg?: RefImageFile;
     diffClusters?: CoordBounds[];
     expectedImg: ImageFile;
     actualImg?: ImageFile;
@@ -109,15 +129,17 @@ export interface ImageInfoNoRef {
     status: TestStatus.ERROR;
     error?: TestError;
     stateName: string;
-    // Ref image may be absent in pwt test results
-    refImg?: ImageFile;
+    /**
+     * @note Ref image is absent in pwt test results
+     */
+    refImg?: RefImageFile;
     actualImg: ImageFile;
 }
 
 export interface ImageInfoUpdated {
     status: TestStatus.UPDATED;
     stateName: string;
-    refImg: ImageFile;
+    refImg: RefImageFile;
     actualImg: ImageFile;
     expectedImg: ImageFile;
 }

--- a/test/unit/lib/gui/tool-runner/index.js
+++ b/test/unit/lib/gui/tool-runner/index.js
@@ -95,6 +95,8 @@ describe('lib/gui/tool-runner/index', () => {
         }).ToolRunner;
 
         sandbox.stub(logger, 'warn');
+
+        sandbox.stub(process, 'cwd').returns('/ref/cwd');
     });
 
     afterEach(() => sandbox.restore());
@@ -240,7 +242,7 @@ describe('lib/gui/tool-runner/index', () => {
             await gui.updateReferenceImage(testRefUpdateData);
 
             assert.calledOnceWith(toolAdapter.updateReference, {
-                refImg: {path: '/ref/path1', size: {height: 100, width: 200}},
+                refImg: {path: '/ref/path1', relativePath: '../path1', size: {height: 100, width: 200}},
                 state: 'plain1'
             });
         });
@@ -289,11 +291,11 @@ describe('lib/gui/tool-runner/index', () => {
 
             assert.calledTwice(toolAdapter.updateReference);
             assert.calledWith(toolAdapter.updateReference.firstCall, {
-                refImg: {path: '/ref/path1', size: {height: 100, width: 200}},
+                refImg: {path: '/ref/path1', relativePath: '../path1', size: {height: 100, width: 200}},
                 state: 'plain1'
             });
             assert.calledWith(toolAdapter.updateReference.secondCall, {
-                refImg: {path: '/ref/path2', size: {height: 200, width: 300}},
+                refImg: {path: '/ref/path2', relativePath: '../path2', size: {height: 200, width: 300}},
                 state: 'plain2'
             });
         });


### PR DESCRIPTION
Add `relativePath` to `refImg` when creating test result after accepting new image reference, just like Testplane@8.13.0 does it.
Branch created from #551, as it changes the way test result is created