### PR TITLE
chore: move "test-adapter" to "adapters/test-result"

### DIFF
--- a/lib/adapters/test-result/hermione.ts
+++ b/lib/adapters/test-result/hermione.ts
@@ -1,0 +1,5 @@
+export {
+    TestplaneTestResultAdapter as HermioneTestResultAdapter,
+    TestplaneTestResultAdapterOptions as HermioneTestResultAdapterOptions,
+    getStatus
+} from './testplane';

--- a/lib/adapters/test-result/index.ts
+++ b/lib/adapters/test-result/index.ts
@@ -1,5 +1,5 @@
-import {TestStatus} from '../constants';
-import {ErrorDetails, ImageBase64, ImageFile, ImageInfoFull, TestError} from '../types';
+import {TestStatus} from '../../constants';
+import {ErrorDetails, ImageBase64, ImageFile, ImageInfoFull, TestError} from '../../types';
 
 export interface ReporterTestResult {
     readonly attempt: number;

--- a/lib/adapters/test-result/playwright.ts
+++ b/lib/adapters/test-result/playwright.ts
@@ -5,9 +5,9 @@ import _ from 'lodash';
 import stripAnsi from 'strip-ansi';
 
 import {ReporterTestResult} from './index';
-import {getError, getShortMD5, isImageDiffError, isNoRefImageError} from '../common-utils';
-import {ERROR, FAIL, PWT_TITLE_DELIMITER, SUCCESS, TestStatus} from '../constants';
-import {ErrorName} from '../errors';
+import {getError, getShortMD5, isImageDiffError, isNoRefImageError} from '../../common-utils';
+import {ERROR, FAIL, PWT_TITLE_DELIMITER, SUCCESS, TestStatus} from '../../constants';
+import {ErrorName} from '../../errors';
 import {
     DiffOptions,
     ErrorDetails,
@@ -16,7 +16,7 @@ import {
     ImageInfoFull, ImageInfoNoRef, ImageInfoPageError, ImageInfoPageSuccess, ImageInfoSuccess,
     ImageSize,
     TestError
-} from '../types';
+} from '../../types';
 import type {CoordBounds} from 'looks-same';
 
 export type PlaywrightAttachment = PlaywrightTestResult['attachments'][number];
@@ -127,7 +127,7 @@ const getImageData = (attachment: PlaywrightAttachment | undefined): ImageFile |
     };
 };
 
-export class PlaywrightTestAdapter implements ReporterTestResult {
+export class PlaywrightTestResultAdapter implements ReporterTestResult {
     private readonly _testCase: PlaywrightTestCase;
     private readonly _testResult: PlaywrightTestResult;
     private _attempt: number;

--- a/lib/adapters/test-result/reporter.ts
+++ b/lib/adapters/test-result/reporter.ts
@@ -1,9 +1,9 @@
-import {TestStatus} from '../constants';
-import {TestError, ErrorDetails, ImageInfoFull, ImageBase64, ImageFile} from '../types';
+import {TestStatus} from '../../constants';
+import {TestError, ErrorDetails, ImageInfoFull, ImageBase64, ImageFile} from '../../types';
 import {ReporterTestResult} from './index';
 import _ from 'lodash';
 import {extractErrorDetails} from './utils';
-import {getShortMD5, getTestHash} from '../common-utils';
+import {getShortMD5, getTestHash} from '../../common-utils';
 
 // This class is primarily useful when cloning ReporterTestResult.
 // It allows to override some properties while keeping computable

--- a/lib/adapters/test-result/sqlite.ts
+++ b/lib/adapters/test-result/sqlite.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {DB_COLUMN_INDEXES, TestStatus} from '../constants';
+import {DB_COLUMN_INDEXES, TestStatus} from '../../constants';
 import {
     AssertViewResult,
     TestError,
@@ -8,10 +8,10 @@ import {
     ImageBase64,
     ImageFile,
     RawSuitesRow
-} from '../types';
+} from '../../types';
 import {ReporterTestResult} from './index';
 import {Writable} from 'type-fest';
-import {getTestHash} from '../common-utils';
+import {getTestHash} from '../../common-utils';
 
 const tryParseJson = (json: string): unknown | undefined => {
     try {
@@ -21,16 +21,16 @@ const tryParseJson = (json: string): unknown | undefined => {
     }
 };
 
-interface SqliteTestAdapterOptions {
+interface SqliteTestResultAdapterOptions {
     titleDelimiter: string;
 }
 
-export class SqliteTestAdapter implements ReporterTestResult {
+export class SqliteTestResultAdapter implements ReporterTestResult {
     private _testResult: RawSuitesRow;
     private _parsedTestResult: Writable<Partial<ReporterTestResult>>;
     private _titleDelimiter: string;
 
-    constructor(testResult: RawSuitesRow, attempt: number, options: SqliteTestAdapterOptions) {
+    constructor(testResult: RawSuitesRow, attempt: number, options: SqliteTestResultAdapterOptions) {
         this._testResult = testResult;
         this._parsedTestResult = {attempt};
         this._titleDelimiter = options.titleDelimiter;

--- a/lib/adapters/test-result/testplane.ts
+++ b/lib/adapters/test-result/testplane.ts
@@ -4,9 +4,9 @@ import type Testplane from 'testplane';
 import type {Test as TestplaneTest} from 'testplane';
 import {ValueOf} from 'type-fest';
 
-import {getCommandsHistory} from '../history-utils';
-import {ERROR, FAIL, SUCCESS, TestStatus, UNKNOWN_SESSION_ID, UPDATED} from '../constants';
-import {getError, hasFailedImages, isImageDiffError, isNoRefImageError, wrapLinkByTag} from '../common-utils';
+import {getCommandsHistory} from '../../history-utils';
+import {ERROR, FAIL, SUCCESS, TestStatus, UNKNOWN_SESSION_ID, UPDATED} from '../../constants';
+import {getError, hasFailedImages, isImageDiffError, isNoRefImageError, wrapLinkByTag} from '../../common-utils';
 import {
     ErrorDetails,
     TestplaneSuite,
@@ -21,9 +21,9 @@ import {
     ImageInfoSuccess,
     ImageInfoUpdated,
     TestError
-} from '../types';
+} from '../../types';
 import {ReporterTestResult} from './index';
-import {getSuitePath} from '../plugin-utils';
+import {getSuitePath} from '../../plugin-utils';
 import {extractErrorDetails} from './utils';
 
 export const getStatus = (eventName: ValueOf<Testplane['events']>, events: Testplane['events'], testResult: TestplaneTestResult): TestStatus => {
@@ -47,23 +47,23 @@ const wrapSkipComment = (skipComment: string | null | undefined): string => {
     return skipComment ? wrapLinkByTag(skipComment) : 'Unknown reason';
 };
 
-export interface TestplaneTestAdapterOptions {
+export interface TestplaneTestResultAdapterOptions {
     attempt: number;
     status: TestStatus;
 }
 
-export class TestplaneTestAdapter implements ReporterTestResult {
+export class TestplaneTestResultAdapter implements ReporterTestResult {
     private _testResult: TestplaneTest | TestplaneTestResult;
     private _errorDetails: ErrorDetails | null;
     private _timestamp: number | undefined;
     private _attempt: number;
     private _status: TestStatus;
 
-    static create<T extends TestplaneTestAdapter>(this: new (testResult: TestplaneTestResult, options: TestplaneTestAdapterOptions) => T, testResult: TestplaneTestResult, options: TestplaneTestAdapterOptions): T {
+    static create<T extends TestplaneTestResultAdapter>(this: new (testResult: TestplaneTestResult, options: TestplaneTestResultAdapterOptions) => T, testResult: TestplaneTestResult, options: TestplaneTestResultAdapterOptions): T {
         return new this(testResult, options);
     }
 
-    constructor(testResult: TestplaneTest | TestplaneTestResult, {attempt, status}: TestplaneTestAdapterOptions) {
+    constructor(testResult: TestplaneTest | TestplaneTestResult, {attempt, status}: TestplaneTestResultAdapterOptions) {
         this._testResult = testResult;
         this._errorDetails = null;
         this._timestamp = (this._testResult as TestplaneTestResult).timestamp ??

--- a/lib/adapters/test-result/transformers/db.ts
+++ b/lib/adapters/test-result/transformers/db.ts
@@ -1,6 +1,6 @@
 import {ReporterTestResult} from '../index';
-import {DbTestResult} from '../../sqlite-client';
-import {getError, getRelativeUrl, getUrlWithBase} from '../../common-utils';
+import {DbTestResult} from '../../../sqlite-client';
+import {getError, getRelativeUrl, getUrlWithBase} from '../../../common-utils';
 import _ from 'lodash';
 
 interface Options {

--- a/lib/adapters/test-result/transformers/tree.ts
+++ b/lib/adapters/test-result/transformers/tree.ts
@@ -1,6 +1,6 @@
 import {ReporterTestResult} from '../index';
 import _ from 'lodash';
-import {BaseTreeTestResult} from '../../tests-tree-builder/base';
+import {BaseTreeTestResult} from '../../../tests-tree-builder/base';
 import {DbTestResultTransformer} from './db';
 import {extractErrorDetails} from '../utils';
 

--- a/lib/adapters/test-result/utils/index.ts
+++ b/lib/adapters/test-result/utils/index.ts
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import {ReporterTestResult} from '../index';
 import {TupleToUnion} from 'type-fest';
-import {ErrorDetails, ImageInfoDiff, ImageInfoFull} from '../../types';
-import {ERROR_DETAILS_PATH} from '../../constants';
+import {ErrorDetails, ImageInfoDiff, ImageInfoFull} from '../../../types';
+import {ERROR_DETAILS_PATH} from '../../../constants';
 import {ReporterTestAdapter} from '../reporter';
-import {getDetailsFileName, isImageBufferData} from '../../common-utils';
+import {getDetailsFileName, isImageBufferData} from '../../../common-utils';
 
 export const copyAndUpdate = (
     original: ReporterTestResult,

--- a/lib/adapters/tool/testplane/test-results-handler.ts
+++ b/lib/adapters/tool/testplane/test-results-handler.ts
@@ -10,7 +10,7 @@ import {TestStatus} from '../../../constants';
 import {GuiReportBuilder} from '../../../report-builder/gui';
 import {EventSource} from '../../../gui/event-source';
 import {TestplaneTestResult} from '../../../types';
-import {getStatus} from '../../../test-adapter/testplane';
+import {getStatus} from '../../test-result/testplane';
 
 export const handleTestResults = (testplane: Testplane, reportBuilder: GuiReportBuilder, client: EventSource): void => {
     const queue = new PQueue({concurrency: os.cpus().length});

--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -27,7 +27,7 @@ import {
     TestError
 } from './types';
 import {ErrorName, ImageDiffError, NoRefImageError} from './errors';
-import {ReporterTestResult} from './test-adapter';
+import type {ReporterTestResult} from './adapters/test-result';
 
 export const getShortMD5 = (str: string): string => {
     return crypto.createHash('md5').update(str, 'ascii').digest('hex').substr(0, 7);

--- a/lib/db-utils/server.ts
+++ b/lib/db-utils/server.ts
@@ -13,7 +13,7 @@ import {DATABASE_URLS_JSON_NAME, DB_COLUMNS, LOCAL_DATABASE_NAME, TestStatus, To
 import {DbLoadResult, HandleDatabasesOptions} from './common';
 import {DbUrlsJsonData, RawSuitesRow, ReporterConfig} from '../types';
 import {Tree} from '../tests-tree-builder/base';
-import {ReporterTestResult} from '../test-adapter';
+import {ReporterTestResult} from '../adapters/test-result';
 import {SqliteClient} from '../sqlite-client';
 
 export * from './common';

--- a/lib/gui/tool-runner/index.ts
+++ b/lib/gui/tool-runner/index.ts
@@ -34,7 +34,7 @@ import {
 
 import type {GuiCliOptions, ServerArgs} from '../index';
 import type {TestBranch, TestEqualDiffsData, TestRefUpdateData} from '../../tests-tree-builder/gui';
-import type {ReporterTestResult} from '../../test-adapter';
+import type {ReporterTestResult} from '../../adapters/test-result';
 import type {Tree, TreeImage} from '../../tests-tree-builder/base';
 import type {TestSpec} from '../../adapters/tool/types';
 import type {

--- a/lib/images-info-saver.ts
+++ b/lib/images-info-saver.ts
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import PQueue from 'p-queue';
 
 import {RegisterWorkers} from './workers/create-workers';
-import {ReporterTestResult} from './test-adapter';
+import {ReporterTestResult} from './adapters/test-result';
 import {
     DiffOptions, ImageBase64, ImageBuffer,
     ImageFile,
@@ -16,7 +16,7 @@ import {
     ImageInfoFull,
     ImageSize, TestSpecByPath
 } from './types';
-import {copyAndUpdate, removeBufferFromImagesInfo} from './test-adapter/utils';
+import {copyAndUpdate, removeBufferFromImagesInfo} from './adapters/test-result/utils';
 import {cacheDiffImages} from './image-cache';
 import {NEW_ISSUE_LINK, PluginEvents, TestStatus, UPDATED} from './constants';
 import {createHash, getCurrentPath, getDiffPath, getReferencePath, getTempPath, makeDirFor} from './server-utils';

--- a/lib/report-builder/gui.ts
+++ b/lib/report-builder/gui.ts
@@ -3,13 +3,13 @@ import {StaticReportBuilder, StaticReportBuilderOptions} from './static';
 import {GuiTestsTreeBuilder, TestBranch, TestEqualDiffsData, TestRefUpdateData} from '../tests-tree-builder/gui';
 import {UPDATED, DB_COLUMNS, ToolName, TestStatus, TESTPLANE_TITLE_DELIMITER, SKIPPED, SUCCESS} from '../constants';
 import {ConfigForStaticFile, getConfigForStaticFile} from '../server-utils';
-import {ReporterTestResult} from '../test-adapter';
+import {ReporterTestResult} from '../adapters/test-result';
 import {Tree, TreeImage} from '../tests-tree-builder/base';
 import {ImageInfoFull, ImageInfoWithState, ReporterConfig} from '../types';
 import {determineStatus, isUpdatedStatus} from '../common-utils';
 import {HtmlReporter, HtmlReporterValues} from '../plugin-api';
 import {SkipItem} from '../tests-tree-builder/static';
-import {copyAndUpdate} from '../test-adapter/utils';
+import {copyAndUpdate} from '../adapters/test-result/utils';
 
 interface UndoAcceptImageResult {
     updatedImage: TreeImage | undefined;

--- a/lib/report-builder/static.ts
+++ b/lib/report-builder/static.ts
@@ -11,13 +11,13 @@ import {
     PluginEvents, UNKNOWN_ATTEMPT, UPDATED
 } from '../constants';
 import type {SqliteClient} from '../sqlite-client';
-import {ReporterTestResult} from '../test-adapter';
+import {ReporterTestResult} from '../adapters/test-result';
 import {saveErrorDetails, saveStaticFilesToReportDir, writeDatabaseUrlsFile} from '../server-utils';
 import {ReporterConfig} from '../types';
 import {HtmlReporter} from '../plugin-api';
 import {getTestFromDb} from '../db-utils/server';
 import {TestAttemptManager} from '../test-attempt-manager';
-import {copyAndUpdate} from '../test-adapter/utils';
+import {copyAndUpdate} from '../adapters/test-result/utils';
 import {RegisterWorkers} from '../workers/create-workers';
 import {ImagesInfoSaver} from '../images-info-saver';
 

--- a/lib/reporter-helpers.ts
+++ b/lib/reporter-helpers.ts
@@ -3,9 +3,9 @@ import tmp from 'tmp';
 import _ from 'lodash';
 import {getShortMD5, isImageInfoWithState} from './common-utils';
 import * as utils from './server-utils';
-import {ReporterTestResult} from './test-adapter';
+import {ReporterTestResult} from './adapters/test-result';
 import {getImagesInfoByStateName} from './server-utils';
-import {copyAndUpdate} from './test-adapter/utils';
+import {copyAndUpdate} from './adapters/test-result/utils';
 import {ImageInfoFull, ImageInfoUpdated} from './types';
 import {UPDATED} from './constants';
 

--- a/lib/server-utils.ts
+++ b/lib/server-utils.ts
@@ -12,14 +12,14 @@ import tmp from 'tmp';
 import {getShortMD5, logger, mkTestId} from './common-utils';
 import {UPDATED, RUNNING, IDLE, SKIPPED, IMAGES_PATH, TestStatus, UNKNOWN_ATTEMPT} from './constants';
 import type {HtmlReporter} from './plugin-api';
-import type {ReporterTestResult} from './test-adapter';
+import type {ReporterTestResult} from './adapters/test-result';
 import {
     TestplaneTestResult,
     ImageInfoWithState,
     ReporterConfig,
     TestSpecByPath
 } from './types';
-import {TestplaneTestAdapter} from './test-adapter/testplane';
+import {TestplaneTestResultAdapter} from './adapters/test-result/testplane';
 
 const DATA_FILE_NAME = 'data.js';
 
@@ -295,7 +295,7 @@ export const formatTestResult = (
     status: TestStatus,
     attempt: number = UNKNOWN_ATTEMPT
 ): ReporterTestResult => {
-    return new TestplaneTestAdapter(rawResult, {attempt, status});
+    return new TestplaneTestResultAdapter(rawResult, {attempt, status});
 };
 
 export const saveErrorDetails = async (testResult: ReporterTestResult, reportPath: string): Promise<void> => {

--- a/lib/sqlite-client.ts
+++ b/lib/sqlite-client.ts
@@ -9,8 +9,8 @@ import {TestStatus, DB_SUITES_TABLE_NAME, SUITES_TABLE_COLUMNS, LOCAL_DATABASE_N
 import {createTablesQuery} from './db-utils/common';
 import type {ImageInfoFull, TestError} from './types';
 import {HtmlReporter} from './plugin-api';
-import {ReporterTestResult} from './test-adapter';
-import {DbTestResultTransformer} from './test-adapter/transformers/db';
+import {ReporterTestResult} from './adapters/test-result';
+import {DbTestResultTransformer} from './adapters/test-result/transformers/db';
 
 const debug = makeDebug('html-reporter:sqlite-client');
 

--- a/lib/test-adapter/hermione.ts
+++ b/lib/test-adapter/hermione.ts
@@ -1,5 +1,0 @@
-export {
-    TestplaneTestAdapter as HermioneTestAdapter,
-    TestplaneTestAdapterOptions as HermioneTestAdapterOptions,
-    getStatus
-} from './testplane';

--- a/lib/test-attempt-manager.ts
+++ b/lib/test-attempt-manager.ts
@@ -1,4 +1,4 @@
-import {ReporterTestResult} from './test-adapter';
+import {ReporterTestResult} from './adapters/test-result';
 import {IDLE, RUNNING, TestStatus} from './constants';
 
 type TestSpec = Pick<ReporterTestResult, 'fullName' | 'browserId'>

--- a/lib/tests-tree-builder/base.ts
+++ b/lib/tests-tree-builder/base.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import {determineFinalStatus} from '../common-utils';
 import {BrowserVersions, PWT_TITLE_DELIMITER, TESTPLANE_TITLE_DELIMITER, TestStatus, ToolName} from '../constants';
-import {ReporterTestResult} from '../test-adapter';
+import {ReporterTestResult} from '../adapters/test-result';
 import {ErrorDetails, ImageInfoFull} from '../types';
-import {TreeTestResultTransformer} from '../test-adapter/transformers/tree';
+import {TreeTestResultTransformer} from '../adapters/test-result/transformers/tree';
 import {DbTestResult} from '../sqlite-client';
 
 export type BaseTreeTestResult = Omit<DbTestResult, 'imagesInfo'> & {

--- a/lib/tests-tree-builder/static.ts
+++ b/lib/tests-tree-builder/static.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import {BaseTestsTreeBuilder, BaseTestsTreeBuilderOptions, Tree} from './base';
 import {BrowserVersions, DB_COLUMN_INDEXES, TestStatus} from '../constants';
-import {ReporterTestResult} from '../test-adapter';
-import {SqliteTestAdapter} from '../test-adapter/sqlite';
+import {ReporterTestResult} from '../adapters/test-result';
+import {SqliteTestResultAdapter} from '../adapters/test-result/sqlite';
 import {getTitleDelimiter} from '../common-utils';
 import {RawSuitesRow} from '../types';
 
@@ -70,7 +70,7 @@ export class StaticTestsTreeBuilder extends BaseTestsTreeBuilder {
             attemptsMap.set(browserId, attemptsMap.has(browserId) ? attemptsMap.get(browserId) as number + 1 : 0);
             const attempt = attemptsMap.get(browserId) as number;
 
-            const formattedResult = new SqliteTestAdapter(row, attempt, {titleDelimiter: getTitleDelimiter(this._toolName)});
+            const formattedResult = new SqliteTestResultAdapter(row, attempt, {titleDelimiter: getTitleDelimiter(this._toolName)});
 
             addBrowserVersion(browsers, formattedResult);
 

--- a/playwright.ts
+++ b/playwright.ts
@@ -12,7 +12,7 @@ import {ReporterConfig, TestSpecByPath} from './lib/types';
 import {parseConfig} from './lib/config';
 import {PluginEvents, ToolName, UNKNOWN_ATTEMPT} from './lib/constants';
 import {RegisterWorkers} from './lib/workers/create-workers';
-import {PlaywrightTestAdapter} from './lib/test-adapter/playwright';
+import {PlaywrightTestResultAdapter} from './lib/adapters/test-result/playwright';
 import {SqliteClient} from './lib/sqlite-client';
 import {SqliteImageStore} from './lib/image-store';
 import {ImagesInfoSaver} from './lib/images-info-saver';
@@ -70,7 +70,7 @@ class MyReporter implements Reporter {
 
             const staticReportBuilder = this._staticReportBuilder as StaticReportBuilder;
 
-            const formattedResult = new PlaywrightTestAdapter(test, result, UNKNOWN_ATTEMPT);
+            const formattedResult = new PlaywrightTestResultAdapter(test, result, UNKNOWN_ATTEMPT);
 
             await staticReportBuilder.addTestResult(formattedResult);
         });

--- a/test/unit/lib/adapters/test-result/playwright.ts
+++ b/test/unit/lib/adapters/test-result/playwright.ts
@@ -7,14 +7,14 @@ import {
     ImageTitleEnding,
     PlaywrightAttachment,
     PwtTestStatus
-} from 'lib/test-adapter/playwright';
+} from 'lib/adapters/test-result/playwright';
 import {ErrorName} from 'lib/errors';
 import {ERROR, FAIL, TestStatus, UNKNOWN_ATTEMPT} from 'lib/constants';
 import {ImageInfoDiff, ImageInfoNoRef} from 'lib/types';
 
-describe('PlaywrightTestAdapter', () => {
+describe('PlaywrightTestResultAdapter', () => {
     let sandbox: sinon.SinonSandbox;
-    let PlaywrightTestAdapter: typeof import('lib/test-adapter/playwright').PlaywrightTestAdapter;
+    let PlaywrightTestResultAdapter: typeof import('lib/adapters/test-result/playwright').PlaywrightTestResultAdapter;
     let imageSizeStub: sinon.SinonStub;
 
     const createAttachment = (path: string): PlaywrightAttachment => ({
@@ -46,9 +46,9 @@ describe('PlaywrightTestAdapter', () => {
 
         imageSizeStub = sinon.stub().returns({height: 100, width: 200});
 
-        PlaywrightTestAdapter = proxyquire('lib/test-adapter/playwright', {
+        PlaywrightTestResultAdapter = proxyquire('lib/adapters/test-result/playwright', {
             'image-size': imageSizeStub
-        }).PlaywrightTestAdapter;
+        }).PlaywrightTestResultAdapter;
     });
 
     afterEach(() => {
@@ -57,7 +57,7 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('attempt', () => {
         it('should return suite attempt', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase({titlePath: sinon.stub().returns(['another-title'])}), mkTestResult(), 3);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase({titlePath: sinon.stub().returns(['another-title'])}), mkTestResult(), 3);
 
             assert.equal(adapter.attempt, 3);
         });
@@ -65,7 +65,7 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('browserId', () => {
         it('should return browserId', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.browserId, 'some-browser');
         });
@@ -73,7 +73,7 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('error', () => {
         it('should return undefined if there are no errors', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({errors: []}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors: []}), UNKNOWN_ATTEMPT);
 
             const {error} = adapter;
 
@@ -83,7 +83,7 @@ describe('PlaywrightTestAdapter', () => {
         it('should return an error with name NO_REF_IMAGE for snapshot missing errors', () => {
             const errorMessage = 'A snapshot doesn\'t exist: image-name.png.';
             const errors = [{message: errorMessage}];
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
 
             const {error} = adapter;
 
@@ -94,7 +94,7 @@ describe('PlaywrightTestAdapter', () => {
         it('should return an error with name IMAGE_DIFF for screenshot comparison failures', () => {
             const errorMessage = 'Screenshot comparison failed';
             const errors = [{message: errorMessage}];
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
 
             const {error} = adapter;
 
@@ -106,7 +106,7 @@ describe('PlaywrightTestAdapter', () => {
             const errorMessage = 'Some error occurred';
             const errorStack = 'Error: Some error occurred at some-file.ts:10:15';
             const errors = [{message: errorMessage, stack: errorStack}];
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
 
             const {error} = adapter;
 
@@ -118,7 +118,7 @@ describe('PlaywrightTestAdapter', () => {
                 {message: 'First error', stack: 'Error: First error at some-file.ts:5:10'},
                 {message: 'Second error', stack: 'Error: Second error at another-file.ts:15:20'}
             ];
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
             const expectedMessage = JSON.stringify(errors.map(err => err.message));
             const expectedStack = JSON.stringify(errors.map(err => err.stack));
 
@@ -131,7 +131,7 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('file', () => {
         it('should return file path', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
 
             assert.strictEqual(adapter.file, 'test-file-path');
         });
@@ -139,7 +139,7 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('fullName', () => {
         it('should return fullName', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
 
             assert.strictEqual(adapter.fullName, 'describe › test');
         });
@@ -151,7 +151,7 @@ describe('PlaywrightTestAdapter', () => {
                 {title: 'Step1', duration: 100},
                 {title: 'Step2', duration: 200}
             ];
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({steps} as any), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({steps} as any), UNKNOWN_ATTEMPT);
             const expectedHistory = ['Step1 <- 100ms\n', 'Step2 <- 200ms\n'];
 
             assert.deepEqual(adapter.history, expectedHistory);
@@ -160,7 +160,7 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('id', () => {
         it('should return id', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult(), 0);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult(), 0);
 
             assert.strictEqual(adapter.id, 'describe test some-browser 0');
         });
@@ -168,7 +168,7 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('imageDir', () => {
         it('should return imageDir', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
 
             assert.strictEqual(adapter.imageDir, '4050de5');
         });
@@ -184,7 +184,7 @@ describe('PlaywrightTestAdapter', () => {
                 {name: 'screenshot', path: 'test-results/test-name-1.png', contentType: 'image/png'}
             ];
 
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({attachments, errors}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({attachments, errors}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.imagesInfo.length, 2);
             assert.deepEqual(adapter.imagesInfo.find(info => (info as ImageInfoDiff).stateName === undefined), {
@@ -209,7 +209,7 @@ describe('PlaywrightTestAdapter', () => {
                 {name: 'screenshot', path: 'test-results/test-name-1.png', contentType: 'image/png'}
             ];
 
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({attachments, errors}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({attachments, errors}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.imagesInfo.length, 2);
             assert.deepEqual(adapter.imagesInfo.find(info => (info as ImageInfoNoRef).stateName === undefined), {
@@ -231,31 +231,31 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('status', () => {
         it('should return SUCCESS for PASSED PwtTestStatus', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.PASSED}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.PASSED}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.status, TestStatus.SUCCESS);
         });
 
         it('should return FAIL for FAILED PwtTestStatus', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.FAILED}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.FAILED}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.status, TestStatus.FAIL);
         });
 
         it('should return FAIL for TIMED_OUT PwtTestStatus', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.TIMED_OUT}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.TIMED_OUT}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.status, TestStatus.FAIL);
         });
 
         it('should return FAIL for INTERRUPTED PwtTestStatus', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.INTERRUPTED}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.INTERRUPTED}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.status, TestStatus.FAIL);
         });
 
         it('should return SKIPPED for any other PwtTestStatus', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.SKIPPED}), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({status: PwtTestStatus.SKIPPED}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.status, TestStatus.SKIPPED);
         });
@@ -263,7 +263,7 @@ describe('PlaywrightTestAdapter', () => {
 
     describe('testPath', () => {
         it('should return testPath', () => {
-            const adapter = new PlaywrightTestAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
 
             assert.deepEqual(adapter.testPath, ['describe', 'test']);
         });

--- a/test/unit/lib/adapters/tool/testplane/test-results-handler.js
+++ b/test/unit/lib/adapters/tool/testplane/test-results-handler.js
@@ -7,7 +7,7 @@ const {handleTestResults} = require('lib/adapters/tool/testplane/test-results-ha
 const {GuiReportBuilder} = require('lib/report-builder/gui');
 const {ClientEvents} = require('lib/gui/constants');
 const {stubTool, stubConfig} = require('test/unit/utils');
-const {TestplaneTestAdapter} = require('lib/test-adapter/testplane');
+const {TestplaneTestResultAdapter} = require('lib/adapters/test-result/testplane');
 const {UNKNOWN_ATTEMPT} = require('lib/constants');
 
 describe('lib/adapters/tool/testplane/test-results-handler', () => {
@@ -37,7 +37,7 @@ describe('lib/adapters/tool/testplane/test-results-handler', () => {
         reportBuilder.addTestResult.callsFake(_.identity);
 
         sandbox.stub(GuiReportBuilder, 'create').returns(reportBuilder);
-        sandbox.stub(TestplaneTestAdapter.prototype, 'id').value('some-id');
+        sandbox.stub(TestplaneTestResultAdapter.prototype, 'id').value('some-id');
 
         client = new EventEmitter();
         sandbox.spy(client, 'emit');

--- a/test/unit/lib/gui/tool-runner/index.js
+++ b/test/unit/lib/gui/tool-runner/index.js
@@ -80,7 +80,7 @@ describe('lib/gui/tool-runner/index', () => {
                 fileExists: sandbox.stub(),
                 deleteFile: sandbox.stub()
             },
-            './test-adapter/utils': {
+            './adapters/test-result/utils': {
                 copyAndUpdate: sandbox.stub().callsFake(_.assign)
             }
         });

--- a/test/unit/lib/images-info-saver.ts
+++ b/test/unit/lib/images-info-saver.ts
@@ -1,7 +1,7 @@
 import * as fsOriginal from 'fs-extra';
 import {ImagesInfoSaver as ImagesInfoSaverOriginal} from 'lib/images-info-saver';
 import {Writable} from 'type-fest';
-import {ReporterTestResult} from 'lib/test-adapter';
+import {ReporterTestResult} from 'lib/adapters/test-result';
 import {
     ImageBase64,
     ImageBuffer,

--- a/test/unit/lib/report-builder/gui.js
+++ b/test/unit/lib/report-builder/gui.js
@@ -4,7 +4,7 @@ const fs = require('fs-extra');
 const _ = require('lodash');
 const proxyquire = require('proxyquire');
 const serverUtils = require('lib/server-utils');
-const {TestplaneTestAdapter} = require('lib/test-adapter/testplane');
+const {TestplaneTestResultAdapter} = require('lib/adapters/test-result/testplane');
 const {SqliteClient} = require('lib/sqlite-client');
 const {GuiTestsTreeBuilder} = require('lib/tests-tree-builder/gui');
 const {HtmlReporter} = require('lib/plugin-api');
@@ -33,7 +33,7 @@ describe('GuiReportBuilder', () => {
             htmlReporter
         };
 
-        TestplaneTestAdapter.create = (obj) => obj;
+        TestplaneTestResultAdapter.create = (obj) => obj;
 
         dbClient = await SqliteClient.create({htmlReporter, reportPath: TEST_REPORT_PATH});
         imagesInfoSaver = sinon.createStubInstance(ImagesInfoSaver);
@@ -100,7 +100,7 @@ describe('GuiReportBuilder', () => {
                 }).StaticReportBuilder
             },
             '../server-utils': {hasImage, deleteFile},
-            '../test-adapter/utils': {copyAndUpdate}
+            '../adapters/test-result/utils': {copyAndUpdate}
         }).GuiReportBuilder;
 
         sandbox.stub(GuiTestsTreeBuilder, 'create').returns(Object.create(GuiTestsTreeBuilder.prototype));

--- a/test/unit/testplane.js
+++ b/test/unit/testplane.js
@@ -19,7 +19,7 @@ describe('lib/testplane', () => {
     const sandbox = sinon.createSandbox();
     let testplane;
     let cacheExpectedPaths = new Map(), cacheAllImages = new Map(), cacheDiffImages = new Map();
-    let fs, originalUtils, utils, SqliteClient, ImagesInfoSaver, TestAdapter, StaticReportBuilder, HtmlReporter, runHtmlReporter;
+    let fs, originalUtils, utils, SqliteClient, ImagesInfoSaver, TestResultAdapter, StaticReportBuilder, HtmlReporter, runHtmlReporter;
 
     let program;
 
@@ -115,15 +115,15 @@ describe('lib/testplane', () => {
             './server-utils': utils
         }).ImagesInfoSaver;
 
-        TestAdapter = proxyquire('lib/test-adapter', {
+        TestResultAdapter = proxyquire('lib/adapters/test-result', {
             'fs-extra': fs,
             './server-utils': utils
-        }).TestAdapter;
+        }).TestResultAdapter;
 
         StaticReportBuilder = proxyquire('lib/report-builder/static', {
             'fs-extra': fs,
             '../server-utils': utils,
-            '../test-adapter': {TestAdapter},
+            '../adapters/test-result': {TestResultAdapter},
             '../images-info-saver': {ImagesInfoSaver}
         }).StaticReportBuilder;
 

--- a/testplane.ts
+++ b/testplane.ts
@@ -18,7 +18,7 @@ import {createWorkers, CreateWorkersRunner} from './lib/workers/create-workers';
 import {SqliteImageStore} from './lib/image-store';
 import {Cache} from './lib/cache';
 import {ImagesInfoSaver} from './lib/images-info-saver';
-import {getStatus} from './lib/test-adapter/testplane';
+import {getStatus} from './lib/adapters/test-result/testplane';
 
 export default (testplane: Testplane, opts: Partial<ReporterOptions>): void => {
     if (testplane.isWorker()) {


### PR DESCRIPTION
## What is done

- moved the "lib/test-adapter" folder to "lib/adapters/test-result"
- change class names "TestplaneTestAdapter" -> "TestplaneTestResultAdapter" and "TestplaneTestAdapter" -> "PlaywrightTestResultAdapter".

This is done because the implementation of the test adapter will appear in the next PR and there would be a name conflict.