### PR TITLE
feat: add copy to clipboard button to all fields in meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="10.3.0"></a>
+# [10.3.0](https://github.com/gemini-testing/html-reporter/compare/v10.0.0...v10.3.0) (2024-06-21)
+
+
+### Bug Fixes
+
+* escape regexp chars when copying a test link ([#552](https://github.com/gemini-testing/html-reporter/issues/552)) ([e7b2103](https://github.com/gemini-testing/html-reporter/commit/e7b2103))
+* save RunMode to localStorage ([#554](https://github.com/gemini-testing/html-reporter/issues/554)) ([e523e21](https://github.com/gemini-testing/html-reporter/commit/e523e21))
+* **pwt:** ignore private report options from pwt ([88e9e5d](https://github.com/gemini-testing/html-reporter/commit/88e9e5d))
+
+
+### Features
+
+* add ability to run cli commands using html-reporter binary ([db0862c](https://github.com/gemini-testing/html-reporter/commit/db0862c))
+* add copy to clipboard button to all fields in meta ([fb651d0](https://github.com/gemini-testing/html-reporter/commit/fb651d0))
+* add relativePath to refImg ([b722899](https://github.com/gemini-testing/html-reporter/commit/b722899))
+
+
+
 <a name="10.2.0"></a>
 # [10.2.0](https://github.com/gemini-testing/html-reporter/compare/v10.0.0...v10.2.0) (2024-06-20)
 

--- a/lib/static/components/section/body/meta-info/content.jsx
+++ b/lib/static/components/section/body/meta-info/content.jsx
@@ -6,18 +6,18 @@ import PropTypes from 'prop-types';
 import {map, mapValues, isObject, omitBy, isEmpty} from 'lodash';
 import {isUrl, getUrlWithBase} from '../../../../../common-utils';
 
-const mkLinkToUrl = (url, text = url) => {
+const mkTextWithClipboardButton = (text, url)  => {
     return <Fragment>
-        <a data-suite-view-link={url} className="custom-icon_view-local" target="_blank" href={url}>
-            {text}
-        </a>
+        {url ? <a data-suite-view-link={url} className="custom-icon_view-local" target="_blank" href={url}>
+            {text || url}
+        </a> : text}
         <ClipboardButton
             className="button custom-icon custom-icon_copy-to-clipboard"
             button-title="copy to clipboard"
-            data-clipboard-text={url}>
+            data-clipboard-text={url || text}>
         </ClipboardButton>
     </Fragment>;
-};
+}
 
 const serializeMetaValues = (metaInfo) => mapValues(metaInfo, (v) => isObject(v) ? JSON.stringify(v) : v);
 
@@ -40,13 +40,16 @@ const resolveUrl = (baseUrl, value) => {
 const metaToElements = (metaInfo, metaInfoBaseUrls) => {
     return map(metaInfo, (value, key) => {
         if (isUrl(value)) {
-            value = mkLinkToUrl(value);
+            value = mkTextWithClipboardButton(value, value);
         } else if (metaInfoBaseUrls[key]) {
             const baseUrl = metaInfoBaseUrls[key];
             const link = isUrl(baseUrl) ? resolveUrl(baseUrl, value) : path.join(baseUrl, value);
-            value = mkLinkToUrl(link, value);
+            value = mkTextWithClipboardButton(value, link);
         } else if (typeof value === 'boolean') {
             value = value.toString();
+        }
+        else if (typeof value === 'string') {
+            value = mkTextWithClipboardButton(value);
         }
 
         return <div key={key} className="meta-info__item">
@@ -93,7 +96,7 @@ class MetaInfoContent extends Component {
             ...extraMetaInfo
         };
         if (result.suiteUrl) {
-            formattedMetaInfo.url = mkLinkToUrl(getUrlWithBase(result.suiteUrl, baseHost), result.metaInfo.url);
+            formattedMetaInfo.url = mkTextWithClipboardButton(result.metaInfo.url, getUrlWithBase(result.suiteUrl, baseHost));
         }
 
         return metaToElements(formattedMetaInfo, metaInfoBaseUrls);

--- a/lib/static/styles.css
+++ b/lib/static/styles.css
@@ -555,6 +555,14 @@ details[open] > .details__summary:before {
     text-overflow: ellipsis;
 }
 
+.meta-info__item .custom-icon_copy-to-clipboard {
+    opacity: 0;
+}
+
+.meta-info__item:hover .custom-icon_copy-to-clipboard {
+    opacity: 1;
+}
+
 .error {
     background: #f0f2f5;
     padding: 10px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "html-reporter",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-reporter",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Html-reporter and GUI for viewing and managing results of a tests run. Currently supports Testplane and Hermione.",
   "files": [
     "build"


### PR DESCRIPTION
Added "copy to clipboard" button to all fields in meta. The button is hidden by default an is revealed on hover.