### PR TITLE
chore: implement adapters: test, testCollection, config

### DIFF
--- a/lib/adapters/config/index.ts
+++ b/lib/adapters/config/index.ts
@@ -1,0 +1,15 @@
+import {TestAdapter} from '../test';
+
+export interface BrowserConfigAdapter {
+    readonly id: string;
+    retry: number;
+}
+
+export interface ConfigAdapter {
+    readonly tolerance: number;
+    readonly antialiasingTolerance: number;
+    readonly browserIds: string[];
+
+    getBrowserConfig(browserId: string): BrowserConfigAdapter;
+    getScreenshotPath(test: TestAdapter, stateName: string): string;
+}

--- a/lib/adapters/config/testplane.ts
+++ b/lib/adapters/config/testplane.ts
@@ -1,0 +1,37 @@
+import type {Config} from 'testplane';
+import type {ConfigAdapter} from './';
+import {TestplaneTestAdapter} from '../test/testplane';
+
+export class TestplaneConfigAdapter implements ConfigAdapter {
+    private _config: Config;
+
+    static create<T extends TestplaneConfigAdapter>(this: new (config: Config) => T, config: Config): T {
+        return new this(config);
+    }
+
+    constructor(config: Config) {
+        this._config = config;
+    }
+
+    get tolerance(): number {
+        return this._config.tolerance;
+    }
+
+    get antialiasingTolerance(): number {
+        return this._config.antialiasingTolerance;
+    }
+
+    get browserIds(): string[] {
+        return this._config.getBrowserIds();
+    }
+
+    getBrowserConfig(browserId: string): ReturnType<Config['forBrowser']> {
+        return this._config.forBrowser(browserId);
+    }
+
+    getScreenshotPath(test: TestplaneTestAdapter, stateName: string): string {
+        const {browserId} = test;
+
+        return this._config.browsers[browserId].getScreenshotPath(test.original, stateName);
+    }
+}

--- a/lib/adapters/test-collection/index.ts
+++ b/lib/adapters/test-collection/index.ts
@@ -1,0 +1,5 @@
+import type {TestAdapter} from '../test';
+
+export interface TestCollectionAdapter {
+    readonly tests: TestAdapter[];
+}

--- a/lib/adapters/test-collection/testplane.ts
+++ b/lib/adapters/test-collection/testplane.ts
@@ -1,0 +1,28 @@
+import {TestplaneTestAdapter} from '../test/testplane';
+import type {TestCollectionAdapter} from './index';
+import type {TestCollection} from 'testplane';
+
+export class TestplaneTestCollectionAdapter implements TestCollectionAdapter {
+    private _testCollection: TestCollection;
+    private _testAdapters: TestplaneTestAdapter[];
+
+    static create<T>(
+        this: new (testCollection: TestCollection) => T,
+        testCollection: TestCollection
+    ): T {
+        return new this(testCollection);
+    }
+
+    constructor(testCollection: TestCollection) {
+        this._testCollection = testCollection;
+        this._testAdapters = this._testCollection.mapTests(test => TestplaneTestAdapter.create(test));
+    }
+
+    get original(): TestCollection {
+        return this._testCollection;
+    }
+
+    get tests(): TestplaneTestAdapter[] {
+        return this._testAdapters;
+    }
+}

--- a/lib/adapters/test-result/playwright.ts
+++ b/lib/adapters/test-result/playwright.ts
@@ -61,7 +61,11 @@ export const getStatus = (result: PlaywrightTestResult): TestStatus => {
         return TestStatus.FAIL;
     }
 
-    return TestStatus.SKIPPED;
+    if (result.status === PwtTestStatus.SKIPPED) {
+        return TestStatus.SKIPPED;
+    }
+
+    return TestStatus.IDLE;
 };
 
 const extractErrorMessage = (result: PlaywrightTestResult): string => {

--- a/lib/adapters/test-result/testplane.ts
+++ b/lib/adapters/test-result/testplane.ts
@@ -59,7 +59,11 @@ export class TestplaneTestResultAdapter implements ReporterTestResult {
     private _attempt: number;
     private _status: TestStatus;
 
-    static create<T extends TestplaneTestResultAdapter>(this: new (testResult: TestplaneTestResult, options: TestplaneTestResultAdapterOptions) => T, testResult: TestplaneTestResult, options: TestplaneTestResultAdapterOptions): T {
+    static create(
+        this: new (testResult: TestplaneTest | TestplaneTestResult, options: TestplaneTestResultAdapterOptions) => TestplaneTestResultAdapter,
+        testResult: TestplaneTest | TestplaneTestResult,
+        options: TestplaneTestResultAdapterOptions
+    ): TestplaneTestResultAdapter {
         return new this(testResult, options);
     }
 

--- a/lib/adapters/test/index.ts
+++ b/lib/adapters/test/index.ts
@@ -1,0 +1,25 @@
+import {TestStatus} from '../../constants';
+import type {ReporterTestResult} from '../test-result';
+import type {AssertViewResult} from '../../types';
+
+export interface CreateTestResultOpts {
+    status: TestStatus;
+    attempt?: number;
+    assertViewResults?: AssertViewResult[];
+    error?: Error;
+    sessionId?: string;
+    meta?: {
+        url?: string;
+    }
+}
+
+export interface TestAdapter {
+    readonly id: string;
+    readonly pending: boolean;
+    readonly disabled: boolean;
+    readonly silentlySkipped: boolean;
+    readonly browserId: string;
+    readonly fullName: string;
+
+    createTestResult(opts: CreateTestResultOpts): ReporterTestResult;
+}

--- a/lib/adapters/test/testplane.ts
+++ b/lib/adapters/test/testplane.ts
@@ -1,0 +1,68 @@
+import {TestplaneTestResultAdapter} from '../test-result/testplane';
+import {UNKNOWN_ATTEMPT} from '../../constants';
+
+import type {TestAdapter, CreateTestResultOpts} from './';
+import type {Test, Suite} from 'testplane';
+import type {ReporterTestResult} from '../test-result';
+
+export class TestplaneTestAdapter implements TestAdapter {
+    private _test: Test;
+
+    static create<T extends TestplaneTestAdapter>(this: new (test: Test) => T, test: Test): T {
+        return new this(test);
+    }
+
+    constructor(test: Test) {
+        this._test = test;
+    }
+
+    get original(): Test {
+        return this._test;
+    }
+
+    get id(): string {
+        return this._test.id;
+    }
+
+    get pending(): boolean {
+        return this._test.pending;
+    }
+
+    get disabled(): boolean {
+        return this._test.disabled;
+    }
+
+    get silentlySkipped(): boolean {
+        return isSilentlySkipped(this._test);
+    }
+
+    get browserId(): string {
+        return this._test.browserId;
+    }
+
+    get fullName(): string {
+        return this._test.fullTitle();
+    }
+
+    createTestResult(opts: CreateTestResultOpts): ReporterTestResult {
+        const {status, assertViewResults, error, sessionId, meta, attempt = UNKNOWN_ATTEMPT} = opts;
+        const test = this._test.clone();
+
+        [
+            {key: 'assertViewResults', value: assertViewResults},
+            {key: 'err', value: error},
+            {key: 'sessionId', value: sessionId},
+            {key: 'meta', value: meta}
+        ].forEach(({key, value}) => {
+            if (value) {
+                test[key] = value;
+            }
+        });
+
+        return TestplaneTestResultAdapter.create(test, {attempt, status});
+    }
+}
+
+function isSilentlySkipped(runnable: Test | Suite): boolean {
+    return Boolean(runnable.silentSkip || runnable.parent && isSilentlySkipped(runnable.parent));
+}

--- a/lib/adapters/tool/index.ts
+++ b/lib/adapters/tool/index.ts
@@ -1,6 +1,7 @@
-import type {Config, TestCollection} from 'testplane';
 import type {CommanderStatic} from '@gemini-testing/commander';
 
+import {TestCollectionAdapter} from '../test-collection';
+import {ConfigAdapter} from '../config';
 import {GuiApi} from '../../gui/api';
 import {EventSource} from '../../gui/event-source';
 import {GuiReportBuilder} from '../../report-builder/gui';
@@ -8,6 +9,7 @@ import {ToolName} from '../../constants';
 
 import type {ReporterConfig, ImageFile} from '../../types';
 import type {TestSpec} from './types';
+import type {HtmlReporter} from '../../plugin-api';
 
 export interface ToolAdapterOptionsFromCli {
     toolName: ToolName;
@@ -21,13 +23,14 @@ export interface UpdateReferenceOpts {
 
 export interface ToolAdapter {
     readonly toolName: ToolName;
-    readonly config: Config;
+    readonly config: ConfigAdapter;
     readonly reporterConfig: ReporterConfig;
+    readonly htmlReporter: HtmlReporter;
     readonly guiApi?: GuiApi;
 
     initGuiApi(): void;
-    readTests(paths: string[], cliTool: CommanderStatic): Promise<TestCollection>;
-    run(testCollection: TestCollection, tests: TestSpec[], cliTool: CommanderStatic): Promise<boolean>;
+    readTests(paths: string[], cliTool: CommanderStatic): Promise<TestCollectionAdapter>;
+    run(testCollection: TestCollectionAdapter, tests: TestSpec[], cliTool: CommanderStatic): Promise<boolean>;
 
     updateReference(opts: UpdateReferenceOpts): void;
     handleTestResults(reportBuilder: GuiReportBuilder, eventSource: EventSource): void;

--- a/lib/adapters/tool/testplane/runner/all-test-runner.ts
+++ b/lib/adapters/tool/testplane/runner/all-test-runner.ts
@@ -1,5 +1,5 @@
-import type {TestCollection} from 'testplane';
 import {BaseRunner} from './runner';
+import type {TestCollection} from 'testplane';
 
 export class AllTestRunner extends BaseRunner {
     override run<U>(runHandler: (testCollection: TestCollection) => U): U {

--- a/lib/adapters/tool/testplane/runner/specific-test-runner.ts
+++ b/lib/adapters/tool/testplane/runner/specific-test-runner.ts
@@ -1,6 +1,6 @@
-import type {TestCollection} from 'testplane';
 import {BaseRunner} from './runner';
 import type {TestSpec} from '../../types';
+import type {TestCollection} from 'testplane';
 
 export class SpecificTestRunner extends BaseRunner {
     private _tests: TestSpec[];

--- a/lib/cli/commands/remove-unused-screens/utils.js
+++ b/lib/cli/commands/remove-unused-screens/utils.js
@@ -20,15 +20,14 @@ exports.getTestsFromFs = async (toolAdapter) => {
 
     const testCollection = await toolAdapter.readTests([], {silent: true});
 
-    testCollection.eachTest((test, browserId) => {
-        const fullTitle = test.fullTitle();
-        const id = `${fullTitle} ${browserId}`;
-        const screenPattern = toolAdapter.config.browsers[browserId].getScreenshotPath(test, '*');
+    for (const test of testCollection.tests) {
+        const id = `${test.fullName} ${test.browserId}`;
+        const screenPattern = toolAdapter.config.getScreenshotPath(test, '*');
 
         tests.byId[id] = {screenPattern, ...test};
-        tests.browserIds.add(browserId);
-        uniqTests.add(fullTitle);
-    });
+        tests.browserIds.add(test.browserId);
+        uniqTests.add(test.fullName);
+    }
 
     tests.count = uniqTests.size;
 

--- a/lib/gui/app.ts
+++ b/lib/gui/app.ts
@@ -4,15 +4,13 @@ import _ from 'lodash';
 import {ToolRunner, ToolRunnerTree, UndoAcceptImagesResult} from './tool-runner';
 import {TestBranch, TestEqualDiffsData, TestRefUpdateData} from '../tests-tree-builder/gui';
 
-import type {Config} from 'testplane';
 import type {ServerArgs} from './index';
 import type {TestSpec} from '../adapters/tool/types';
-
-type BrowserConfig = ReturnType<Config['forBrowser']>;
+import type {BrowserConfigAdapter} from '../adapters/config/index';
 
 export class App {
     private _toolRunner: ToolRunner;
-    private _browserConfigs: BrowserConfig[];
+    private _browserConfigs: BrowserConfigAdapter[];
     private _retryCache: Record<string, number>;
 
     static create<T extends App>(this: new (args: ServerArgs) => T, args: ServerArgs): T {
@@ -46,7 +44,7 @@ export class App {
 
     private async _runWithoutRetries(tests: TestSpec[]): Promise<boolean> {
         if (_.isEmpty(this._browserConfigs)) {
-            this._browserConfigs = _.map(this._toolRunner.config.getBrowserIds(), (id) => this._toolRunner.config.forBrowser(id));
+            this._browserConfigs = _.map(this._toolRunner.config.browserIds, (id) => this._toolRunner.config.getBrowserConfig(id));
         }
 
         this._disableRetries();

--- a/lib/gui/tool-runner/index.ts
+++ b/lib/gui/tool-runner/index.ts
@@ -4,7 +4,6 @@ import os from 'node:os';
 import {CommanderStatic} from '@gemini-testing/commander';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import type {TestCollection, Test as TestplaneTest, Config as TestplaneConfig} from 'testplane';
 import _ from 'lodash';
 import looksSame, {CoordBounds} from 'looks-same';
 import PQueue from 'p-queue';
@@ -12,7 +11,6 @@ import type {Response} from 'express';
 
 import {GuiReportBuilder, GuiReportBuilderResult} from '../../report-builder/gui';
 import {EventSource} from '../event-source';
-import {TestplaneToolAdapter} from '../../adapters/tool/testplane';
 import {SqliteClient} from '../../sqlite-client';
 import {Cache} from '../../cache';
 import {ImagesInfoSaver} from '../../images-info-saver';
@@ -20,7 +18,7 @@ import {SqliteImageStore} from '../../image-store';
 import * as reporterHelper from '../../reporter-helpers';
 import {logger, getShortMD5, isUpdatedStatus} from '../../common-utils';
 import {formatId, mkFullTitle, mergeDatabasesForReuse, filterByEqualDiffSizes} from './utils';
-import {formatTestResult, getExpectedCacheKey} from '../../server-utils';
+import {getExpectedCacheKey} from '../../server-utils';
 import {getTestsTreeFromDatabase} from '../../db-utils/server';
 import {
     UPDATED,
@@ -29,9 +27,11 @@ import {
     ToolName,
     DATABASE_URLS_JSON_NAME,
     LOCAL_DATABASE_NAME,
-    PluginEvents
+    PluginEvents,
+    UNKNOWN_ATTEMPT
 } from '../../constants';
 
+import type {ToolAdapter} from '../../adapters/tool';
 import type {GuiCliOptions, ServerArgs} from '../index';
 import type {TestBranch, TestEqualDiffsData, TestRefUpdateData} from '../../tests-tree-builder/gui';
 import type {ReporterTestResult} from '../../adapters/test-result';
@@ -39,11 +39,13 @@ import type {Tree, TreeImage} from '../../tests-tree-builder/base';
 import type {TestSpec} from '../../adapters/tool/types';
 import type {
     AssertViewResult,
-    TestplaneTestResult,
     ImageFile,
     ImageInfoDiff, ImageInfoUpdated, ImageInfoWithState,
     ReporterConfig, TestSpecByPath, RefImageFile
 } from '../../types';
+import type {TestAdapter} from '../../adapters/test/index';
+import type {TestCollectionAdapter} from '../../adapters/test-collection';
+import type {ConfigAdapter} from '../../adapters/config';
 
 export type ToolRunnerTree = GuiReportBuilderResult & Pick<GuiCliOptions, 'autoRun'>;
 
@@ -54,16 +56,16 @@ export interface UndoAcceptImagesResult {
 
 export class ToolRunner {
     private _testFiles: string[];
-    private _toolAdapter: TestplaneToolAdapter;
+    private _toolAdapter: ToolAdapter;
     private _tree: ToolRunnerTree | null;
-    protected _collection: TestCollection | null;
+    protected _collection: TestCollectionAdapter | null;
     private _globalOpts: CommanderStatic;
     private _guiOpts: GuiCliOptions;
     private _reportPath: string;
     private _reporterConfig: ReporterConfig;
     private _eventSource: EventSource;
     protected _reportBuilder: GuiReportBuilder | null;
-    private _tests: Record<string, TestplaneTest>;
+    private _testAdapters: Record<string, TestAdapter>;
     private _expectedImagesCache: Cache<[TestSpecByPath, string | undefined], string>;
 
     static create<T extends ToolRunner>(this: new (args: ServerArgs) => T, args: ServerArgs): T {
@@ -85,12 +87,12 @@ export class ToolRunner {
         this._eventSource = new EventSource();
         this._reportBuilder = null;
 
-        this._tests = {};
+        this._testAdapters = {};
 
         this._expectedImagesCache = new Cache(getExpectedCacheKey);
     }
 
-    get config(): TestplaneConfig {
+    get config(): ConfigAdapter {
         return this._toolAdapter.config;
     }
 
@@ -123,7 +125,7 @@ export class ToolRunner {
         await this._handleRunnableCollection();
     }
 
-    async _readTests(): Promise<TestCollection> {
+    async _readTests(): Promise<TestCollectionAdapter> {
         return this._toolAdapter.readTests(this._testFiles, this._globalOpts);
     }
 
@@ -135,7 +137,7 @@ export class ToolRunner {
         return this._reportBuilder;
     }
 
-    protected _ensureTestCollection(): TestCollection {
+    protected _ensureTestCollection(): TestCollectionAdapter {
         if (!this._collection) {
             throw new Error('ToolRunner has to be initialized before usage');
         }
@@ -172,17 +174,36 @@ export class ToolRunner {
         const reportBuilder = this._ensureReportBuilder();
 
         return Promise.all(tests.map(async (test): Promise<TestBranch> => {
-            const updateResult = this._createTestplaneTestResult(test);
+            const testAdapter = this._getTestAdapterById(test);
+            const assertViewResults = this._prepareAssertViewResults(test.imagesInfo, testAdapter);
+            const {sessionId, url} = test.metaInfo as {sessionId?: string; url?: string};
+
             const latestAttempt = reportBuilder.getLatestAttempt({
-                fullName: updateResult.fullTitle(),
-                browserId: updateResult.browserId
+                fullName: testAdapter.fullName,
+                browserId: testAdapter.browserId
             });
-            const latestResult = formatTestResult(updateResult, UPDATED, latestAttempt);
+
+            const latestResult = testAdapter.createTestResult({
+                assertViewResults,
+                status: UPDATED,
+                attempt: latestAttempt,
+                error: test.error,
+                sessionId,
+                meta: {url}
+            });
+
             const estimatedStatus = reportBuilder.getUpdatedReferenceTestStatus(latestResult);
 
-            const formattedResultWithoutAttempt = formatTestResult(updateResult, UPDATED);
-            const formattedResult = reportBuilder.provideAttempt(formattedResultWithoutAttempt);
+            const formattedResultWithoutAttempt = testAdapter.createTestResult({
+                assertViewResults,
+                status: UPDATED,
+                attempt: UNKNOWN_ATTEMPT,
+                error: test.error,
+                sessionId,
+                meta: {url}
+            });
 
+            const formattedResult = reportBuilder.provideAttempt(formattedResultWithoutAttempt);
             const formattedResultUpdated = await reporterHelper.updateReferenceImages(formattedResult, this._reportPath, this._handleReferenceUpdate.bind(this));
 
             await reportBuilder.addTestResult(formattedResultUpdated, {status: estimatedStatus});
@@ -196,8 +217,18 @@ export class ToolRunner {
         const reportBuilder = this._ensureReportBuilder();
 
         await Promise.all(tests.map(async (test) => {
-            const updateResult = this._createTestplaneTestResult(test);
-            const formattedResultWithoutAttempt = formatTestResult(updateResult, UPDATED);
+            const testAdapter = this._getTestAdapterById(test);
+            const assertViewResults = this._prepareAssertViewResults(test.imagesInfo, testAdapter);
+            const {sessionId, url} = test.metaInfo as {sessionId?: string; url?: string};
+
+            const formattedResultWithoutAttempt = testAdapter.createTestResult({
+                assertViewResults,
+                status: UPDATED,
+                attempt: UNKNOWN_ATTEMPT,
+                error: test.error,
+                sessionId,
+                meta: {url}
+            });
 
             await Promise.all(formattedResultWithoutAttempt.imagesInfo.map(async (imageInfo) => {
                 const {stateName} = imageInfo as ImageInfoWithState;
@@ -227,10 +258,10 @@ export class ToolRunner {
                     await reporterHelper.revertReferenceImage(removedResult, newResult, stateName);
                 }
 
-                if (previousExpectedPath && (updateResult as TestplaneTest).fullTitle) {
+                if (previousExpectedPath) {
                     this._expectedImagesCache.set([{
-                        testPath: [(updateResult as TestplaneTest).fullTitle()],
-                        browserId: (updateResult as TestplaneTest).browserId
+                        testPath: [testAdapter.fullName],
+                        browserId: testAdapter.browserId
                     }, stateName], previousExpectedPath);
                 }
             }));
@@ -292,61 +323,50 @@ export class ToolRunner {
         const reportBuilder = this._ensureReportBuilder();
         const queue = new PQueue({concurrency: os.cpus().length});
 
-        this._ensureTestCollection().eachTest((test, browserId) => {
-            if (test.disabled || this._isSilentlySkipped(test)) {
+        for (const test of this._ensureTestCollection().tests) {
+            if (test.disabled || test.silentlySkipped) {
                 return;
             }
 
             // TODO: remove toString after publish major version
-            const testId = formatId(test.id.toString(), browserId);
-            this._tests[testId] = _.extend(test, {browserId});
+            const testId = formatId(test.id.toString(), test.browserId);
+            this._testAdapters[testId] = test;
 
             if (test.pending) {
-                queue.add(async () => reportBuilder.addTestResult(formatTestResult(test, SKIPPED)));
+                queue.add(async () => reportBuilder.addTestResult(test.createTestResult({status: SKIPPED})));
             } else {
-                queue.add(async () => reportBuilder.addTestResult(formatTestResult(test, IDLE)));
+                queue.add(async () => reportBuilder.addTestResult(test.createTestResult({status: IDLE})));
             }
-        });
+        }
 
         await queue.onIdle();
         await this._fillTestsTree();
     }
 
-    protected _isSilentlySkipped({silentSkip, parent}: TestplaneTest): boolean {
-        return Boolean(silentSkip || parent && this._isSilentlySkipped(parent));
+    protected _getTestAdapterById(updateData: TestRefUpdateData): TestAdapter {
+        const fullTitle = mkFullTitle(updateData);
+        const testId = this._toolAdapter.toolName === ToolName.Testplane
+            ? formatId(getShortMD5(fullTitle), updateData.browserId)
+            : formatId(fullTitle, updateData.browserId);
+
+        return this._testAdapters[testId];
     }
 
-    protected _createTestplaneTestResult(updateData: TestRefUpdateData): TestplaneTestResult {
-        const {browserId} = updateData;
-        const fullTitle = mkFullTitle(updateData);
-        const testId = formatId(getShortMD5(fullTitle), browserId);
-        const testplaneTest = this._tests[testId];
-        const {sessionId, url} = updateData.metaInfo as {sessionId?: string; url?: string};
+    protected _prepareAssertViewResults(imagesInfo: TestRefUpdateData['imagesInfo'], testAdapter: TestAdapter): AssertViewResult[] {
         const assertViewResults: AssertViewResult[] = [];
 
-        updateData.imagesInfo
+        imagesInfo
             .filter(({stateName, actualImg}) => Boolean(stateName) && Boolean(actualImg))
             .forEach((imageInfo) => {
                 const {stateName, actualImg} = imageInfo as {stateName: string, actualImg: ImageFile};
-                const absoluteRefImgPath = this._toolAdapter.config.browsers[browserId].getScreenshotPath(testplaneTest, stateName);
+                const absoluteRefImgPath = this._toolAdapter.config.getScreenshotPath(testAdapter, stateName);
                 const relativeRefImgPath = absoluteRefImgPath && path.relative(process.cwd(), absoluteRefImgPath);
                 const refImg: RefImageFile = {path: absoluteRefImgPath, relativePath: relativeRefImgPath, size: actualImg.size};
 
                 assertViewResults.push({stateName, refImg, currImg: actualImg, isUpdated: isUpdatedStatus(imageInfo.status)});
             });
 
-        const testplaneTestResult: TestplaneTestResult = _.merge({}, testplaneTest, {
-            assertViewResults,
-            err: updateData.error as TestplaneTestResult['err'],
-            sessionId,
-            meta: {url}
-        } satisfies Partial<TestplaneTestResult>) as unknown as TestplaneTestResult;
-
-        // _.merge can't fully clone test object since hermione@7+
-        // TODO: use separate object to represent test results. Do not extend test object with test results
-        return testplaneTest && testplaneTest.clone
-            ? Object.assign(testplaneTest.clone(), testplaneTestResult)
-            : testplaneTestResult;
+        return assertViewResults;
     }
 
     protected _handleReferenceUpdate(testResult: ReporterTestResult, imageInfo: ImageInfoUpdated, state: string): void {

--- a/test/unit/lib/adapters/config/testplane.ts
+++ b/test/unit/lib/adapters/config/testplane.ts
@@ -1,0 +1,62 @@
+import type {Config, Test} from 'testplane';
+import sinon from 'sinon';
+import {TestplaneConfigAdapter} from '../../../../../lib/adapters/config/testplane';
+import {TestplaneTestAdapter} from '../../../../../lib/adapters/test/testplane';
+import {stubConfig, mkState} from '../../../utils';
+
+describe('lib/adapters/config/testplane', () => {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(() => sandbox.restore());
+
+    describe('tolerance', () => {
+        it('should return tolerance from original config', () => {
+            const config = stubConfig({tolerance: 100500}) as unknown as Config;
+            const configAdapter = TestplaneConfigAdapter.create(config);
+
+            assert.equal(configAdapter.tolerance, 100500);
+        });
+    });
+
+    describe('antialiasingTolerance', () => {
+        it('should return antialiasingTolerance from original config', () => {
+            const config = stubConfig({antialiasingTolerance: 500100}) as unknown as Config;
+            const configAdapter = TestplaneConfigAdapter.create(config);
+
+            assert.equal(configAdapter.antialiasingTolerance, 500100);
+        });
+    });
+
+    describe('browserIds', () => {
+        it('should return browser ids from original config', () => {
+            const config = stubConfig({browsers: {yabro1: {}, yabro2: {}}}) as unknown as Config;
+            const configAdapter = TestplaneConfigAdapter.create(config);
+
+            assert.deepEqual(configAdapter.browserIds, ['yabro1', 'yabro2']);
+        });
+    });
+
+    describe('getBrowserConfig', () => {
+        it('should return browser config from original config', () => {
+            const browserConfig = {foo: 'bar'} as unknown as ReturnType<Config['forBrowser']>;
+            const config = stubConfig({browsers: {yabro: browserConfig}}) as unknown as Config;
+            const configAdapter = TestplaneConfigAdapter.create(config);
+
+            assert.deepEqual(configAdapter.getBrowserConfig('yabro'), browserConfig);
+        });
+    });
+
+    describe('getScreenshotPath', () => {
+        it('should return screenshot path from original browser config', () => {
+            const test = mkState({browserId: 'yabro'});
+            const testAdapter = TestplaneTestAdapter.create(test as unknown as Test);
+            const stateName = 'plain';
+
+            const getScreenshotPath = sandbox.stub().withArgs(test, stateName).returns('/ref/path');
+            const config = stubConfig({browsers: {yabro: {getScreenshotPath}}}) as unknown as Config;
+            const configAdapter = TestplaneConfigAdapter.create(config);
+
+            assert.equal(configAdapter.getScreenshotPath(testAdapter, stateName), '/ref/path');
+        });
+    });
+});

--- a/test/unit/lib/adapters/test-collection/testplane.ts
+++ b/test/unit/lib/adapters/test-collection/testplane.ts
@@ -1,0 +1,37 @@
+import type {TestCollection} from 'testplane';
+import sinon from 'sinon';
+import {TestplaneTestCollectionAdapter} from '../../../../../lib/adapters/test-collection/testplane';
+import {TestplaneTestAdapter} from '../../../../../lib/adapters/test/testplane';
+import {stubTestCollection, mkState} from '../../../utils';
+
+describe('lib/adapters/test-collection/testplane', () => {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(() => sandbox.restore());
+
+    describe('original', () => {
+        it('shoult return original test instance', () => {
+            const testCollection = stubTestCollection() as TestCollection;
+
+            assert.equal(TestplaneTestCollectionAdapter.create(testCollection).original, testCollection);
+        });
+    });
+
+    describe('tests', () => {
+        it('should return tests', () => {
+            const test1 = mkState();
+            const testAdapter1 = {} as TestplaneTestAdapter;
+            const test2 = mkState();
+            const testAdapter2 = {} as TestplaneTestAdapter;
+
+            sandbox.stub(TestplaneTestAdapter, 'create')
+                .withArgs(test1).returns(testAdapter1)
+                .withArgs(test2).returns(testAdapter2);
+
+            const testCollection = stubTestCollection({yabro1: test1, yabro2: test2}) as TestCollection;
+            const testCollectionAdapter = TestplaneTestCollectionAdapter.create(testCollection);
+
+            assert.deepEqual(testCollectionAdapter.tests, [testAdapter1, testAdapter2]);
+        });
+    });
+});

--- a/test/unit/lib/adapters/test/testplane.ts
+++ b/test/unit/lib/adapters/test/testplane.ts
@@ -1,0 +1,108 @@
+import type {Test} from 'testplane';
+import sinon, {type SinonStub} from 'sinon';
+import {TestplaneTestAdapter} from '../../../../../lib/adapters/test/testplane';
+import {TestplaneTestResultAdapter} from '../../../../../lib/adapters/test-result/testplane';
+import {mkState} from '../../../utils';
+import {TestStatus} from '../../../../../lib/constants';
+
+describe('lib/adapters/test/testplane', () => {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(() => sandbox.restore());
+
+    describe('original', () => {
+        it('shoult return original test instance', () => {
+            const test = mkState() as unknown as Test;
+
+            assert.equal(TestplaneTestAdapter.create(test).original, test);
+        });
+    });
+
+    describe('id', () => {
+        it('should return id from original test', () => {
+            const test = mkState({id: 'foo'}) as unknown as Test;
+
+            assert.equal(TestplaneTestAdapter.create(test).id, 'foo');
+        });
+    });
+
+    describe('pending', () => {
+        it('should return pending from original test', () => {
+            const test = mkState({pending: true}) as unknown as Test;
+
+            assert.isTrue(TestplaneTestAdapter.create(test).pending);
+        });
+    });
+
+    describe('disabled', () => {
+        it('should return disabled from original test', () => {
+            const test = mkState({disabled: true}) as unknown as Test;
+
+            assert.isTrue(TestplaneTestAdapter.create(test).disabled);
+        });
+    });
+
+    describe('silentlySkipped', () => {
+        it('should return false if test and parent is not silently skipped', () => {
+            const test = mkState({
+                silentSkip: false,
+                parent: {
+                    silentSkip: false
+                }
+            }) as unknown as Test;
+
+            assert.isFalse(TestplaneTestAdapter.create(test).silentlySkipped);
+        });
+
+        describe('should return true', () => {
+            it('if test is silently skipped', () => {
+                const test = mkState({silentSkip: true}) as unknown as Test;
+
+                assert.isTrue(TestplaneTestAdapter.create(test).silentlySkipped);
+            });
+
+            it('if test parent is silently skipped', () => {
+                const test = mkState({
+                    silentSkip: false,
+                    parent: {
+                        silentSkip: true
+                    }
+                }) as unknown as Test;
+
+                assert.isTrue(TestplaneTestAdapter.create(test).silentlySkipped);
+            });
+        });
+    });
+
+    describe('browserId', () => {
+        it('should return browserId from original test', () => {
+            const test = mkState({browserId: 'yabro'}) as unknown as Test;
+
+            assert.equal(TestplaneTestAdapter.create(test).browserId, 'yabro');
+        });
+    });
+
+    describe('fullName', () => {
+        it('should return full title from original test', () => {
+            const test = mkState({fullTitle: () => 'suite test'}) as unknown as Test;
+
+            assert.equal(TestplaneTestAdapter.create(test).fullName, 'suite test');
+        });
+    });
+
+    describe('createTestResult', () => {
+        it('should return testplane test result adapter', () => {
+            const testResultAdapter = {} as unknown as TestplaneTestResultAdapter;
+            const clonedTest = mkState();
+            const test = mkState({clone: () => clonedTest}) as unknown as Test;
+            const status = TestStatus.SUCCESS;
+            const attempt = 0;
+            sandbox.stub(TestplaneTestResultAdapter, 'create').withArgs(clonedTest, {status, attempt}).returns(testResultAdapter);
+
+            const formattedTestResult = TestplaneTestAdapter.create(test).createTestResult({status, attempt});
+
+            assert.equal(formattedTestResult, testResultAdapter);
+            assert.calledOnceWith(TestplaneTestResultAdapter.create as SinonStub, clonedTest, {status, attempt});
+        });
+    });
+});

--- a/test/unit/lib/adapters/tool/testplane/index.ts
+++ b/test/unit/lib/adapters/tool/testplane/index.ts
@@ -9,6 +9,7 @@ import {ToolName} from '../../../../../../lib/constants';
 import {GuiApi} from '../../../../../../lib/gui/api';
 import {GuiReportBuilder} from '../../../../../../lib/report-builder/gui';
 import {EventSource} from '../../../../../../lib/gui/event-source';
+import {TestplaneTestCollectionAdapter} from '../../../../../../lib/adapters/test-collection/testplane';
 
 import {stubTool, stubConfig, stubTestCollection} from '../../../../utils';
 import type {ReporterConfig} from '../../../../../../lib/types';
@@ -241,13 +242,13 @@ describe('lib/adapters/tool/testplane/index', () => {
         let collection: TestCollection;
         let runner: {run: SinonStub};
 
-        const run_ = async (testplane: Testplane, collection: TestCollection, tests: TestSpec[], cliTool: CommanderStatic): Promise<void> => {
+        const run_ = async (testplane: Testplane, collectionAdapter: TestplaneTestCollectionAdapter, tests: TestSpec[], cliTool: CommanderStatic): Promise<void> => {
             const toolAdapter = TestplaneToolAdapter.create({toolName: ToolName.Testplane, tool: testplane, reporterConfig: {} as ReporterConfig});
 
-            await toolAdapter.run(collection, tests, cliTool);
+            await toolAdapter.run(collectionAdapter, tests, cliTool);
 
             const runHandler = runner.run.firstCall.args[0];
-            await runHandler(collection);
+            await runHandler(collectionAdapter.original);
         };
 
         beforeEach(() => {
@@ -262,7 +263,7 @@ describe('lib/adapters/tool/testplane/index', () => {
             const tests = [] as TestSpec[];
             const cliTool = {grep: /some-grep/, set: 'some-set', browser: 'yabro', devtools: true} as unknown as CommanderStatic;
 
-            await run_(testplane, collection, tests, cliTool);
+            await run_(testplane, TestplaneTestCollectionAdapter.create(collection), tests, cliTool);
 
             assert.calledOnceWith(testplane.run, collection, sinon.match({
                 grep: cliTool.grep,
@@ -278,7 +279,7 @@ describe('lib/adapters/tool/testplane/index', () => {
                 const tests = [] as TestSpec[];
                 const cliTool = {} as unknown as CommanderStatic;
 
-                await run_(testplane, collection, tests, cliTool);
+                await run_(testplane, TestplaneTestCollectionAdapter.create(collection), tests, cliTool);
 
                 assert.calledOnceWith(testplane.run, collection, sinon.match({
                     replMode: {
@@ -294,7 +295,7 @@ describe('lib/adapters/tool/testplane/index', () => {
                 const tests = [] as TestSpec[];
                 const cliTool = {repl: true} as unknown as CommanderStatic;
 
-                await run_(testplane, collection, tests, cliTool);
+                await run_(testplane, TestplaneTestCollectionAdapter.create(collection), tests, cliTool);
 
                 assert.calledOnceWith(testplane.run, collection, sinon.match({
                     replMode: {
@@ -310,7 +311,7 @@ describe('lib/adapters/tool/testplane/index', () => {
                 const tests = [] as TestSpec[];
                 const cliTool = {replBeforeTest: true} as unknown as CommanderStatic;
 
-                await run_(testplane, collection, tests, cliTool);
+                await run_(testplane, TestplaneTestCollectionAdapter.create(collection), tests, cliTool);
 
                 assert.calledOnceWith(testplane.run, collection, sinon.match({
                     replMode: {
@@ -326,7 +327,7 @@ describe('lib/adapters/tool/testplane/index', () => {
                 const tests = [] as TestSpec[];
                 const cliTool = {replOnFail: true} as unknown as CommanderStatic;
 
-                await run_(testplane, collection, tests, cliTool);
+                await run_(testplane, TestplaneTestCollectionAdapter.create(collection), tests, cliTool);
 
                 assert.calledOnceWith(testplane.run, collection, sinon.match({
                     replMode: {

--- a/test/unit/lib/cli/commands/remove-unused-screens/utils.js
+++ b/test/unit/lib/cli/commands/remove-unused-screens/utils.js
@@ -5,6 +5,8 @@ const fs = require('fs-extra');
 const proxyquire = require('proxyquire');
 const inquirer = require('inquirer');
 
+const {TestplaneTestAdapter} = require('lib/adapters/test/testplane');
+const {TestplaneConfigAdapter} = require('lib/adapters/config/testplane');
 const {SUCCESS, ERROR} = require('lib/constants/test-statuses');
 const {stubToolAdapter, stubConfig, mkState} = require('test/unit/utils');
 
@@ -12,16 +14,16 @@ describe('lib/cli/commands/remove-unused-screens/utils', () => {
     const sandbox = sinon.sandbox.create();
     let utils, fgMock;
 
-    const mkTestCollection_ = (testsTree = {}) => {
-        return {
-            eachTest: (cb) => {
-                Object.keys(testsTree).forEach((browserId) => cb(testsTree[browserId], browserId));
-            }
-        };
+    const mkConfigAdapter_ = (config = stubConfig()) => {
+        return TestplaneConfigAdapter.create(config);
     };
 
-    const stubTest_ = (opts) => {
-        return mkState(_.defaults(opts, {id: () => 'default-id'}));
+    const mkTest_ = (opts = {}) => {
+        return mkState(_.defaults(opts, {id: () => 'default-id', browserId: 'default-bro-id'}));
+    };
+
+    const mkTestAdapter_ = (test = mkTest_()) => {
+        return TestplaneTestAdapter.create(test);
     };
 
     const mkTestsTreeFromDb_ = ({
@@ -36,7 +38,7 @@ describe('lib/cli/commands/remove-unused-screens/utils', () => {
         };
     };
 
-    const mkToolAdapter_ = (testCollection = mkTestCollection_(), config = stubConfig(), htmlReporter) => {
+    const mkToolAdapter_ = (testCollection = {tests: []}, config = stubConfig(), htmlReporter) => {
         const toolAdapter = stubToolAdapter({config});
 
         toolAdapter.readTests.resolves(testCollection);
@@ -76,10 +78,11 @@ describe('lib/cli/commands/remove-unused-screens/utils', () => {
         });
 
         it('should add test tests tree with its screen info', async () => {
-            const test = stubTest_({fullTitle: () => 'first'});
-            const testCollection = mkTestCollection_({bro: test});
+            const test = mkTest_({fullTitle: () => 'first', browserId: 'bro'});
+            const testAdapter = mkTestAdapter_(test);
+            const testCollection = {tests: [testAdapter]};
             getScreenshotPath.withArgs(test, '*').returns('/ref/path/*.png');
-            const config = stubConfig({browsers: {bro: {getScreenshotPath}}});
+            const config = mkConfigAdapter_(stubConfig({browsers: {bro: {getScreenshotPath}}}));
 
             fgMock.withArgs('/ref/path/*.png').resolves(['/ref/path/1.png', '/ref/path/2.png']);
 
@@ -91,7 +94,7 @@ describe('lib/cli/commands/remove-unused-screens/utils', () => {
             assert.deepEqual(
                 tests.byId['first bro'],
                 {
-                    ...test,
+                    ...testAdapter,
                     screenPaths: ['/ref/path/1.png', '/ref/path/2.png'],
                     screenPattern: '/ref/path/*.png'
                 }
@@ -99,14 +102,15 @@ describe('lib/cli/commands/remove-unused-screens/utils', () => {
         });
 
         it('should collect all screen patterns in tests tree', async () => {
-            const test1 = stubTest_({fullTitle: () => 'first'});
-            const test2 = stubTest_({fullTitle: () => 'second'});
-            const testCollection = mkTestCollection_({bro1: test1, bro2: test2});
+            const test1 = mkTest_({fullTitle: () => 'first', browserId: 'bro1'});
+            const test2 = mkTest_({fullTitle: () => 'second', browserId: 'bro2'});
+
+            const testCollection = {tests: [mkTestAdapter_(test1), mkTestAdapter_(test2)]};
             getScreenshotPath
                 .withArgs(test1, '*').returns('/ref/path-1/*.png')
                 .withArgs(test2, '*').returns('/ref/path-2/*.png');
 
-            const config = stubConfig({browsers: {bro1: {getScreenshotPath}, bro2: {getScreenshotPath}}});
+            const config = mkConfigAdapter_(stubConfig({browsers: {bro1: {getScreenshotPath}, bro2: {getScreenshotPath}}}));
             const toolAdapter = mkToolAdapter_(testCollection, config);
 
             const tests = await utils.getTestsFromFs(toolAdapter);
@@ -115,14 +119,17 @@ describe('lib/cli/commands/remove-unused-screens/utils', () => {
         });
 
         it('should return the number of unique tests', async () => {
-            const test1 = stubTest_({fullTitle: () => 'first'});
-            const test2 = stubTest_({fullTitle: () => 'second'});
-            const testCollection = mkTestCollection_({bro1: test1, bro2: test1, bro3: test2, bro4: test2});
+            const testCollection = {tests: [
+                mkTestAdapter_(mkTest_({fullTitle: () => 'first', browserId: 'bro1'})),
+                mkTestAdapter_(mkTest_({fullTitle: () => 'first', browserId: 'bro2'})),
+                mkTestAdapter_(mkTest_({fullTitle: () => 'second', browserId: 'bro3'})),
+                mkTestAdapter_(mkTest_({fullTitle: () => 'second', browserId: 'bro4'}))
+            ]};
 
-            const config = stubConfig({browsers: {
+            const config = mkConfigAdapter_(stubConfig({browsers: {
                 bro1: {getScreenshotPath}, bro2: {getScreenshotPath},
                 bro3: {getScreenshotPath}, bro4: {getScreenshotPath}
-            }});
+            }}));
             const toolAdapter = mkToolAdapter_(testCollection, config);
 
             const tests = await utils.getTestsFromFs(toolAdapter);
@@ -131,12 +138,15 @@ describe('lib/cli/commands/remove-unused-screens/utils', () => {
         });
 
         it('should return the list of unique browsers', async () => {
-            const test = stubTest_({fullTitle: () => 'first'});
-            const testCollection = mkTestCollection_({bro1: test, bro2: test, bro3: test});
+            const testCollection = {tests: [
+                mkTestAdapter_(mkTest_({fullTitle: () => 'first', browserId: 'bro1'})),
+                mkTestAdapter_(mkTest_({fullTitle: () => 'first', browserId: 'bro2'})),
+                mkTestAdapter_(mkTest_({fullTitle: () => 'second', browserId: 'bro3'}))
+            ]};
 
-            const config = stubConfig({browsers: {
+            const config = mkConfigAdapter_(stubConfig({browsers: {
                 bro1: {getScreenshotPath}, bro2: {getScreenshotPath}, bro3: {getScreenshotPath}
-            }});
+            }}));
             const toolAdapter = mkToolAdapter_(testCollection, config);
 
             const tests = await utils.getTestsFromFs(toolAdapter);

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -21,7 +21,10 @@ function stubReporterConfig(opts = {}) {
 const stubTestCollection = (testsTree = {}) => {
     return {
         eachTest: (cb) => {
-            Object.keys(testsTree).forEach((test) => cb(testsTree[test]));
+            Object.keys(testsTree).forEach((browserId) => cb(testsTree[browserId], browserId));
+        },
+        mapTests: (cb) => {
+            return Object.keys(testsTree).map((browserId) => cb(testsTree[browserId], browserId));
         }
     };
 };
@@ -52,7 +55,7 @@ function stubTool(config = stubConfig(), events = {}, errors = {}, htmlReporter)
 }
 
 function stubToolAdapter({
-    config = stubConfig(), reporterConfig = stubReporterConfig(), testCollection = stubTestCollection(), htmlReporter
+    config = stubConfig(), reporterConfig = stubReporterConfig(), testCollection = {tests: []}, htmlReporter
 } = {}) {
     const toolAdapter = {
         config,

--- a/testplane.ts
+++ b/testplane.ts
@@ -7,6 +7,7 @@ import PQueue from 'p-queue';
 import {CommanderStatic} from '@gemini-testing/commander';
 
 import {TestplaneToolAdapter} from './lib/adapters/tool/testplane';
+import {getStatus} from './lib/adapters/test-result/testplane';
 import {commands as cliCommands} from './lib/cli';
 import {parseConfig} from './lib/config';
 import {ToolName} from './lib/constants';
@@ -18,7 +19,6 @@ import {createWorkers, CreateWorkersRunner} from './lib/workers/create-workers';
 import {SqliteImageStore} from './lib/image-store';
 import {Cache} from './lib/cache';
 import {ImagesInfoSaver} from './lib/images-info-saver';
-import {getStatus} from './lib/adapters/test-result/testplane';
 
 export default (testplane: Testplane, opts: Partial<ReporterOptions>): void => {
     if (testplane.isWorker()) {


### PR DESCRIPTION
## What is done

Implement adapters: test, testCollection and config. In order to support gui command for playwright.

Previous PR with implementation tool adapter - https://github.com/gemini-testing/html-reporter/pull/551.
After that PR, I will be able to implement the launch of playwright tests using gui command.