### PR TITLE
fix: result state after screenshot-accepter image accept

### DIFF
--- a/lib/gui/tool-runner/index.ts
+++ b/lib/gui/tool-runner/index.ts
@@ -173,8 +173,12 @@ export class ToolRunner {
 
         return Promise.all(tests.map(async (test): Promise<TestBranch> => {
             const updateResult = this._createTestplaneTestResult(test);
-            const currentResult = formatTestResult(updateResult, UPDATED, test.attempt);
-            const estimatedStatus = reportBuilder.getUpdatedReferenceTestStatus(currentResult);
+            const latestAttempt = reportBuilder.getLatestAttempt({
+                fullName: updateResult.fullTitle(),
+                browserId: updateResult.browserId
+            });
+            const latestResult = formatTestResult(updateResult, UPDATED, latestAttempt);
+            const estimatedStatus = reportBuilder.getUpdatedReferenceTestStatus(latestResult);
 
             const formattedResultWithoutAttempt = formatTestResult(updateResult, UPDATED);
             const formattedResult = reportBuilder.provideAttempt(formattedResultWithoutAttempt);

--- a/lib/report-builder/static.ts
+++ b/lib/report-builder/static.ts
@@ -75,6 +75,10 @@ export class StaticReportBuilder {
         this._workers = workers;
     }
 
+    getLatestAttempt(testInfo: {fullName: string, browserId: string}): number {
+        return this._testAttemptManager.getCurrentAttempt(testInfo);
+    }
+
     /** If passed test result doesn't have attempt, this method registers new attempt and sets attempt number */
     provideAttempt(testResultOriginal: ReporterTestResult): ReporterTestResult {
         let formattedResult = testResultOriginal;


### PR DESCRIPTION
The idea is to calc new result state based on the latest result, not the current one