### PR TITLE
refactor: use one argument with all options inside report builders

### DIFF
--- a/lib/gui/tool-runner/index.ts
+++ b/lib/gui/tool-runner/index.ts
@@ -113,7 +113,12 @@ export class ToolRunner {
             reportPath: this._toolAdapter.htmlReporter.config.path
         });
 
-        this._reportBuilder = GuiReportBuilder.create(this._toolAdapter.htmlReporter, this._reporterConfig, {dbClient, imagesInfoSaver});
+        this._reportBuilder = GuiReportBuilder.create({
+            htmlReporter: this._toolAdapter.htmlReporter,
+            reporterConfig: this._reporterConfig,
+            dbClient,
+            imagesInfoSaver
+        });
         this._toolAdapter.handleTestResults(this._reportBuilder, this._eventSource);
 
         this._collection = await this._readTests();

--- a/lib/report-builder/gui.ts
+++ b/lib/report-builder/gui.ts
@@ -7,7 +7,7 @@ import {ReporterTestResult} from '../adapters/test-result';
 import {Tree, TreeImage} from '../tests-tree-builder/base';
 import {ImageInfoFull, ImageInfoWithState, ReporterConfig} from '../types';
 import {determineStatus, isUpdatedStatus} from '../common-utils';
-import {HtmlReporter, HtmlReporterValues} from '../plugin-api';
+import {HtmlReporterValues} from '../plugin-api';
 import {SkipItem} from '../tests-tree-builder/static';
 import {copyAndUpdate} from '../adapters/test-result/utils';
 
@@ -33,10 +33,10 @@ export class GuiReportBuilder extends StaticReportBuilder {
     private _skips: SkipItem[];
     private _apiValues?: HtmlReporterValues;
 
-    constructor(htmlReporter: HtmlReporter, pluginConfig: ReporterConfig, options: StaticReportBuilderOptions) {
-        super(htmlReporter, pluginConfig, options);
+    constructor(options: StaticReportBuilderOptions) {
+        super(options);
 
-        this._testsTree = GuiTestsTreeBuilder.create({toolName: ToolName.Testplane, baseHost: pluginConfig.baseHost});
+        this._testsTree = GuiTestsTreeBuilder.create({toolName: ToolName.Testplane, baseHost: this._reporterConfig.baseHost});
         this._skips = [];
     }
 
@@ -58,8 +58,8 @@ export class GuiReportBuilder extends StaticReportBuilder {
     }
 
     getResult(): GuiReportBuilderResult {
-        const {customGui} = this._pluginConfig;
-        const config = {...getConfigForStaticFile(this._pluginConfig), customGui};
+        const {customGui} = this._reporterConfig;
+        const config = {...getConfigForStaticFile(this._reporterConfig), customGui};
 
         this._testsTree.sortTree();
 

--- a/playwright.ts
+++ b/playwright.ts
@@ -55,7 +55,7 @@ class MyReporter implements Reporter {
                 reportPath: htmlReporter.config.path
             });
 
-            this._staticReportBuilder = StaticReportBuilder.create(htmlReporter, config, {dbClient, imagesInfoSaver});
+            this._staticReportBuilder = StaticReportBuilder.create({htmlReporter, reporterConfig: config, dbClient, imagesInfoSaver});
             this._staticReportBuilder.registerWorkers(workers);
 
             await this._staticReportBuilder.saveStaticFiles();

--- a/test/unit/lib/report-builder/gui.js
+++ b/test/unit/lib/report-builder/gui.js
@@ -21,9 +21,9 @@ describe('GuiReportBuilder', () => {
     const sandbox = sinon.sandbox.create();
     let hasImage, deleteFile, GuiReportBuilder, dbClient, copyAndUpdate, imagesInfoSaver;
 
-    const mkGuiReportBuilder_ = async ({toolConfig, pluginConfig} = {}) => {
+    const mkGuiReportBuilder_ = async ({toolConfig, reporterConfig} = {}) => {
         toolConfig = _.defaults(toolConfig || {}, {getAbsoluteUrl: _.noop});
-        pluginConfig = _.defaults(pluginConfig || {}, {baseHost: '', path: TEST_REPORT_PATH, baseTestPath: ''});
+        reporterConfig = _.defaults(reporterConfig || {}, {baseHost: '', path: TEST_REPORT_PATH, baseTestPath: ''});
 
         const htmlReporter = HtmlReporter.create({baseHost: ''});
 
@@ -39,7 +39,7 @@ describe('GuiReportBuilder', () => {
         imagesInfoSaver = sinon.createStubInstance(ImagesInfoSaver);
         imagesInfoSaver.save.callsFake(_.identity);
 
-        const reportBuilder = GuiReportBuilder.create(testplane.htmlReporter, pluginConfig, {dbClient, imagesInfoSaver});
+        const reportBuilder = GuiReportBuilder.create({htmlReporter: testplane.htmlReporter, reporterConfig, dbClient, imagesInfoSaver});
 
         const workers = {saveDiffTo: () => {}};
         reportBuilder.registerWorkers(workers);
@@ -226,7 +226,7 @@ describe('GuiReportBuilder', () => {
         });
 
         it('should add base host to result with value from plugin parameter "baseHost"', async () => {
-            const reportBuilder = await mkGuiReportBuilder_({pluginConfig: {baseHost: 'some-host'}});
+            const reportBuilder = await mkGuiReportBuilder_({reporterConfig: {baseHost: 'some-host'}});
 
             assert.equal(reportBuilder.getResult().config.baseHost, 'some-host');
         });

--- a/test/unit/lib/report-builder/static.js
+++ b/test/unit/lib/report-builder/static.js
@@ -34,8 +34,8 @@ describe('StaticReportBuilder', () => {
         './server-utils': utils
     });
 
-    const mkStaticReportBuilder_ = async ({pluginConfig} = {}) => {
-        pluginConfig = _.defaults(pluginConfig, {baseHost: '', path: TEST_REPORT_PATH, baseTestPath: ''});
+    const mkStaticReportBuilder_ = async ({reporterConfig} = {}) => {
+        reporterConfig = _.defaults(reporterConfig, {baseHost: '', path: TEST_REPORT_PATH, baseTestPath: ''});
 
         htmlReporter = _.extend(HtmlReporter.create({baseHost: ''}), {
             reportsSaver: {
@@ -49,7 +49,7 @@ describe('StaticReportBuilder', () => {
 
         imagesInfoSaver.save.callsFake(_.identity);
 
-        const reportBuilder = StaticReportBuilder.create(htmlReporter, pluginConfig, {dbClient, imagesInfoSaver});
+        const reportBuilder = StaticReportBuilder.create({htmlReporter, reporterConfig, dbClient, imagesInfoSaver});
         workers = {saveDiffTo: sinon.stub()};
 
         reportBuilder.registerWorkers(workers);
@@ -143,7 +143,7 @@ describe('StaticReportBuilder', () => {
 
         it('should not save error details if turned off', async () => {
             const reportBuilder = await mkStaticReportBuilder_({
-                pluginConfig: {saveErrorDetails: false, path: TEST_REPORT_PATH}
+                reporterConfig: {saveErrorDetails: false, path: TEST_REPORT_PATH}
             });
             const testResult = stubTest_({errorDetails: {filePath: 'some-path'}});
 
@@ -154,7 +154,7 @@ describe('StaticReportBuilder', () => {
 
         it('should use server-utils to save error details if needed', async () => {
             const reportBuilder = await mkStaticReportBuilder_({
-                pluginConfig: {saveErrorDetails: true, path: TEST_REPORT_PATH}
+                reporterConfig: {saveErrorDetails: true, path: TEST_REPORT_PATH}
             });
             const testResult = stubTest_({errorDetails: {filePath: 'some-path'}});
 

--- a/testplane.ts
+++ b/testplane.ts
@@ -73,7 +73,12 @@ export default (testplane: Testplane, opts: Partial<ReporterOptions>): void => {
             reportPath: htmlReporter.config.path
         });
 
-        staticReportBuilder = StaticReportBuilder.create(htmlReporter, config, {dbClient, imagesInfoSaver});
+        staticReportBuilder = StaticReportBuilder.create({
+            htmlReporter: toolAdapter.htmlReporter,
+            reporterConfig: config,
+            dbClient,
+            imagesInfoSaver
+        });
 
         handlingTestResults = Promise.all([
             staticReportBuilder.saveStaticFiles(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.common.json",
     "include": ["lib", "testplane.ts", "hermione.ts", "gemini.js", "playwright.ts"],
-    "exclude": ["lib/static",],
+    "exclude": ["lib/static", "lib/bundle"],
     "compilerOptions": {
         "outDir": "build",
     },


### PR DESCRIPTION
## What is done

- exclude "bundle" folder in tsconfig
- refactoring in report builders (just send one argument with all options)

There is nothing to review here, so I merge it without approve.