### PR TITLE
chore: use default title delimiter for all supported tools

### DIFF
--- a/lib/adapters/test-result/playwright.ts
+++ b/lib/adapters/test-result/playwright.ts
@@ -6,7 +6,7 @@ import stripAnsi from 'strip-ansi';
 
 import {ReporterTestResult} from './index';
 import {getError, getShortMD5, isImageDiffError, isNoRefImageError} from '../../common-utils';
-import {ERROR, FAIL, PWT_TITLE_DELIMITER, SUCCESS, TestStatus} from '../../constants';
+import {ERROR, FAIL, DEFAULT_TITLE_DELIMITER, SUCCESS, TestStatus} from '../../constants';
 import {ErrorName} from '../../errors';
 import {
     DiffOptions,
@@ -185,7 +185,7 @@ export class PlaywrightTestResultAdapter implements ReporterTestResult {
     }
 
     get fullName(): string {
-        return this.testPath.join(PWT_TITLE_DELIMITER);
+        return this.testPath.join(DEFAULT_TITLE_DELIMITER);
     }
 
     get history(): string[] {

--- a/lib/adapters/test-result/sqlite.ts
+++ b/lib/adapters/test-result/sqlite.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {DB_COLUMN_INDEXES, TestStatus} from '../../constants';
+import {DB_COLUMN_INDEXES, TestStatus, DEFAULT_TITLE_DELIMITER} from '../../constants';
 import {
     AssertViewResult,
     TestError,
@@ -21,19 +21,13 @@ const tryParseJson = (json: string): unknown | undefined => {
     }
 };
 
-interface SqliteTestResultAdapterOptions {
-    titleDelimiter: string;
-}
-
 export class SqliteTestResultAdapter implements ReporterTestResult {
     private _testResult: RawSuitesRow;
     private _parsedTestResult: Writable<Partial<ReporterTestResult>>;
-    private _titleDelimiter: string;
 
-    constructor(testResult: RawSuitesRow, attempt: number, options: SqliteTestResultAdapterOptions) {
+    constructor(testResult: RawSuitesRow, attempt: number) {
         this._testResult = testResult;
         this._parsedTestResult = {attempt};
-        this._titleDelimiter = options.titleDelimiter;
     }
 
     get assertViewResults(): AssertViewResult[] {
@@ -76,7 +70,7 @@ export class SqliteTestResultAdapter implements ReporterTestResult {
 
     get fullName(): string {
         if (!_.has(this._parsedTestResult, 'fullName')) {
-            this._parsedTestResult.fullName = this.testPath.join(this._titleDelimiter);
+            this._parsedTestResult.fullName = this.testPath.join(DEFAULT_TITLE_DELIMITER);
         }
 
         return this._parsedTestResult.fullName as string;

--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -5,14 +5,12 @@ import axios, {AxiosRequestConfig} from 'axios';
 import {
     ERROR,
     FAIL,
-    TESTPLANE_TITLE_DELIMITER,
-    IDLE, PWT_TITLE_DELIMITER,
+    IDLE,
     QUEUED,
     RUNNING,
     SKIPPED,
     SUCCESS,
     TestStatus,
-    ToolName,
     UPDATED
 } from './constants';
 
@@ -238,10 +236,6 @@ export const isCheckboxChecked = (status: number): boolean => Number(status) ===
 export const isCheckboxIndeterminate = (status: number): boolean => Number(status) === INDETERMINATE;
 export const isCheckboxUnchecked = (status: number): boolean => Number(status) === UNCHECKED;
 export const getToggledCheckboxState = (status: number): number => isCheckboxChecked(status) ? UNCHECKED : CHECKED;
-
-export const getTitleDelimiter = (toolName: ToolName): string => {
-    return toolName === ToolName.Playwright ? PWT_TITLE_DELIMITER : TESTPLANE_TITLE_DELIMITER;
-};
 
 export function getDetailsFileName(testId: string, browserId: string, attempt: number): string {
     return `${testId}-${browserId}_${Number(attempt) + 1}_${Date.now()}.json`;

--- a/lib/constants/tests.ts
+++ b/lib/constants/tests.ts
@@ -1,5 +1,5 @@
-export const TESTPLANE_TITLE_DELIMITER = ' ';
-
+export const DEFAULT_TITLE_DELIMITER = ' ';
+export const TESTPLANE_TITLE_DELIMITER = DEFAULT_TITLE_DELIMITER;
 export const PWT_TITLE_DELIMITER = ' › ';
 
 export const UNKNOWN_ATTEMPT = -1;

--- a/lib/db-utils/server.ts
+++ b/lib/db-utils/server.ts
@@ -9,7 +9,7 @@ import NestedError from 'nested-error-stacks';
 import {StaticTestsTreeBuilder} from '../tests-tree-builder/static';
 import * as commonSqliteUtils from './common';
 import {isUrl, fetchFile, normalizeUrls, logger} from '../common-utils';
-import {DATABASE_URLS_JSON_NAME, DB_COLUMNS, LOCAL_DATABASE_NAME, TestStatus, ToolName} from '../constants';
+import {DATABASE_URLS_JSON_NAME, DB_COLUMNS, LOCAL_DATABASE_NAME, TestStatus} from '../constants';
 import {DbLoadResult, HandleDatabasesOptions} from './common';
 import {DbUrlsJsonData, RawSuitesRow, ReporterConfig} from '../types';
 import {Tree} from '../tests-tree-builder/base';
@@ -57,10 +57,10 @@ export async function mergeDatabases(srcDbPaths: string[], reportPath: string): 
     }
 }
 
-export function getTestsTreeFromDatabase(toolName: ToolName, dbPath: string, baseHost: string): Tree {
+export function getTestsTreeFromDatabase(dbPath: string, baseHost: string): Tree {
     try {
         const db = new Database(dbPath, {readonly: true, fileMustExist: true});
-        const testsTreeBuilder = StaticTestsTreeBuilder.create({toolName, baseHost});
+        const testsTreeBuilder = StaticTestsTreeBuilder.create({baseHost});
 
         const suitesRows = (db.prepare(commonSqliteUtils.selectAllSuitesQuery())
             .raw()

--- a/lib/gui/tool-runner/index.ts
+++ b/lib/gui/tool-runner/index.ts
@@ -397,7 +397,7 @@ export class ToolRunner {
         const dbPath = path.resolve(this._reportPath, LOCAL_DATABASE_NAME);
 
         if (await fs.pathExists(dbPath)) {
-            return getTestsTreeFromDatabase(ToolName.Testplane, dbPath, this._reporterConfig.baseHost);
+            return getTestsTreeFromDatabase(dbPath, this._reporterConfig.baseHost);
         }
 
         logger.warn(chalk.yellow(`Nothing to reuse in ${this._reportPath}: can not load data from ${DATABASE_URLS_JSON_NAME}`));

--- a/lib/plugin-api.ts
+++ b/lib/plugin-api.ts
@@ -18,7 +18,7 @@ interface ReporterOptions {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ParametersExceptFirst<F> = F extends (arg0: any, ...rest: infer R) => any ? R : never;
+type Parameters<F> = F extends (...rest: infer R) => any ? R : never;
 
 export class HtmlReporter extends EventsEmitter2 {
     protected _config: ReporterConfig;
@@ -104,7 +104,7 @@ export class HtmlReporter extends EventsEmitter2 {
         return mergeDatabases(...args);
     }
 
-    getTestsTreeFromDatabase(...args: ParametersExceptFirst<typeof getTestsTreeFromDatabase>): ReturnType<typeof getTestsTreeFromDatabase> {
-        return getTestsTreeFromDatabase(this.values.toolName, ...args);
+    getTestsTreeFromDatabase(...args: Parameters<typeof getTestsTreeFromDatabase>): ReturnType<typeof getTestsTreeFromDatabase> {
+        return getTestsTreeFromDatabase(...args);
     }
 }

--- a/lib/report-builder/gui.ts
+++ b/lib/report-builder/gui.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {StaticReportBuilder, StaticReportBuilderOptions} from './static';
 import {GuiTestsTreeBuilder, TestBranch, TestEqualDiffsData, TestRefUpdateData} from '../tests-tree-builder/gui';
-import {UPDATED, DB_COLUMNS, ToolName, TestStatus, TESTPLANE_TITLE_DELIMITER, SKIPPED, SUCCESS} from '../constants';
+import {UPDATED, DB_COLUMNS, TestStatus, DEFAULT_TITLE_DELIMITER, SKIPPED, SUCCESS} from '../constants';
 import {ConfigForStaticFile, getConfigForStaticFile} from '../server-utils';
 import {ReporterTestResult} from '../adapters/test-result';
 import {Tree, TreeImage} from '../tests-tree-builder/base';
@@ -36,7 +36,7 @@ export class GuiReportBuilder extends StaticReportBuilder {
     constructor(options: StaticReportBuilderOptions) {
         super(options);
 
-        this._testsTree = GuiTestsTreeBuilder.create({toolName: ToolName.Testplane, baseHost: this._reporterConfig.baseHost});
+        this._testsTree = GuiTestsTreeBuilder.create({baseHost: this._reporterConfig.baseHost});
         this._skips = [];
     }
 
@@ -51,7 +51,7 @@ export class GuiReportBuilder extends StaticReportBuilder {
         // Fill test attempt manager with data from db
         for (const [, testResult] of Object.entries(tree.results.byId)) {
             this._testAttemptManager.registerAttempt({
-                fullName: testResult.suitePath.join(TESTPLANE_TITLE_DELIMITER),
+                fullName: testResult.suitePath.join(DEFAULT_TITLE_DELIMITER),
                 browserId: testResult.name
             }, testResult.status, testResult.attempt);
         }

--- a/lib/static/modules/actions.js
+++ b/lib/static/modules/actions.js
@@ -11,7 +11,6 @@ import {fetchDataFromDatabases, mergeDatabases, connectToDatabase, getMainDataba
 import {setFilteredBrowsers} from './query-params';
 import plugins from './plugins';
 import performanceMarks from '../../constants/performance-marks';
-import {ToolName} from '../../constants';
 
 export const createNotification = (id, status, message, props = {}) => {
     const notificationProps = {
@@ -92,8 +91,7 @@ export const initStaticReport = () => {
         await plugins.loadAll(dataFromStaticFile.config);
 
         performance?.mark?.(performanceMarks.PLUGINS_LOADED);
-        const {toolName = ToolName.Testplane} = dataFromStaticFile.apiValues;
-        const testsTreeBuilder = StaticTestsTreeBuilder.create({toolName});
+        const testsTreeBuilder = StaticTestsTreeBuilder.create();
 
         if (!db || isEmpty(fetchDbDetails)) {
             return dispatch({

--- a/lib/tests-tree-builder/base.ts
+++ b/lib/tests-tree-builder/base.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {determineFinalStatus} from '../common-utils';
-import {BrowserVersions, PWT_TITLE_DELIMITER, TESTPLANE_TITLE_DELIMITER, TestStatus, ToolName} from '../constants';
+import {BrowserVersions, DEFAULT_TITLE_DELIMITER, TestStatus} from '../constants';
 import {ReporterTestResult} from '../adapters/test-result';
 import {ErrorDetails, ImageInfoFull} from '../types';
 import {TreeTestResultTransformer} from '../adapters/test-result/transformers/tree';
@@ -81,13 +81,11 @@ interface ImagesPayload {
 }
 
 export interface BaseTestsTreeBuilderOptions {
-    toolName: ToolName;
-    baseHost: string;
+    baseHost?: string;
 }
 
 export class BaseTestsTreeBuilder {
     protected _tree: Tree;
-    protected _toolName: ToolName;
     protected _transformer: TreeTestResultTransformer;
 
     static create<T extends BaseTestsTreeBuilder>(
@@ -97,10 +95,8 @@ export class BaseTestsTreeBuilder {
         return new this(options);
     }
 
-    constructor({toolName, baseHost}: BaseTestsTreeBuilderOptions) {
-        this._toolName = toolName;
-
-        this._transformer = new TreeTestResultTransformer({baseHost});
+    constructor(options: BaseTestsTreeBuilderOptions = {}) {
+        this._transformer = new TreeTestResultTransformer(options);
 
         this._tree = {
             suites: {byId: {}, allIds: [], allRootIds: []},
@@ -150,9 +146,7 @@ export class BaseTestsTreeBuilder {
     }
 
     protected _buildId(parentId: string | string[] = [], name: string | string[] = []): string {
-        const delimiter = this._toolName === ToolName.Playwright ? PWT_TITLE_DELIMITER : TESTPLANE_TITLE_DELIMITER;
-
-        return ([] as string[]).concat(parentId, name).join(delimiter);
+        return ([] as string[]).concat(parentId, name).join(DEFAULT_TITLE_DELIMITER);
     }
 
     protected _addSuites(testPath: string[], browserId: string): void {

--- a/lib/tests-tree-builder/static.ts
+++ b/lib/tests-tree-builder/static.ts
@@ -3,7 +3,6 @@ import {BaseTestsTreeBuilder, BaseTestsTreeBuilderOptions, Tree} from './base';
 import {BrowserVersions, DB_COLUMN_INDEXES, TestStatus} from '../constants';
 import {ReporterTestResult} from '../adapters/test-result';
 import {SqliteTestResultAdapter} from '../adapters/test-result/sqlite';
-import {getTitleDelimiter} from '../common-utils';
 import {RawSuitesRow} from '../types';
 
 interface Stats {
@@ -70,7 +69,7 @@ export class StaticTestsTreeBuilder extends BaseTestsTreeBuilder {
             attemptsMap.set(browserId, attemptsMap.has(browserId) ? attemptsMap.get(browserId) as number + 1 : 0);
             const attempt = attemptsMap.get(browserId) as number;
 
-            const formattedResult = new SqliteTestResultAdapter(row, attempt, {titleDelimiter: getTitleDelimiter(this._toolName)});
+            const formattedResult = new SqliteTestResultAdapter(row, attempt);
 
             addBrowserVersion(browsers, formattedResult);
 

--- a/test/unit/lib/adapters/test-result/playwright.ts
+++ b/test/unit/lib/adapters/test-result/playwright.ts
@@ -141,7 +141,7 @@ describe('PlaywrightTestResultAdapter', () => {
         it('should return fullName', () => {
             const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
 
-            assert.strictEqual(adapter.fullName, 'describe › test');
+            assert.strictEqual(adapter.fullName, 'describe test');
         });
     });
 
@@ -170,7 +170,7 @@ describe('PlaywrightTestResultAdapter', () => {
         it('should return imageDir', () => {
             const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult(), UNKNOWN_ATTEMPT);
 
-            assert.strictEqual(adapter.imageDir, '4050de5');
+            assert.strictEqual(adapter.imageDir, '75bcb6c');
         });
     });
 


### PR DESCRIPTION
## What is done

- handle "uncaughtException" and "unhandledRejection" when using cli commands from html-reporter binary file
- use default title delimiter - " " (one space) for all supported tools. If tool used another title delimiter then it must modify it to default inside adapters. In the process of implementing support pwt in gui command I realized that it's easier to support (no need to send tool name in a bunch of files and call a special helper to get correct delimiter).