### PR TITLE
chore: move logic with change retries to testplane adapter

### DIFF
--- a/lib/adapters/config/index.ts
+++ b/lib/adapters/config/index.ts
@@ -1,15 +1,9 @@
 import {TestAdapter} from '../test';
 
-export interface BrowserConfigAdapter {
-    readonly id: string;
-    retry: number;
-}
-
 export interface ConfigAdapter {
     readonly tolerance: number;
     readonly antialiasingTolerance: number;
     readonly browserIds: string[];
 
-    getBrowserConfig(browserId: string): BrowserConfigAdapter;
     getScreenshotPath(test: TestAdapter, stateName: string): string;
 }

--- a/lib/adapters/tool/index.ts
+++ b/lib/adapters/tool/index.ts
@@ -31,6 +31,7 @@ export interface ToolAdapter {
     initGuiApi(): void;
     readTests(paths: string[], cliTool: CommanderStatic): Promise<TestCollectionAdapter>;
     run(testCollection: TestCollectionAdapter, tests: TestSpec[], cliTool: CommanderStatic): Promise<boolean>;
+    runWithoutRetries(testCollection: TestCollectionAdapter, tests: TestSpec[], cliTool: CommanderStatic): Promise<boolean>;
 
     updateReference(opts: UpdateReferenceOpts): void;
     handleTestResults(reportBuilder: GuiReportBuilder, eventSource: EventSource): void;

--- a/lib/gui/index.ts
+++ b/lib/gui/index.ts
@@ -6,7 +6,7 @@ import * as server from './server';
 import {logger} from '../common-utils';
 import * as utils from '../server-utils';
 
-import type {TestplaneToolAdapter} from '../adapters/tool/testplane';
+import type {ToolAdapter} from '../adapters/tool';
 
 const {logError} = utils;
 
@@ -19,7 +19,7 @@ export interface GuiCliOptions {
 
 export interface ServerArgs {
     paths: string[];
-    toolAdapter: TestplaneToolAdapter;
+    toolAdapter: ToolAdapter;
     cli: {
         options: GuiCliOptions;
         tool: CommanderStatic;

--- a/lib/gui/server.ts
+++ b/lib/gui/server.ts
@@ -12,6 +12,7 @@ import {initPluginsRoutes} from './routes/plugins';
 import {ServerArgs} from './index';
 import {ServerReadyData} from './api';
 import {ToolName} from '../constants';
+import type {TestplaneToolAdapter} from '../adapters/tool/testplane';
 
 export const start = async (args: ServerArgs): Promise<ServerReadyData> => {
     const {toolAdapter} = args;
@@ -49,7 +50,7 @@ export const start = async (args: ServerArgs): Promise<ServerReadyData> => {
     server.get('/init', async (_req, res) => {
         try {
             if (toolAdapter.toolName === ToolName.Testplane) {
-                await toolAdapter.initGuiHandler();
+                await (toolAdapter as TestplaneToolAdapter).initGuiHandler();
             }
 
             res.json(app.data);
@@ -83,7 +84,7 @@ export const start = async (args: ServerArgs): Promise<ServerReadyData> => {
     server.post('/run-custom-gui-action', async ({body: payload}, res) => {
         try {
             if (toolAdapter.toolName === ToolName.Testplane) {
-                await toolAdapter.runCustomGuiAction(payload);
+                await (toolAdapter as TestplaneToolAdapter).runCustomGuiAction(payload);
             }
 
             res.sendStatus(OK);

--- a/lib/gui/tool-runner/index.ts
+++ b/lib/gui/tool-runner/index.ts
@@ -320,8 +320,13 @@ export class ToolRunner {
 
     async run(tests: TestSpec[] = []): Promise<boolean> {
         const testCollection = this._ensureTestCollection();
+        const shouldRunAllTests = _.isEmpty(tests);
 
-        return this._toolAdapter.run(testCollection, tests, this._globalOpts);
+        // if tests are not passed, then run all tests with all available retries
+        // if tests are specified, then retry only passed tests without retries
+        return shouldRunAllTests
+            ? this._toolAdapter.run(testCollection, tests, this._globalOpts)
+            : this._toolAdapter.runWithoutRetries(testCollection, tests, this._globalOpts);
     }
 
     protected async _handleRunnableCollection(): Promise<void> {

--- a/test/unit/lib/gui/app.js
+++ b/test/unit/lib/gui/app.js
@@ -62,58 +62,13 @@ describe('lib/gui/app', () => {
     afterEach(() => sandbox.restore());
 
     describe('run', () => {
-        it('should run all tests with retries from config', async () => {
-            let retryBeforeRun;
-            toolRunner.run.callsFake(() => {
-                retryBeforeRun = tool.config.getBrowserConfig('bro1').retry;
-                return Promise.resolve();
-            });
+        it('should run passed tests', async () => {
+            const tests = [{testName: 'abc', browserName: 'yabro'}];
             const App_ = await mkApp_({tool});
 
-            return App_
-                .run()
-                .then(() => assert.equal(retryBeforeRun, 1));
-        });
+            await App_.run(tests);
 
-        it('should run specified tests with no retries', async () => {
-            let bro1RetryBeforeRun;
-            let bro2RetryBeforeRun;
-            toolRunner.run.callsFake(() => {
-                bro1RetryBeforeRun = tool.config.getBrowserConfig('bro1').retry;
-                bro2RetryBeforeRun = tool.config.getBrowserConfig('bro2').retry;
-                return Promise.resolve();
-            });
-            const App_ = await mkApp_({tool});
-
-            return App_
-                .run(['test'])
-                .then(() => {
-                    assert.equal(bro1RetryBeforeRun, 0);
-                    assert.equal(bro2RetryBeforeRun, 0);
-                });
-        });
-
-        it('should restore config retry values after run', async () => {
-            const App_ = await mkApp_({tool});
-
-            return App_
-                .run(['test'])
-                .then(() => {
-                    assert.equal(tool.config.getBrowserConfig('bro1').retry, 1);
-                    assert.equal(tool.config.getBrowserConfig('bro2').retry, 2);
-                });
-        });
-
-        it('should restore config retry values even after error', async () => {
-            await toolRunner.run.rejects();
-            const App_ = await mkApp_({tool});
-
-            return App_
-                .run(['test'])
-                .catch(() => {
-                    assert.equal(tool.config.getBrowserConfig('bro1').retry, 1);
-                    assert.equal(tool.config.getBrowserConfig('bro2').retry, 2);
-                });
+            assert.calledOnceWith(toolRunner.run, tests);
         });
     });
 

--- a/test/unit/lib/gui/tool-runner/index.js
+++ b/test/unit/lib/gui/tool-runner/index.js
@@ -536,18 +536,32 @@ describe('lib/gui/tool-runner/index', () => {
     });
 
     describe('run', () => {
-        it('should run tool with passed opts', async () => {
+        it('should call "run" tool method if tests are not passed', async () => {
             const cliTool = {grep: /some-grep/, set: 'some-set', browser: 'yabro', devtools: true};
-            const collection = {tests: []};
+            const tests = [];
+            const collection = {tests};
             toolAdapter.readTests.resolves(collection);
 
             const gui = initGuiReporter({toolAdapter, cli: {tool: cliTool, options: {}}});
-            const tests = [];
 
             await gui.initialize();
             await gui.run(tests);
 
             assert.calledOnceWith(toolAdapter.run, collection, tests, cliTool);
+        });
+
+        it('should call "runWithoutRetries" tool method if tests are not passed', async () => {
+            const cliTool = {grep: /some-grep/, set: 'some-set', browser: 'yabro', devtools: true};
+            const tests = [stubTest_()];
+            const collection = {tests: [mkTestAdapter_(tests[0])]};
+            toolAdapter.readTests.resolves(collection);
+
+            const gui = initGuiReporter({toolAdapter, cli: {tool: cliTool, options: {}}});
+
+            await gui.initialize();
+            await gui.run(tests);
+
+            assert.calledOnceWith(toolAdapter.runWithoutRetries, collection, tests, cliTool);
         });
     });
 

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -62,6 +62,7 @@ function stubToolAdapter({
         reporterConfig,
         htmlReporter: htmlReporter || sinon.createStubInstance(HtmlReporter),
         run: sinon.stub().resolves(false),
+        runWithoutRetries: sinon.stub().resolves(false),
         readTests: sinon.stub().resolves(testCollection),
         updateReference: sinon.stub(),
         handleTestResults: sinon.stub(),


### PR DESCRIPTION
## What is done

- move logic with run tests without retries from `lib/gui/app` to `lib/adapters/tool/testplane`. Because other tools should implement it by themself. 
- add method `runWithoutRetries` which must be implemented in each tool adapter.