### PR TITLE
feat: add "timestamp" field to redux storage

### DIFF
--- a/lib/report-builder/gui.ts
+++ b/lib/report-builder/gui.ts
@@ -24,8 +24,9 @@ export interface GuiReportBuilderResult {
     tree: Tree;
     skips: SkipItem[];
     config: ConfigForStaticFile & {customGui: ReporterConfig['customGui']};
-    date: string;
+    timestamp: number;
     apiValues?: HtmlReporterValues;
+    date: string;
 }
 
 export class GuiReportBuilder extends StaticReportBuilder {
@@ -62,13 +63,16 @@ export class GuiReportBuilder extends StaticReportBuilder {
         const config = {...getConfigForStaticFile(this._reporterConfig), customGui};
 
         this._testsTree.sortTree();
+        const timestamp = Date.now();
 
         return {
             tree: this._testsTree.tree,
             skips: this._skips,
             config,
-            date: new Date().toString(),
-            apiValues: this._apiValues
+            apiValues: this._apiValues,
+            timestamp,
+            // TODO: remove in next major (should use timestamp instead)
+            date: new Date(timestamp).toString()
         };
     }
 

--- a/lib/server-utils.ts
+++ b/lib/server-utils.ts
@@ -230,15 +230,20 @@ export interface DataForStaticFile {
     skips: object[];
     config: ConfigForStaticFile;
     apiValues: HtmlReporter['values'];
+    timestamp: number;
     date: string;
 }
 
 export function getDataForStaticFile(htmlReporter: HtmlReporter, pluginConfig: ReporterConfig): DataForStaticFile {
+    const timestamp = Date.now();
+
     return {
         skips: [],
         config: getConfigForStaticFile(pluginConfig),
         apiValues: htmlReporter.values,
-        date: new Date().toString()
+        timestamp,
+        // TODO: remove in next major (should use timestamp instead)
+        date: new Date(timestamp).toString()
     };
 }
 

--- a/lib/static/components/controls/report-info.jsx
+++ b/lib/static/components/controls/report-info.jsx
@@ -1,11 +1,14 @@
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
+import {Label} from '@gravity-ui/uikit';
+import {isEmpty} from 'lodash';
 import {version} from '../../../../package.json';
-import { Label } from '@gravity-ui/uikit';
 
 class ReportInfo extends Component {
     render() {
-        const {gui, date} = this.props;
+        const {gui, timestamp} = this.props;
+        const lang = isEmpty(navigator.languages) ? navigator.language : navigator.languages[0];
+        const date = new Date(timestamp).toLocaleString(lang);
 
         return (
             <div className="report-info">
@@ -23,5 +26,5 @@ class ReportInfo extends Component {
 }
 
 export default connect(
-    ({gui, date}) => ({gui, date})
+    ({gui, timestamp}) => ({gui, timestamp})
 )(ReportInfo);

--- a/lib/static/modules/reducers/index.js
+++ b/lib/static/modules/reducers/index.js
@@ -7,6 +7,7 @@ import running from './running';
 import processing from './processing';
 import loading from './loading';
 import gui from './gui';
+import timestamp from './timestamp';
 import date from './date';
 import autoRun from './auto-run';
 import apiValues from './api-values';
@@ -37,7 +38,8 @@ export default reduceReducers(
     stopping,
     loading,
     gui,
-    date,
+    timestamp,
+    date, // TODO: remove in next major (should use timestamp instead)
     autoRun,
     apiValues,
     modals,

--- a/lib/static/modules/reducers/timestamp.js
+++ b/lib/static/modules/reducers/timestamp.js
@@ -1,14 +1,12 @@
 import actionNames from '../action-names';
-import {dateToLocaleString} from '../utils';
 
-// TODO: remove in next major (should use timestamp instead)
 export default (state, action) => {
     switch (action.type) {
         case actionNames.INIT_GUI_REPORT:
         case actionNames.INIT_STATIC_REPORT: {
-            const {date} = action.payload;
+            const {timestamp} = action.payload;
 
-            return {...state, date: dateToLocaleString(date)};
+            return {...state, timestamp};
         }
 
         default:


### PR DESCRIPTION
## What is done:

- add "timestamp" field to redux storage in order to use from plugins
- filed "date" will be removed in next major version