### PR TITLE
fix: return correct test result status

### DIFF
--- a/lib/adapters/test-result/testplane.ts
+++ b/lib/adapters/test-result/testplane.ts
@@ -6,7 +6,7 @@ import {ValueOf} from 'type-fest';
 
 import {getCommandsHistory} from '../../history-utils';
 import {ERROR, FAIL, SUCCESS, TestStatus, UNKNOWN_SESSION_ID, UPDATED} from '../../constants';
-import {getError, hasFailedImages, isImageDiffError, isNoRefImageError, wrapLinkByTag} from '../../common-utils';
+import {getError, hasUnrelatedToScreenshotsErrors, isImageDiffError, isNoRefImageError, wrapLinkByTag} from '../../common-utils';
 import {
     ErrorDetails,
     TestplaneSuite,
@@ -32,7 +32,7 @@ export const getStatus = (eventName: ValueOf<Testplane['events']>, events: Testp
     } else if (eventName === events.TEST_PENDING) {
         return TestStatus.SKIPPED;
     } else if (eventName === events.RETRY || eventName === events.TEST_FAIL) {
-        return hasFailedImages(testResult.assertViewResults as ImageInfoFull[]) ? TestStatus.FAIL : TestStatus.ERROR;
+        return hasUnrelatedToScreenshotsErrors(testResult.err!) ? TestStatus.ERROR : TestStatus.FAIL;
     } else if (eventName === events.TEST_BEGIN) {
         return TestStatus.RUNNING;
     }

--- a/test/unit/lib/adapters/test-result/testplane.ts
+++ b/test/unit/lib/adapters/test-result/testplane.ts
@@ -6,13 +6,29 @@ import tmpOriginal from 'tmp';
 
 import {TestStatus} from 'lib/constants/test-statuses';
 import {ERROR_DETAILS_PATH} from 'lib/constants/paths';
-import {TestplaneTestResultAdapter, TestplaneTestResultAdapterOptions} from 'lib/adapters/test-result/testplane';
+import {TestplaneTestResultAdapter, TestplaneTestResultAdapterOptions, getStatus} from 'lib/adapters/test-result/testplane';
 import {TestplaneTestResult} from 'lib/types';
 import * as originalUtils from 'lib/server-utils';
 import * as originalCommonUtils from 'lib/common-utils';
 import * as originalTestAdapterUtils from 'lib/adapters/test-result/utils';
 
+import type Testplane from 'testplane';
 import type {ReporterTestResult} from 'lib/adapters/test-result';
+
+describe('getStatus', () => {
+    it('should be "error" if test has both: runtime errors and assertview fails', () => {
+        const status = getStatus(
+            'failTest',
+            {TEST_FAIL: 'failTest'} as Testplane['events'],
+            {
+                assertViewResults: [{}, {}],
+                err: {name: 'foo', message: 'bar'}
+            } as TestplaneTestResult
+        );
+
+        assert.equal(status, TestStatus.ERROR);
+    });
+});
 
 describe('TestplaneTestResultAdapter', () => {
     const sandbox = sinon.sandbox.create();


### PR DESCRIPTION
Now (test has failed status, and no error message is shown, though there was an error):
![image](https://github.com/user-attachments/assets/42896ea3-5c4e-4d70-b826-917a60f21f63)


After this PR (test has error status and error message is shown):
![image](https://github.com/user-attachments/assets/caf22d7a-c923-4d15-a37c-bf07a571055c)
