### PR TITLE
chore: use upstream node@22

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.4]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Switching to node 22.x as the bug with node 22.5 was fixed in 22.5.1