### PR TITLE
fix: undo accept image

### DIFF
--- a/lib/static/modules/reducers/tree/nodes/suites.js
+++ b/lib/static/modules/reducers/tree/nodes/suites.js
@@ -145,7 +145,7 @@ export function failSuites(tree, suiteIds, diff = tree) {
 
         if (!suite.parentId && !diff.suites.failedRootIds.includes(suite.id)) {
             diff.suites.failedRootIds.push(suite.id);
-        } else {
+        } else if (suite.parentId) {
             processingSuiteIds.push(suite.parentId);
         }
     }

--- a/test/unit/lib/static/modules/reducers/tree/index.js
+++ b/test/unit/lib/static/modules/reducers/tree/index.js
@@ -1877,6 +1877,18 @@ describe('lib/static/modules/reducers/tree', () => {
 
                 assert.equal(fourthState.tree.suites.byId['s1'].status, FAIL);
             });
+
+            it('should fail parent suites', () => {
+                state.tree.suites.byId['s0'].status = SUCCESS;
+                state.tree.suites.byId['s1'].status = SUCCESS;
+                state.tree.results.byId['r1'].status = STAGED;
+                state.tree.images.byId['i1'].status = STAGED;
+
+                const nextState = reducer(state, {type: actionNames.STATIC_ACCEPTER_UNSTAGE_SCREENSHOT, payload: {imageId: 'i1'}});
+
+                assert.equal(nextState.tree.suites.byId['s0'].status, FAIL);
+                assert.equal(nextState.tree.suites.byId['s1'].status, FAIL);
+            });
         });
     });
 });


### PR DESCRIPTION
`failSuites` function is used to fail parent suites after "undo"
In this PR, i added a check in order to not add parent "null" to our loop