### PR TITLE
fix: disable portal for header select elements

### DIFF
--- a/lib/static/components/controls/selects/control.jsx
+++ b/lib/static/components/controls/selects/control.jsx
@@ -44,6 +44,7 @@ export default class ControlSelect extends Component {
             <div className={className}>
                 <CustomLabel size='m' pin='round-brick'>{label}</CustomLabel>
                 <Select
+                    disablePortal
                     className={`select__dropdown-${size || 's'}`}
                     selection
                     options={options}

--- a/lib/static/components/controls/selects/group-tests.jsx
+++ b/lib/static/components/controls/selects/group-tests.jsx
@@ -45,6 +45,7 @@ class GroupTestsSelect extends Component {
             <div className={className}>
                 <CustomLabel size='m' pin='round-brick'>Group By</CustomLabel>
                 <Select
+                    disablePortal
                     className='group-by-dropdown'
                     options={options}
                     value={[selectedGroupKey]}


### PR DESCRIPTION
Fixes an issue when select dropdowns are positioned wrong when header is hidden

Test report: https://nda.ya.ru/t/R93-0jax77g2LS