### PR TITLE
fix: correctly build link to error details

### DIFF
--- a/lib/adapters/test-result/reporter.ts
+++ b/lib/adapters/test-result/reporter.ts
@@ -15,7 +15,7 @@ export class ReporterTestAdapter implements ReporterTestResult {
 
     constructor(testResult: ReporterTestResult) {
         this._testResult = testResult;
-        this._errorDetails = null;
+        this._errorDetails = this._testResult.errorDetails || null;
     }
 
     get attempt(): number {

--- a/lib/adapters/test-result/transformers/tree.ts
+++ b/lib/adapters/test-result/transformers/tree.ts
@@ -2,7 +2,6 @@ import {ReporterTestResult} from '../index';
 import _ from 'lodash';
 import {BaseTreeTestResult} from '../../../tests-tree-builder/base';
 import {DbTestResultTransformer} from './db';
-import {extractErrorDetails} from '../utils';
 
 interface Options {
     baseHost?: string;
@@ -21,7 +20,7 @@ export class TreeTestResultTransformer {
         return {
             ..._.omit(result, 'imagesInfo'),
             attempt: testResult.attempt,
-            errorDetails: extractErrorDetails(testResult)
+            errorDetails: testResult.errorDetails
         };
     }
 }


### PR DESCRIPTION
### What is done

It turned out that after refactoring, `extractErrorDetails` is called several times - https://github.com/gemini-testing/html-reporter/blob/v10.7.0/lib/adapters/test-result/utils/index.ts#L50-L64 which builds the path to the file and calls `Date.now()` inside it. As a result, each call generates a unique path. And one is used for link inside html-reporter and another for save file in folder.

Now we will use the already existing value.