### PR TITLE
fix(new-ui): use actual ids in selectors instead of fulltitle

### DIFF
--- a/lib/static/new-ui/features/suites/components/SuitesTreeView/selectors.ts
+++ b/lib/static/new-ui/features/suites/components/SuitesTreeView/selectors.ts
@@ -70,7 +70,7 @@ export const getTreeViewItems = createSelector(
                 diffImg
             };
 
-            if (!browsersState[data.fullTitle].shouldBeShown) {
+            if (!browsersState[browserData.id].shouldBeShown) {
                 return null;
             }
 
@@ -87,7 +87,7 @@ export const getTreeViewItems = createSelector(
                 status: suiteData.status
             };
 
-            if (!suitesState[data.fullTitle].shouldBeShown) {
+            if (!suitesState[suiteData.id].shouldBeShown) {
                 return null;
             }
 


### PR DESCRIPTION
⚠️ Only last commit needs review

Fixed a crash when full title differs from id