### PR TITLE
fix: fix large padding on top of test card when there is no describe

### DIFF
--- a/lib/static/new-ui/components/SuiteTitle/index.module.css
+++ b/lib/static/new-ui/components/SuiteTitle/index.module.css
@@ -26,7 +26,6 @@
 }
 
 .content {
-    margin-top: 8px;
     display: flex;
     flex-direction: column;
     row-gap: 8px;

--- a/lib/static/new-ui/components/SuiteTitle/index.tsx
+++ b/lib/static/new-ui/components/SuiteTitle/index.tsx
@@ -25,7 +25,7 @@ export function SuiteTitle(props: SuiteTitlePropsInternal): ReactNode {
 
     return <div className={classNames(styles.container, props.className)}>
         <div className={styles.content}>
-            <div className={classNames(styles.breadcrumbs)}>
+            {suitePath.length > 0 && <div className={classNames(styles.breadcrumbs)}>
                 {suitePath.map((item, index) => (
                     <div key={index} className={styles.breadcrumbsItem}>
                         {item}
@@ -35,7 +35,7 @@ export function SuiteTitle(props: SuiteTitlePropsInternal): ReactNode {
                             </div>}
                     </div>
                 ))}
-            </div>
+            </div>}
             <div className={styles.titleContainer}>
                 <h2 className={classNames('text-display-1')}>
                     {suiteName ?? 'Unknown Suite'}


### PR DESCRIPTION
When a test is not nested in any describe, heading has padding that's too large. This PR fixes that.

Test report: https://nda.ya.ru/t/ZH3rtNfr79sg3u