### PR TITLE
fix: add playwright visual checks results to correct steps in new ui

### DIFF
--- a/lib/static/new-ui/store/selectors.ts
+++ b/lib/static/new-ui/store/selectors.ts
@@ -9,6 +9,7 @@ import {
 } from '@/static/new-ui/types/store';
 import {EditScreensFeature, RunTestsFeature} from '@/constants';
 
+export const getToolName = (state: State): string => state.apiValues.toolName;
 export const getAllRootSuiteIds = (state: State): string[] => state.tree.suites.allRootIds;
 export const getAllRootGroupIds = (state: State): string[] => state.tree.groups.allRootIds;
 export const getGroups = (state: State): Record<string, GroupEntity> => state.tree.groups.byId;


### PR DESCRIPTION
Previously in pwt visual assertions were added as "assertView" commands at the end of the test. This PR makes it so that they are added to corresponding toMatchScreenshot commands.

Demo report: https://nda.ya.ru/t/jzvnUjB779sizC