### PR TITLE
fix: display skip reason in new ui

### DIFF
--- a/lib/adapters/test-result/testplane.ts
+++ b/lib/adapters/test-result/testplane.ts
@@ -10,8 +10,7 @@ import {
     hasUnrelatedToScreenshotsErrors,
     isImageDiffError,
     isInvalidRefImageError,
-    isNoRefImageError,
-    wrapLinkByTag
+    isNoRefImageError
 } from '../../common-utils';
 import {
     ErrorDetails,
@@ -50,7 +49,7 @@ const getSkipComment = (suite: TestplaneTestResult | TestplaneSuite): string | n
 };
 
 const wrapSkipComment = (skipComment: string | null | undefined): string => {
-    return skipComment ? wrapLinkByTag(skipComment) : 'Unknown reason';
+    return skipComment ?? 'Unknown reason';
 };
 
 const getHistory = (history?: TestplaneTestResult['history']): TestStepCompressed[] => {

--- a/lib/common-utils.ts
+++ b/lib/common-utils.ts
@@ -107,12 +107,6 @@ export const getRelativeUrl = (absoluteUrl: string): string => {
     }
 };
 
-export const wrapLinkByTag = (text: string): string => {
-    return text.replace(/https?:\/\/[^\s]*/g, (url) => {
-        return `<a target="_blank" href="${url}">${url}</a>`;
-    });
-};
-
 export const mkTestId = (fullTitle: string, browserId: string): string => {
     return fullTitle + '.' + browserId;
 };

--- a/lib/static/components/section/section-browser.jsx
+++ b/lib/static/components/section/section-browser.jsx
@@ -2,7 +2,6 @@ import React, {Fragment, useContext, useLayoutEffect} from 'react';
 import {last, isEmpty} from 'lodash';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import Parser from 'html-react-parser';
 import PropTypes from 'prop-types';
 import * as actions from '../../modules/actions';
 import BrowserTitle from './title/browser';
@@ -11,6 +10,7 @@ import Body from './body';
 import {isSkippedStatus} from '../../../common-utils';
 import {sectionStatusResolver} from './utils';
 import {MeasurementContext} from '../measurement-context';
+import {makeLinksClickable} from '@/static/new-ui/utils';
 
 function SectionBrowser(props) {
     const onToggleSection = () => {
@@ -24,7 +24,7 @@ function SectionBrowser(props) {
             <Fragment>
                 [skipped] {props.browser.name}
                 {skipReason && ', reason: '}
-                {skipReason && Parser(skipReason)}
+                {skipReason && makeLinksClickable(skipReason)}
             </Fragment>
         );
     };

--- a/lib/static/new-ui/components/AttemptPickerItem/index.module.css
+++ b/lib/static/new-ui/components/AttemptPickerItem/index.module.css
@@ -23,6 +23,13 @@
     --g-button-text-color-hover: hsl(208 88% 48% / 1);
 }
 
+.attempt-picker-item--skipped {
+    background-color: var(--g-color-private-black-50);
+    color: var(--g-color-private-black-600);
+    --box-shadow-color: var(--g-color-private-black-250);
+    --g-button-text-color-hover: var(--g-color-private-black-700);
+}
+
 .attempt-picker-item--success {
     --box-shadow-color: #21a95661;
 }

--- a/lib/static/new-ui/components/MetaInfo/index.tsx
+++ b/lib/static/new-ui/components/MetaInfo/index.tsx
@@ -10,6 +10,7 @@ import {ResultEntity, State} from '@/static/new-ui/types/store';
 import {HtmlReporterValues} from '@/plugin-api';
 import {ReporterConfig} from '@/types';
 import styles from './index.module.css';
+import Parser from 'html-react-parser';
 
 const serializeMetaValues = (metaInfo: Record<string, unknown>): Record<string, string> =>
     mapValues(metaInfo, (v): string => {
@@ -107,6 +108,23 @@ function MetaInfoInternal(props: MetaInfoInternalProps): ReactNode {
             content: getRelativeUrl(result.suiteUrl),
             url: getUrlWithBase(result.suiteUrl, baseHost)
         });
+    }
+
+    const shouldAddSkipReason = Boolean(!metaInfoItemsWithResolvedUrls.find(item => item.label === 'muteReason'));
+    if (result.skipReason && shouldAddSkipReason) {
+        const reason = Parser(result.skipReason);
+        if (typeof reason === 'string') {
+            metaInfoItemsWithResolvedUrls.push({
+                label: 'skipReason',
+                content: reason
+            });
+        } else if (!Array.isArray(reason) && typeof reason.props.children === 'string' && typeof reason.props.href === 'string') {
+            metaInfoItemsWithResolvedUrls.push({
+                label: 'skipReason',
+                content: reason.props.children,
+                url: reason.props.href
+            });
+        }
     }
 
     return <DefinitionList className={styles.metaInfo} qa={props.qa} items={

--- a/lib/static/new-ui/features/suites/components/SuitesPage/types.ts
+++ b/lib/static/new-ui/features/suites/components/SuitesPage/types.ts
@@ -19,6 +19,7 @@ export interface TreeViewItemData {
     errorStack?: string;
     images?: ImageEntity[];
     parentData?: TreeViewItemData;
+    skipReason?: string;
 }
 
 export interface TreeRoot {

--- a/lib/static/new-ui/features/suites/components/SuitesTreeView/index.module.css
+++ b/lib/static/new-ui/features/suites/components/SuitesTreeView/index.module.css
@@ -57,6 +57,8 @@
             color: #fff !important;
             /* Sets spinner color */
             --g-color-line-brand: #fff;
+            --color-link: #fff;
+            --color-link-hover: rgba(255, 255, 255, 0.6);
         }
 
         .tree-view__item__title--current {

--- a/lib/static/new-ui/features/suites/components/SuitesTreeView/selectors.ts
+++ b/lib/static/new-ui/features/suites/components/SuitesTreeView/selectors.ts
@@ -66,7 +66,8 @@ export const getTreeViewItems = createSelector(
                 images: resultImages,
                 errorTitle,
                 errorStack,
-                parentData
+                parentData,
+                skipReason: lastResult.skipReason
             };
         };
 

--- a/lib/static/new-ui/features/suites/components/TestSteps/index.tsx
+++ b/lib/static/new-ui/features/suites/components/TestSteps/index.tsx
@@ -32,6 +32,10 @@ interface TestStepsProps {
 }
 
 function TestStepsInternal(props: TestStepsProps): ReactNode {
+    if (props.testSteps.length === 0) {
+        return null;
+    }
+
     const items = useList({
         items: props.testSteps,
         withExpandedState: true,

--- a/lib/static/new-ui/features/suites/components/TreeViewItemSubtitle/index.module.css
+++ b/lib/static/new-ui/features/suites/components/TreeViewItemSubtitle/index.module.css
@@ -20,3 +20,21 @@
     font-size: 15px;
     word-break: break-word;
 }
+
+.skip-reason-container {
+    font-size: 15px;
+    overflow: hidden;
+}
+
+.skip-reason {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.skip-reason-container a:link, .skip-reason-container a:visited {
+    color: var(--color-link);
+}
+
+.skip-reason-container a:hover {
+    color: var(--color-link-hover);
+}

--- a/lib/static/new-ui/features/suites/components/TreeViewItemSubtitle/index.tsx
+++ b/lib/static/new-ui/features/suites/components/TreeViewItemSubtitle/index.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, {ReactNode} from 'react';
 import stripAnsi from 'strip-ansi';
+import Parser from 'html-react-parser';
 
 import {TreeViewItemData} from '@/static/new-ui/features/suites/components/SuitesPage/types';
 import {ImageWithMagnifier} from '@/static/new-ui/components/ImageWithMagnifier';
@@ -16,7 +17,11 @@ interface TreeViewItemSubtitleProps {
 }
 
 export function TreeViewItemSubtitle(props: TreeViewItemSubtitleProps): ReactNode {
-    if (props.item.images?.length) {
+    if (props.item.skipReason) {
+        return <div className={styles.skipReasonContainer}>
+            <div className={styles.skipReason}>Skipped ⋅ {Parser(props.item.skipReason)}</div>
+        </div>;
+    } else if (props.item.images?.length) {
         return <div>
             {props.item.images.map((imageEntity, index) => {
                 const image = (imageEntity as ImageEntityFail).diffImg ?? (imageEntity as ImageEntityFail).actualImg;

--- a/lib/static/new-ui/features/suites/components/TreeViewItemSubtitle/index.tsx
+++ b/lib/static/new-ui/features/suites/components/TreeViewItemSubtitle/index.tsx
@@ -1,13 +1,13 @@
 import classNames from 'classnames';
 import React, {ReactNode} from 'react';
 import stripAnsi from 'strip-ansi';
-import Parser from 'html-react-parser';
 
 import {TreeViewItemData} from '@/static/new-ui/features/suites/components/SuitesPage/types';
 import {ImageWithMagnifier} from '@/static/new-ui/components/ImageWithMagnifier';
 import {ImageEntityFail} from '@/static/new-ui/types/store';
 import styles from './index.module.css';
 import {getAssertViewStatusMessage} from '@/static/new-ui/utils/assert-view-status';
+import {makeLinksClickable} from '@/static/new-ui/utils';
 
 interface TreeViewItemSubtitleProps {
     item: TreeViewItemData;
@@ -19,7 +19,7 @@ interface TreeViewItemSubtitleProps {
 export function TreeViewItemSubtitle(props: TreeViewItemSubtitleProps): ReactNode {
     if (props.item.skipReason) {
         return <div className={styles.skipReasonContainer}>
-            <div className={styles.skipReason}>Skipped ⋅ {Parser(props.item.skipReason)}</div>
+            <div className={styles.skipReason}>Skipped ⋅ {makeLinksClickable(props.item.skipReason)}</div>
         </div>;
     } else if (props.item.images?.length) {
         return <div>

--- a/lib/static/new-ui/types/store.ts
+++ b/lib/static/new-ui/types/store.ts
@@ -70,6 +70,7 @@ export interface ResultEntityCommon {
     suitePath: string[];
     /** @note Browser Name/ID, e.g. `chrome-desktop` */
     name: string;
+    skipReason?: string;
 }
 
 export interface ResultEntityError extends ResultEntityCommon {

--- a/lib/static/new-ui/utils/index.tsx
+++ b/lib/static/new-ui/utils/index.tsx
@@ -8,7 +8,7 @@ import {
     CloudCheck
 } from '@gravity-ui/icons';
 import {Spin} from '@gravity-ui/uikit';
-import React from 'react';
+import React, {ReactNode} from 'react';
 
 import {TestStatus} from '@/constants';
 import {ImageFile} from '@/types';
@@ -34,12 +34,6 @@ export const getIconByStatus = (status: TestStatus): React.JSX.Element => {
     return <CircleDashed />;
 };
 
-export const getFullTitleByTitleParts = (titleParts: string[]): string => {
-    const DELIMITER = ' ';
-
-    return titleParts.join(DELIMITER).trim();
-};
-
 export const getImageDisplayedSize = (image: ImageFile): string => `${image.size.width}×${image.size.height}`;
 
 export const stringify = (value: unknown): string => {
@@ -60,4 +54,36 @@ export const stringify = (value: unknown): string => {
     }
 
     return toString(value);
+};
+
+export const makeLinksClickable = (text: string): React.JSX.Element => {
+    const urlRegex = /https?:\/\/[^\s]*/g;
+
+    const parts = text.split(urlRegex);
+    const urls = text.match(urlRegex) || [];
+
+    return <>{
+        parts.reduce((elements, part, index) => {
+            elements.push(part);
+
+            if (urls[index]) {
+                const href = urls[index].startsWith('www.')
+                    ? `http://${urls[index]}`
+                    : urls[index];
+
+                elements.push(
+                    <a
+                        key={index}
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {urls[index]}
+                    </a>
+                );
+            }
+
+            return elements;
+        }, [] as ReactNode[])
+    }</>;
 };


### PR DESCRIPTION
### What's done:
- Skip reason is now displayed as part of preview in tree view in new ui
- Skip reason is displayed in meta when possible

Demo report: https://nda.ya.ru/t/Ba_4zPC979ttwt