### PR TITLE
fix(gitignore): remove icons folder from gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ sqlite.db
 /lib/static/*.svg
 /lib/static/data.js
 /lib/static/images
-/lib/static/icons
 /lib/static/gui.html
 /lib/static/index.html
 /lib/static/sql-wasm.js


### PR DESCRIPTION
Убрал директорию с иконками из под гитигнора, там хранятся исходные файлы, которые должны быть закоммичены.

Если в этой директории также могут находиться файлы, которые не должны попасть в репозиторий, их следует хранить отдельно от постоянных файлов.