### PR TITLE
Ignore puppeteer TargetCloseError errors

### DIFF
--- a/lib/cli/index.ts
+++ b/lib/cli/index.ts
@@ -6,6 +6,7 @@ import pkg from '../../package.json';
 import {ToolName} from '../constants';
 import {makeToolAdapter, type ToolAdapter} from '../adapters/tool';
 import {logger} from '../common-utils';
+import {shouldIgnoreUnhandledRejection} from '../errors/utils/should-ignore-errors';
 
 export const commands = {
     GUI: 'gui',
@@ -21,6 +22,11 @@ process.on('uncaughtException', err => {
 });
 
 process.on('unhandledRejection', (reason, p) => {
+    if (shouldIgnoreUnhandledRejection(reason as Error)) {
+        logger.warn(`Unhandled Rejection "${reason}" in html-reporter:${process.pid} was ignored`);
+        return;
+    }
+
     const error = new Error([
         `Unhandled Rejection in ${toolAdapter ? toolAdapter.toolName + ':' : ''}${process.pid}:`,
         `Promise: ${JSON.stringify(p)}`,

--- a/lib/errors/utils/should-ignore-errors.ts
+++ b/lib/errors/utils/should-ignore-errors.ts
@@ -1,0 +1,17 @@
+const puppeteerErrMsgs = [/Cannot extract value when objectId is given/, /Execution context was destroyed/];
+
+export const shouldIgnoreUnhandledRejection = (err: Error | undefined): boolean => {
+    if (!err) {
+        return false;
+    }
+
+    if (err.name === "ProtocolError" || err.name === "TargetCloseError") {
+        return true;
+    }
+
+    if (puppeteerErrMsgs.some(msg => msg.test(err.message)) && err.stack?.includes("/puppeteer-core/")) {
+        return true;
+    }
+
+    return false;
+};


### PR DESCRIPTION
По мотивам https://t.me/testplane/1223 создан ПР с игнорированием ошибок puppeteer, как в самом Testplane