### PR TITLE
fix(merge-reports): ability to merge reports locally

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,7 @@ hot
 /lib/static/*.min.js
 /lib/static/data.js
 /lib/static/sql-wasm.js
+/@
 /test/func/**/report
 /test/func/**/report-backup
 /test/func/**/reports

--- a/lib/adapters/event-handling/testplane/snapshots.ts
+++ b/lib/adapters/event-handling/testplane/snapshots.ts
@@ -33,12 +33,13 @@ interface CreateSnapshotFilePathParams {
     attempt: number;
     hash: string;
     browserId: string;
+    timestamp: number;
 }
 
-export function createSnapshotFilePath({attempt: attemptInput, hash, browserId}: CreateSnapshotFilePathParams): string {
+export function createSnapshotFilePath({attempt: attemptInput, hash, browserId, timestamp}: CreateSnapshotFilePathParams): string {
     const attempt: number = attemptInput || 0;
-    const imageDir = _.compact([SNAPSHOTS_PATH, hash]);
-    const components = imageDir.concat(`${browserId}_${attempt}.zip`);
+    const snapshotDir = _.compact([SNAPSHOTS_PATH, hash]);
+    const components = snapshotDir.concat(`${browserId}_${timestamp}_${attempt}.zip`);
 
     return path.join(...components);
 }
@@ -141,7 +142,8 @@ export const finalizeSnapshotsForTest = async ({testResult, attempt, reportPath,
         const zipFilePath = createSnapshotFilePath({
             attempt,
             hash: testResult.imageDir,
-            browserId: testResult.browserId
+            browserId: testResult.browserId,
+            timestamp: testResult.timestamp
         });
         const absoluteZipFilePath = path.resolve(reportPath, zipFilePath);
         await fsExtra.ensureDir(path.dirname(absoluteZipFilePath));

--- a/lib/adapters/test-result/index.ts
+++ b/lib/adapters/test-result/index.ts
@@ -22,7 +22,7 @@ export interface ReporterTestResult {
     readonly status: TestStatus;
     readonly testPath: string[];
     /** Test start timestamp in ms */
-    readonly timestamp: number | undefined;
+    readonly timestamp: number;
     readonly url?: string;
     /** Test duration in ms */
     readonly duration: number;

--- a/lib/adapters/test-result/playwright.ts
+++ b/lib/adapters/test-result/playwright.ts
@@ -350,7 +350,7 @@ export class PlaywrightTestResultAdapter implements ReporterTestResult {
         return this._testCase.titlePath().slice(3);
     }
 
-    get timestamp(): number | undefined {
+    get timestamp(): number {
         return this._testResult.startTime.getTime();
     }
 

--- a/lib/adapters/test-result/reporter.ts
+++ b/lib/adapters/test-result/reporter.ts
@@ -108,7 +108,7 @@ export class ReporterTestAdapter implements ReporterTestResult {
         return this._testResult.testPath;
     }
 
-    get timestamp(): number | undefined {
+    get timestamp(): number {
         return this._testResult.timestamp;
     }
 

--- a/lib/adapters/test-result/sqlite.ts
+++ b/lib/adapters/test-result/sqlite.ts
@@ -144,7 +144,7 @@ export class SqliteTestResultAdapter implements ReporterTestResult {
         return this._parsedTestResult.testPath as string[];
     }
 
-    get timestamp(): number | undefined {
+    get timestamp(): number {
         return Number(this._testResult[DB_COLUMN_INDEXES.timestamp]);
     }
 

--- a/lib/adapters/test-result/testplane.ts
+++ b/lib/adapters/test-result/testplane.ts
@@ -258,7 +258,7 @@ export class TestplaneTestResultAdapter implements ReporterTestResult {
         return true;
     }
 
-    get timestamp(): number | undefined {
+    get timestamp(): number {
         return this._timestamp;
     }
 

--- a/lib/cli/commands/merge-reports.js
+++ b/lib/cli/commands/merge-reports.js
@@ -3,13 +3,10 @@
 const {commands} = require('..');
 const mergeReports = require('../../merge-reports');
 const {logError} = require('../../server-utils');
-const {ToolName} = require('../../constants');
 
 const {MERGE_REPORTS: commandName} = commands;
 
 module.exports = (program, toolAdapter) => {
-    const {toolName} = toolAdapter;
-
     program
         .command(`${commandName} [paths...]`)
         .allowUnknownOption()
@@ -17,10 +14,6 @@ module.exports = (program, toolAdapter) => {
         .option('-d, --destination <destination>', 'path to directory with merged report', toolAdapter.reporterConfig.path)
         .option('-h, --header <header>', 'http header for databaseUrls.json files from source paths', collect, [])
         .action(async (paths, options) => {
-            if (toolName !== ToolName.Testplane) {
-                throw new Error(`CLI command "${commandName}" supports only "${ToolName.Testplane}" tool`);
-            }
-
             try {
                 const {destination: destPath, header: headers} = options;
 

--- a/lib/constants/database.ts
+++ b/lib/constants/database.ts
@@ -67,3 +67,5 @@ export const DB_COLUMN_INDEXES = SUITES_TABLE_COLUMNS.reduce((acc: Record<string
     acc[name] = index;
     return acc;
 }, {}) as unknown as DbColumnIndexes;
+
+export const DB_FILE_EXTENSION = '.db';

--- a/lib/db-utils/server.ts
+++ b/lib/db-utils/server.ts
@@ -18,7 +18,11 @@ import {SqliteClient} from '../sqlite-client';
 
 export * from './common';
 
-export const prepareUrls = (urls: string[], baseUrl: string): string[] => isUrl(baseUrl) ? normalizeUrls(urls, baseUrl) : urls;
+export const prepareUrls = (urls: string[], baseUrl: string): string[] => {
+    return isUrl(baseUrl)
+        ? normalizeUrls(urls, baseUrl)
+        : urls.map(u => isUrl(u) ? u : path.join(path.parse(baseUrl).dir, u));
+};
 
 export async function downloadDatabases(dbJsonUrls: string[], opts: HandleDatabasesOptions): Promise<(string | DbLoadResult)[]> {
     const loadDbJsonUrl = async (dbJsonUrl: string): Promise<{data: DbUrlsJsonData | null}> => {

--- a/lib/merge-reports/index.js
+++ b/lib/merge-reports/index.js
@@ -1,12 +1,19 @@
 'use strict';
 
+const url = require('url');
+const urljoin = require('url-join');
+const path = require('path');
+const fs = require('fs-extra');
 const axios = require('axios');
 const _ = require('lodash');
+
 const serverUtils = require('../server-utils');
+const {isUrl, logger} = require('../common-utils');
 const dbServerUtils = require('../db-utils/server');
+const {DB_FILE_EXTENSION, IMAGES_PATH, SNAPSHOTS_PATH, ERROR_DETAILS_PATH, DATABASE_URLS_JSON_NAME, LOCAL_DATABASE_NAME} = require('../constants');
 
 module.exports = async (toolAdapter, srcPaths, {destPath, headers}) => {
-    validateOpts({srcPaths, destPath, headers});
+    await validateOpts({srcPaths, destPath, headers});
 
     let headersFromEnv;
     const {htmlReporter, reporterConfig} = toolAdapter;
@@ -24,22 +31,79 @@ module.exports = async (toolAdapter, srcPaths, {destPath, headers}) => {
     const parsedHeaders = {...headersFromCli, ...headersFromEnv};
 
     const resolvedUrls = await tryResolveUrls(srcPaths, parsedHeaders);
+    const resolvedDbFiles = resolvedUrls.filter(serverUtils.isDbFile);
+
+    const {true: remoteDbUrls = [], false: localDbPaths = []} = _.groupBy(resolvedDbFiles, isUrl);
+    const dbPaths = localDbPaths.map((db, ind, arr) => {
+        const dbName = arr.length > 1 ? genUniqDbName(db, ind + 1) : path.basename(db);
+        return {src: path.resolve(process.cwd(), db), dest: path.resolve(destPath, dbName)};
+    });
+
+    const allDbPaths = [...remoteDbUrls, ...dbPaths.map(({dest}) => path.parse(dest).base)];
+    const copyFilePromises = [];
+
+    if (!_.isEmpty(localDbPaths)) {
+        const srcReportPaths = _.uniq(localDbPaths.map(db => path.resolve(process.cwd(), path.parse(db).dir)));
+
+        copyFilePromises.push(...[
+            copyDbFiles(dbPaths),
+            copyArtifacts({srcPaths: srcReportPaths, destPath, folderName: IMAGES_PATH}),
+            copyArtifacts({srcPaths: srcReportPaths, destPath, folderName: SNAPSHOTS_PATH}),
+            copyArtifacts({srcPaths: srcReportPaths, destPath, folderName: ERROR_DETAILS_PATH})
+        ]);
+    }
 
     await Promise.all([
         serverUtils.saveStaticFilesToReportDir(htmlReporter, reporterConfig, destPath),
-        serverUtils.writeDatabaseUrlsFile(destPath, resolvedUrls)
+        serverUtils.writeDatabaseUrlsFile(destPath, allDbPaths),
+        ...copyFilePromises
     ]);
 
     await htmlReporter.emitAsync(htmlReporter.events.REPORT_SAVED, {reportPath: destPath});
 };
 
-function validateOpts({srcPaths, destPath, headers}) {
+async function validateOpts({srcPaths, destPath, headers}) {
     if (!srcPaths.length) {
         throw new Error('Nothing to merge, no source reports are passed');
     }
 
+    if (srcPaths.length === 1) {
+        throw new Error(`Nothing to merge, only one source report is passed: ${srcPaths[0]}`);
+    }
+
     if (srcPaths.includes(destPath)) {
         throw new Error(`Destination report path: ${destPath}, exists in source report paths`);
+    }
+
+    for (const srcPath of srcPaths) {
+        if (isUrl(srcPath)) {
+            continue;
+        }
+
+        let srcPathStat;
+
+        try {
+            srcPathStat = await fs.stat(srcPath);
+        } catch (err) {
+            if (err.code !== 'ENOENT') {
+                throw err;
+            } else {
+                throw new Error(`Specified source path: ${srcPath} doesn't exists on file system`);
+            }
+        }
+
+        if (srcPathStat.isDirectory()) {
+            const dbUrlsJsonPath = path.join(srcPath, DATABASE_URLS_JSON_NAME);
+            const isDbUrlsJsonPathExists = await fs.pathExists(dbUrlsJsonPath);
+
+            if (!isDbUrlsJsonPathExists) {
+                throw new Error(`${DATABASE_URLS_JSON_NAME} doesn't exist in specified source path: ${srcPath}`);
+            }
+        } else {
+            if (!srcPath.endsWith(DATABASE_URLS_JSON_NAME) && !srcPath.endsWith(LOCAL_DATABASE_NAME)) {
+                throw new Error(`Specified source path: ${srcPath} must ends with ${DATABASE_URLS_JSON_NAME} or ${LOCAL_DATABASE_NAME}`);
+            }
+        }
     }
 
     for (const header of headers) {
@@ -51,7 +115,15 @@ function validateOpts({srcPaths, destPath, headers}) {
 
 async function tryResolveUrls(urls, headers) {
     const resolvedUrls = [];
-    const results = await Promise.all(urls.map(url => tryResolveUrl(url, headers)));
+    const results = await Promise.all(urls.map(async u => {
+        const extName = path.extname(isUrl(u) ? url.parse(u).pathname : u);
+
+        if (!extName) {
+            u = isUrl(u) ? urljoin(u, DATABASE_URLS_JSON_NAME) : path.join(u, DATABASE_URLS_JSON_NAME);
+        }
+
+        return tryResolveUrl(u, headers);
+    }));
 
     results.forEach(({jsonUrls, dbUrls}) => {
         resolvedUrls.push(...jsonUrls.concat(dbUrls));
@@ -64,11 +136,14 @@ async function tryResolveUrl(url, headers) {
     const jsonUrls = [];
     const dbUrls = [];
 
-    if (serverUtils.isDbUrl(url)) {
+    if (serverUtils.isDbFile(url)) {
         dbUrls.push(url);
     } else if (serverUtils.isJsonUrl(url)) {
         try {
-            const {data} = await axios.get(url, {headers});
+            const data = isUrl(url)
+                ? (await axios.get(url, {headers})).data
+                : await fs.readJSON(url);
+
             const currentDbUrls = _.get(data, 'dbUrls', []);
             const currentJsonUrls = _.get(data, 'jsonUrls', []);
 
@@ -84,9 +159,32 @@ async function tryResolveUrl(url, headers) {
                 jsonUrls.push(...response.jsonUrls);
             });
         } catch (e) {
+            logger.warn(`Failed to handle ${url}: ${e.message}`);
             jsonUrls.push(url);
         }
     }
 
     return {jsonUrls, dbUrls};
+}
+
+function genUniqDbName(dbPath, num) {
+    return `${path.basename(dbPath, DB_FILE_EXTENSION)}_${num}${DB_FILE_EXTENSION}`;
+}
+
+async function copyDbFiles(dbPaths) {
+    await Promise.all(dbPaths.map(({src, dest}) => fs.copy(src, dest)));
+}
+
+async function copyArtifacts({srcPaths, destPath, folderName}) {
+    for (const reportPath of srcPaths) {
+        const src = path.resolve(reportPath, folderName);
+        const dest = path.resolve(destPath, folderName);
+
+        const exists = await fs.pathExists(src);
+        if (!exists) {
+            continue;
+        }
+
+        await fs.copy(src, dest, {recursive: true, overwrite: false});
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "signal-exit": "^4.1.0",
         "strip-ansi": "^6.0.1",
         "tmp": "^0.1.0",
+        "url-join": "^4.0.1",
         "worker-farm": "^1.7.0",
         "yazl": "^3.3.1"
       },
@@ -31168,8 +31169,7 @@
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
@@ -57128,8 +57128,7 @@
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "url-parse": {
       "version": "1.5.10",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "signal-exit": "^4.1.0",
     "strip-ansi": "^6.0.1",
     "tmp": "^0.1.0",
+    "url-join": "^4.0.1",
     "worker-farm": "^1.7.0",
     "yazl": "^3.3.1"
   },

--- a/test/unit/lib/server-utils.js
+++ b/test/unit/lib/server-utils.js
@@ -29,35 +29,38 @@ describe('server-utils', () => {
                 const test = {
                     imageDir: 'some/dir',
                     browserId: 'bro',
-                    attempt: 2
+                    attempt: 2,
+                    timestamp: Date.now()
                 };
 
                 const resultPath = utils[`get${testData.name}Path`](test);
 
-                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_2.png`));
+                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_${test.timestamp}_2.png`));
             });
 
             it('should add default attempt if it does not exist from test', () => {
                 const test = {
                     imageDir: 'some/dir',
-                    browserId: 'bro'
+                    browserId: 'bro',
+                    timestamp: Date.now()
                 };
 
                 const resultPath = utils[`get${testData.name}Path`](test);
 
-                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_0.png`));
+                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_${test.timestamp}_0.png`));
             });
 
             it('should add state name to the path if it was passed', () => {
                 const test = {
                     imageDir: 'some/dir',
-                    browserId: 'bro'
+                    browserId: 'bro',
+                    timestamp: Date.now()
                 };
                 const stateName = 'plain';
 
                 const resultPath = utils[`get${testData.name}Path`](test, stateName);
 
-                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `plain/bro~${testData.prefix}_0.png`));
+                assert.equal(resultPath, path.join(IMAGES_PATH, 'some', 'dir', `plain/bro~${testData.prefix}_${test.timestamp}_0.png`));
             });
         });
 
@@ -69,23 +72,25 @@ describe('server-utils', () => {
             it('should generate correct absolute path for test image', () => {
                 const test = {
                     imageDir: 'some/dir',
-                    browserId: 'bro'
+                    browserId: 'bro',
+                    timestamp: Date.now()
                 };
 
                 const resultPath = utils[`get${testData.name}AbsolutePath`](test, 'reportPath');
 
-                assert.equal(resultPath, path.join('/root', 'reportPath', IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_0.png`));
+                assert.equal(resultPath, path.join('/root', 'reportPath', IMAGES_PATH, 'some', 'dir', `bro~${testData.prefix}_${test.timestamp}_0.png`));
             });
 
             it('should add state name to the path if it was passed', () => {
                 const test = {
                     imageDir: 'some/dir',
-                    browserId: 'bro'
+                    browserId: 'bro',
+                    timestamp: Date.now()
                 };
 
                 const resultPath = utils[`get${testData.name}AbsolutePath`](test, 'reportPath', 'plain');
 
-                assert.equal(resultPath, path.join('/root', 'reportPath', IMAGES_PATH, 'some', 'dir', 'plain', `bro~${testData.prefix}_0.png`));
+                assert.equal(resultPath, path.join('/root', 'reportPath', IMAGES_PATH, 'some', 'dir', 'plain', `bro~${testData.prefix}_${test.timestamp}_0.png`));
             });
         });
     });
@@ -202,10 +207,9 @@ describe('server-utils', () => {
             assert.calledOnceWith(fs.writeJson, '/foobar/databaseUrls.json', {dbUrls: [], jsonUrls: []});
         });
 
-        it('should not write invalid urls', () => {
+        it('should not write invalid urls', async () => {
             const destPath = '/foo';
             const srcPaths = [
-                null,
                 '',
                 'foo',
                 'foo.bar',
@@ -213,7 +217,7 @@ describe('server-utils', () => {
                 'http://foo.bar/baz.bar?test=stub'
             ];
 
-            utils.writeDatabaseUrlsFile(destPath, srcPaths);
+            await utils.writeDatabaseUrlsFile(destPath, srcPaths);
 
             assert.calledOnceWith(fs.writeJson, sinon.match.any, {dbUrls: [], jsonUrls: []});
         });


### PR DESCRIPTION
### What is done

Previously, merge reports only worked with urls on `databaseUrls.json` and `sqlite.db`. If user send path to these files on file system merge was complete successfully but in merged report the tests were not displayed.

So in this PR I fix this behaviour and now merge reports correctly work with files on fs.

What can be improved: ability to path just a folder.