### PR TITLE
chore: use /test forlder in npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 .*
-test
+/test
 hot
 lib/static/js/
 lib/static/report.css


### PR DESCRIPTION
the directory `test` was lost form `adapters` folder when I published new version to npm