### PR TITLE
fix: fix compatibility with older testplane versions and stop writing invalid warnings

### DIFF
--- a/lib/adapters/event-handling/testplane/snapshots.ts
+++ b/lib/adapters/event-handling/testplane/snapshots.ts
@@ -83,13 +83,14 @@ export const finalizeSnapshotsForTest = async ({testResult, attempt, reportPath,
 
         delete snapshotsInProgress[hash];
 
-        if (!snapshots || snapshots.length === 0) {
-            console.warn(`No snapshots found for test hash: ${hash}`);
+        // Here we only check LastFailedRun, because in case of Off, we wouldn't even be here. LastFailedRun is the only case when we may want to not save snapshots.
+        const shouldSave = RecordMode && recordConfig && (recordConfig.mode !== RecordMode.LastFailedRun || (eventName === events.TEST_FAIL));
+        if (!shouldSave) {
             return [];
         }
 
-        const shouldSave = RecordMode && (recordConfig.mode !== RecordMode.LastFailedRun || (eventName === events.TEST_FAIL));
-        if (!shouldSave) {
+        if (!snapshots || snapshots.length === 0) {
+            console.warn(`No snapshots found for test hash: ${hash}`);
             return [];
         }
 

--- a/lib/adapters/tool/testplane/index.ts
+++ b/lib/adapters/tool/testplane/index.ts
@@ -110,7 +110,7 @@ export class TestplaneToolAdapter implements ToolAdapter {
         for (const browserConfig of this._browserConfigs) {
             const features: BrowserFeature[] = [];
 
-            if (browserConfig.record.mode === RecordMode.On) {
+            if (RecordMode && browserConfig.record && browserConfig.record.mode === RecordMode.On) {
                 features.push(BrowserFeature.LiveSnapshotsStreaming);
             }
 


### PR DESCRIPTION
Tested on testplane v8.22.1