### PR TITLE
fix: fix copying test name to clipboard

### DIFF
--- a/lib/static/components/section/title/browser.jsx
+++ b/lib/static/components/section/title/browser.jsx
@@ -10,33 +10,8 @@ import {EXPAND_ALL} from '../../../../constants/expand-modes';
 import {getToggledCheckboxState} from '../../../../common-utils';
 import ViewInBrowserIcon from '../../icons/view-in-browser';
 import Bullet from '../../bullet';
-import {ActionTooltip, Button, CopyToClipboard} from '@gravity-ui/uikit';
+import {ClipboardButton} from '../../../new-ui/components/ClipboardButton';
 import {ArrowShapeTurnUpRight} from '@gravity-ui/icons';
-
-const ShareButtonComponent = ({status, ...rest}) => {
-    return (
-        <ActionTooltip
-            title={status === 'success' ? 'Copied' : 'Copy test link'}
-        >
-            <Button
-                size='s'
-                view='flat'
-                extraProps={{
-                    'aria-label': 'Copy test link'
-                }}
-                {...rest}
-            >
-                <Button.Icon>
-                    <ArrowShapeTurnUpRight width={16} height={16}/>
-                </Button.Icon>
-            </Button>
-        </ActionTooltip>
-    );
-};
-
-ShareButtonComponent.propTypes = {
-    status: PropTypes.string.isRequired
-};
 
 const BrowserTitle = (props) => {
     const testUrl = React.useMemo(() => {
@@ -52,8 +27,6 @@ const BrowserTitle = (props) => {
 
     const onCopyTestLink = (e) => {
         e.stopPropagation();
-
-        props.actions.copyTestLink();
     };
 
     const onToggleCheckbox = (e) => {
@@ -70,9 +43,12 @@ const BrowserTitle = (props) => {
             <Bullet status={props.checkStatus} onClick={onToggleCheckbox} />
             {props.title}
             <ViewInBrowserIcon resultId={props.lastResultId}/>
-            <CopyToClipboard text={testUrl} timeout={1000}>
-                {(status) => <ShareButtonComponent onClick={onCopyTestLink} status={status}/>}
-            </CopyToClipboard>
+            <ClipboardButton
+                text={testUrl}
+                title="copy test link"
+                icon={<ArrowShapeTurnUpRight width={16} height={16}/>}
+                onClick={onCopyTestLink}
+            />
         </div>
     );
 };

--- a/lib/static/components/section/title/simple.jsx
+++ b/lib/static/components/section/title/simple.jsx
@@ -8,17 +8,12 @@ import * as actions from '../../../modules/actions';
 import {mkGetTestsBySuiteId} from '../../../modules/selectors/tree';
 import {getToggledCheckboxState} from '../../../../common-utils';
 import Bullet from '../../bullet';
-import {Button, ClipboardButton, Spin} from '@gravity-ui/uikit';
+import {Button, Spin} from '@gravity-ui/uikit';
 import {ArrowRotateLeft} from '@gravity-ui/icons';
 import {TestStatus} from '../../../../constants';
+import {ClipboardButton} from '../../../new-ui/components/ClipboardButton';
 
 const SectionTitle = ({name, suiteId, handler, gui, checkStatus, suiteTests, actions, running, runningThis}) => {
-    const onCopySuiteName = (e) => {
-        e.stopPropagation();
-
-        actions.copySuiteName(suiteId);
-    };
-
     const onSuiteRetry = (e) => {
         e.stopPropagation();
 
@@ -34,12 +29,15 @@ const SectionTitle = ({name, suiteId, handler, gui, checkStatus, suiteTests, act
         });
     };
 
+    const onCopyButtonClick = (e) => {
+        e.stopPropagation();
+    };
+
     const drawCopyButton = () => (
         <ClipboardButton
             size='s'
-            onClick={onCopySuiteName}
-            title="copy to clipboard"
-            text={suiteId}>
+            text={suiteId}
+            onClick={onCopyButtonClick}>
         </ClipboardButton>
     );
 

--- a/lib/static/new-ui/components/ClipboardButton/index.tsx
+++ b/lib/static/new-ui/components/ClipboardButton/index.tsx
@@ -1,0 +1,89 @@
+import React, {useState, useCallback, useRef} from 'react';
+import {Button, ClipboardIcon} from '@gravity-ui/uikit';
+import type {ButtonButtonProps} from '@gravity-ui/uikit';
+
+export interface ClipboardButtonProps extends Omit<ButtonButtonProps, 'children'> {
+    text: string;
+    icon?: React.ReactNode;
+}
+
+type CopyStatus = 'pending' | 'success' | 'error';
+
+// TODO: Use gravity-ui/uikit/ClipboardButton when https://github.com/gravity-ui/uikit/issues/2298 is fixed
+export const ClipboardButton: React.FC<ClipboardButtonProps> = ({
+    text,
+    icon,
+    size = 's',
+    view = 'flat',
+    title = 'Copy to clipboard',
+    onClick,
+    ...buttonProps
+}) => {
+    const [status, setStatus] = useState<CopyStatus>('pending');
+    const timeoutRef = useRef<NodeJS.Timeout>();
+
+    const copyToClipboard = useCallback((textToCopy: string): boolean => {
+        try {
+            const input = document.createElement('input');
+            input.style.position = 'fixed';
+            input.style.left = '-9999px';
+            input.value = textToCopy;
+
+            document.body.appendChild(input);
+            input.select();
+            input.setSelectionRange(0, 99999);
+
+            const success = document.execCommand('copy');
+            document.body.removeChild(input);
+
+            return success;
+        } catch (error) {
+            console.error('Failed to copy text: ', error);
+            return false;
+        }
+    }, []);
+
+    const handleClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+        const success = copyToClipboard(text);
+
+        if (success) {
+            setStatus('success');
+
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+
+            timeoutRef.current = setTimeout(() => {
+                setStatus('pending');
+            }, 1000);
+        } else {
+            setStatus('error');
+
+            setTimeout(() => {
+                setStatus('pending');
+            }, 1000);
+        }
+
+        onClick?.(event);
+    }, [text, onClick, copyToClipboard]);
+
+    React.useEffect(() => {
+        return () => {
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+        };
+    }, []);
+
+    return <Button
+        size={size}
+        view={view}
+        title={title}
+        onClick={handleClick}
+        {...buttonProps}
+    >
+        <Button.Icon>
+            {icon || <ClipboardIcon status={status} />}
+        </Button.Icon>
+    </Button>;
+};

--- a/test/unit/lib/static/components/section/title/browser.jsx
+++ b/test/unit/lib/static/components/section/title/browser.jsx
@@ -91,22 +91,6 @@ describe('<BrowserTitle/>', () => {
     });
 
     describe('<ClipboardButton/>', () => {
-        it('should call action "onCopyTestLink" on click', async () => {
-            window.prompt = sinon.stub();
-            const user = userEvent.setup();
-
-            const browsersById = mkBrowser({id: 'yabro', name: 'yabro', resultIds: ['default_res']});
-            const resultsById = mkResult({id: 'default_res', status: SUCCESS, skipReason: 'some-reason'});
-            const browsersStateById = {'yabro': {checkStatus: UNCHECKED}};
-            const tree = mkStateTree({browsersById, resultsById, browsersStateById});
-
-            const component = mkBrowserTitleComponent({browserId: 'yabro'}, {tree});
-            await user.click(component.queryByRole('button'));
-
-            assert.calledOnce(actionsStub.copyTestLink);
-            assert.calledWithExactly(actionsStub.copyTestLink);
-        });
-
         it('should call "appendQuery" with correct arguments', () => {
             const browsersById = mkBrowser({id: 'yabro', name: 'yabro', parentId: 'test'});
             const resultsById = mkResult({id: 'default_res', status: SUCCESS, skipReason: 'some-reason'});


### PR DESCRIPTION
Gravity UI currently has this issue: https://github.com/gravity-ui/uikit/issues/2298 that prevents copying anything on pages served over http. This PR fixes that by implementing our custom component.