### PR TITLE
fix: fix scroll issues in old ui

### DIFF
--- a/lib/static/modules/middlewares/local-storage.js
+++ b/lib/static/modules/middlewares/local-storage.js
@@ -25,6 +25,7 @@ function shouldUpdateLocalStorage(actionType) {
         || [
             actionNames.INIT_GUI_REPORT,
             actionNames.INIT_STATIC_REPORT,
-            actionNames.CHANGE_VIEW_MODE
+            actionNames.CHANGE_VIEW_MODE,
+            actionNames.SET_DIFF_MODE
         ].includes(actionType);
 }

--- a/lib/static/new-ui/components/DiffViewer/ListMode.module.css
+++ b/lib/static/new-ui/components/DiffViewer/ListMode.module.css
@@ -2,3 +2,9 @@
     display: flex;
     flex-direction: column;
 }
+
+.image-container {
+    display: flex;
+    aspect-ratio: var(--natural-width) / var(--natural-height);
+    max-height: calc(var(--natural-height) * 1px);
+}

--- a/lib/static/new-ui/components/DiffViewer/ListMode.tsx
+++ b/lib/static/new-ui/components/DiffViewer/ListMode.tsx
@@ -14,15 +14,15 @@ export function ListMode(props: SideBySideToFitModeProps): ReactNode {
     return <div className={styles.listMode}>
         <div>
             {props.expected.label}
-            <Screenshot image={props.expected} />
+            <Screenshot image={props.expected} containerClassName={styles.imageContainer}/>
         </div>
         <div>
             {props.actual.label}
-            <Screenshot image={props.actual} />
+            <Screenshot image={props.actual} containerClassName={styles.imageContainer}/>
         </div>
         <div>
             {props.diff.label}
-            <Screenshot image={props.diff} diffClusters={props.diff.diffClusters}/>
+            <Screenshot image={props.diff} diffClusters={props.diff.diffClusters} containerClassName={styles.imageContainer}/>
         </div>
     </div>;
 }

--- a/lib/static/new-ui/components/DiffViewer/SideBySideMode.module.css
+++ b/lib/static/new-ui/components/DiffViewer/SideBySideMode.module.css
@@ -9,3 +9,8 @@
     display: flex;
     flex-direction: column;
 }
+
+.image-container {
+    aspect-ratio: var(--natural-width) / var(--natural-height);
+    max-height: calc(var(--natural-height)* 1px);
+}

--- a/lib/static/new-ui/components/DiffViewer/SideBySideMode.tsx
+++ b/lib/static/new-ui/components/DiffViewer/SideBySideMode.tsx
@@ -17,15 +17,15 @@ export function SideBySideMode(props: SideBySideToFitModeProps): ReactNode {
     return <div className={styles.sideBySideMode}>
         <div className={styles.imageWrapper} style={getImageSizeCssVars(expected.size)}>
             {expected.label}
-            <Screenshot image={expected} />
+            <Screenshot image={expected} containerClassName={styles.imageContainer} />
         </div>
         <div className={styles.imageWrapper} style={getImageSizeCssVars(actual.size)}>
             {actual.label}
-            <Screenshot image={actual}/>
+            <Screenshot image={actual} containerClassName={styles.imageContainer} />
         </div>
         <div className={styles.imageWrapper} style={getImageSizeCssVars(diff.size)}>
             {diff.label}
-            <Screenshot image={diff} diffClusters={diff.diffClusters}/>
+            <Screenshot image={diff} diffClusters={diff.diffClusters} containerClassName={styles.imageContainer} />
         </div>
     </div>;
 }

--- a/lib/static/new-ui/components/DiffViewer/SideBySideToFitMode.module.css
+++ b/lib/static/new-ui/components/DiffViewer/SideBySideToFitMode.module.css
@@ -11,7 +11,15 @@
 }
 
 .image {
-    max-height: max(var(--desired-height), calc(var(--natural-height) * 1px / 2));
+    max-height: min(
+        max(var(--desired-height), calc(var(--natural-height) * 1px / 2)),
+        calc(var(--natural-height) * 1px)
+    );
     width: var(--img-width);
     height: var(--img-height);
+}
+
+.image-container {
+    aspect-ratio: var(--natural-width) / var(--natural-height);
+    max-height: max(var(--desired-height), calc(var(--natural-height) * 1px / 2));
 }

--- a/lib/static/new-ui/components/DiffViewer/SideBySideToFitMode.tsx
+++ b/lib/static/new-ui/components/DiffViewer/SideBySideToFitMode.tsx
@@ -22,15 +22,15 @@ export function SideBySideToFitMode(props: SideBySideToFitModeProps): ReactNode 
     return <div className={styles.sideBySideToFitMode} style={{'--desired-height': props.desiredHeight} as React.CSSProperties}>
         <div className={styles.imageWrapper} style={getImageSizeCssVars(expected.size)}>
             {expected.label}
-            <Screenshot imageClassName={styles.image} image={expected} />
+            <Screenshot imageClassName={styles.image} image={expected} containerClassName={styles.imageContainer} />
         </div>
         <div className={styles.imageWrapper} style={getImageSizeCssVars(actual.size)}>
             {actual.label}
-            <Screenshot imageClassName={styles.image} image={actual} />
+            <Screenshot imageClassName={styles.image} image={actual} containerClassName={styles.imageContainer} />
         </div>
         <div className={styles.imageWrapper} style={getImageSizeCssVars(diff.size)}>
             {diff.label}
-            <Screenshot imageClassName={styles.image} image={diff} diffClusters={diff.diffClusters}/>
+            <Screenshot imageClassName={styles.image} image={diff} diffClusters={diff.diffClusters} containerClassName={styles.imageContainer} />
         </div>
     </div>;
 }

--- a/lib/static/new-ui/components/Screenshot/index.module.css
+++ b/lib/static/new-ui/components/Screenshot/index.module.css
@@ -10,6 +10,5 @@
 .image {
     aspect-ratio: var(--natural-width) / var(--natural-height);
     max-width: calc(min(var(--natural-width) * 1px, 100%));
-    width: 100%;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
 }

--- a/lib/static/new-ui/components/Screenshot/index.tsx
+++ b/lib/static/new-ui/components/Screenshot/index.tsx
@@ -68,7 +68,7 @@ export const Screenshot = forwardRef<HTMLImageElement, ScreenshotProps>(function
     const imageClassName = classNames(styles.image, props.imageClassName);
     const imageStyle: React.CSSProperties = Object.assign({}, props.style);
     if (image.size) {
-        imageStyle.aspectRatio = `${image.size.width} / ${image.size.height} auto`;
+        imageStyle.aspectRatio = `${image.size.width} / ${image.size.height}`;
     }
 
     let diffCircles: ReactNode[] = [];


### PR DESCRIPTION
### What's done?

This PR fixes scroll issues in old ui, by making diff viewer size more deterministic. The issue was that in certain cases when image is not loaded, size wasn't computed correctly.

Demo reports coming soon.