### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
     <a href="https://testplane.io"><img src="https://img.shields.io/badge/Docs-Website-6c47ff" alt="Total Downloads"></a>
     <a href="https://www.npmjs.com/package/html-reporter"><img src="https://img.shields.io/npm/dt/html-reporter.svg" alt="Total Downloads"></a>
+    <a href="https://dependents.info/gemini-testing/html-reporter"><img src="https://dependents.info/gemini-testing/html-reporter/badge" alt="Network Dependents" /></a>
     <a href="https://github.com/gemini-testing/html-reporter/releases"><img src="https://img.shields.io/npm/v/html-reporter.svg" alt="Latest Release"></a>
     <a href="https://github.com/gemini-testing/html-reporter/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/html-reporter.svg" alt="License"></a>
     <a href="https://t.me/testplane"><img src="https://img.shields.io/badge/community-chat-blue?logo=telegram" alt="Community Chat"></a>
@@ -21,6 +22,12 @@
 <br/>
 
 `html-reporter` or, as we also call it, Testplane UI — is an open-source project that can be used to view test results or interact with tools like [Testplane](https://testplane.io), [Playwright](https://playwright.dev/) or [Jest](https://jestjs.io/).
+
+## Used by
+
+<a href="https://dependents.info/gemini-testing/html-reporter">
+  <img src="https://dependents.info/gemini-testing/html-reporter/image" alt="Users Image" />
+</a>
 
 ## Features
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="692" alt="image" src="https://github.com/user-attachments/assets/215a2388-1086-4bcb-b6ed-91bd3c9a5f79" />

Please feel free to close the PR if you don't want to have this!