### PR TITLE
feat(move-button): button for fast move between visual checks and suites

### DIFF
--- a/lib/static/modules/reducers/suites-page.ts
+++ b/lib/static/modules/reducers/suites-page.ts
@@ -2,7 +2,7 @@ import {Page, State} from '@/static/new-ui/types/store';
 import actionNames from '@/static/modules/action-names';
 import {applyStateUpdate} from '@/static/modules/utils/state';
 import {SomeAction} from '@/static/modules/actions/types';
-import {getSuitesThreeViewData} from '@/static/new-ui/features/suites/components/SuitesPage/selectors';
+import {getSuitesTreeViewData} from '@/static/new-ui/features/suites/components/SuitesPage/selectors';
 import {findTreeNodeByBrowserId, findTreeNodeById, getGroupId} from '@/static/new-ui/features/suites/utils';
 import * as localStorageWrapper from '../local-storage-wrapper';
 import {MIN_SECTION_SIZE_PERCENT} from '@/static/new-ui/features/suites/constants';
@@ -21,7 +21,7 @@ export default (state: State, action: SomeAction): State => {
         case actionNames.SUITES_PAGE_SET_TREE_VIEW_MODE:
         case actionNames.CHANGE_VIEW_MODE as any: // eslint-disable-line @typescript-eslint/no-explicit-any
         case actionNames.GROUP_TESTS_SET_CURRENT_EXPRESSION: {
-            const {allTreeNodeIds} = getSuitesThreeViewData(state);
+            const {allTreeNodeIds} = getSuitesTreeViewData(state);
 
             const expandedTreeNodesById: Record<string, boolean> = Object.assign({}, state.ui.suitesPage.expandedTreeNodesById);
 
@@ -35,7 +35,7 @@ export default (state: State, action: SomeAction): State => {
             if (action.type === actionNames.GROUP_TESTS_SET_CURRENT_EXPRESSION || action.type === actionNames.SUITES_PAGE_SET_TREE_VIEW_MODE) {
                 const {currentBrowserId} = state.app.suitesPage;
                 if (currentBrowserId) {
-                    const {tree} = getSuitesThreeViewData(state);
+                    const {tree} = getSuitesTreeViewData(state);
                     const browserTreeViewData = findTreeNodeByBrowserId(tree, currentBrowserId);
                     currentTreeNodeId = browserTreeViewData?.id;
                     if (browserTreeViewData) {
@@ -152,7 +152,7 @@ export default (state: State, action: SomeAction): State => {
             }) as State;
         }
         case actionNames.SUITES_PAGE_REVEAL_TREE_NODE: {
-            const {tree} = getSuitesThreeViewData(state);
+            const {tree} = getSuitesTreeViewData(state);
             let nodeData = findTreeNodeById(tree, action.payload.nodeId);
             const newExpandedTreeNodesById: Record<string, boolean> = {};
 

--- a/lib/static/new-ui/app/App.tsx
+++ b/lib/static/new-ui/app/App.tsx
@@ -28,14 +28,14 @@ export function App(): ReactNode {
             url: '/suites',
             icon: ListCheck,
             element: <SuitesPage/>,
-            children: [<Route key={'suite'} path=':suiteId' element={<SuitesPage/>} />]
+            children: [<Route key={'suite'} path='/suites/:suiteId?/:stateName?/:attempt?' element={<SuitesPage/>} />]
         },
         {
             title: 'Visual Checks',
             url: '/visual-checks',
             icon: Eye,
             element: <VisualChecksPage/>,
-            children: [<Route key={'image'} path=':imageId' element={<VisualChecksPage/>} />]
+            children: [<Route key={'image'} path='/visual-checks/:imageId?/:attempt?' element={<VisualChecksPage/>} />]
         }
     ];
 

--- a/lib/static/new-ui/components/CompactAttemptPicker/index.tsx
+++ b/lib/static/new-ui/components/CompactAttemptPicker/index.tsx
@@ -40,30 +40,32 @@ export function CompactAttemptPicker(): ReactNode {
         return null;
     }
 
-    return <div className={styles.container}>
-        <Button view={'outlined'} onClick={onPreviousClick} disabled={currentAttemptIndex === 0}><Icon data={ChevronLeft}/></Button>
-        <Select renderControl={({triggerProps: {onClick, onKeyDown}, ref}): React.JSX.Element => {
-            return <Button className={styles.attemptSelect} onClick={onClick} onKeyDown={onKeyDown} ref={ref as Ref<HTMLButtonElement>} view={'flat'}>
-                Attempt <span className={styles.attemptNumber}>
-                    {currentAttemptIndex !== null ? currentAttemptIndex + 1 : '–'}
-                </span> of <span className={styles.attemptNumber}>{totalAttemptsCount ?? '–'}</span>
-            </Button>;
-        }}
-        renderOption={(option): React.JSX.Element => {
-            const attemptStatus = resultsById[option.data.resultId].status;
-            return <div className={styles.attemptOption}>
-                {getIconByStatus(attemptStatus)}
-                <span>{option.content}</span>
-            </div>;
-        }} popupClassName={styles.attemptSelectPopup}
-        onUpdate={onUpdate}
-        >
-            {currentBrowser.resultIds.map((resultId, index) => {
-                return <Select.Option key={index} value={index.toString()} content={`Attempt #${index + 1}`} data={{resultId}}></Select.Option>;
-            })}
-        </Select>
-        <Button view={'outlined'} onClick={onNextClick} disabled={totalAttemptsCount === null || currentAttemptIndex === totalAttemptsCount - 1}>
-            <Icon data={ChevronRight}/>
-        </Button>
-    </div>;
+    return (
+        <div className={styles.container}>
+            <Button view={'outlined'} onClick={onPreviousClick} disabled={currentAttemptIndex === 0}><Icon data={ChevronLeft}/></Button>
+            <Select
+                renderControl={({triggerProps: {onClick, onKeyDown}, ref}): React.JSX.Element => (
+                    <Button className={styles.attemptSelect} onClick={onClick} onKeyDown={onKeyDown} ref={ref as Ref<HTMLButtonElement>} view={'flat'}>
+                        Attempt <span className={styles.attemptNumber}>
+                            {currentAttemptIndex !== null ? currentAttemptIndex + 1 : '–'}
+                        </span> of <span className={styles.attemptNumber}>{totalAttemptsCount ?? '–'}</span>
+                    </Button>
+                )}
+                renderOption={(option): React.JSX.Element => (
+                    <div className={styles.attemptOption}>
+                        {getIconByStatus(resultsById[option.data.resultId].status)}
+                        <span>{option.content}</span>
+                    </div>
+                )} popupClassName={styles.attemptSelectPopup}
+                onUpdate={onUpdate}
+            >
+                {currentBrowser.resultIds.map((resultId, index) => (
+                    <Select.Option key={index} value={index.toString()} content={`Attempt #${index + 1}`} data={{resultId}}></Select.Option>
+                ))}
+            </Select>
+            <Button view={'outlined'} onClick={onNextClick} disabled={totalAttemptsCount === null || currentAttemptIndex === totalAttemptsCount - 1}>
+                <Icon data={ChevronRight}/>
+            </Button>
+        </div>
+    );
 }

--- a/lib/static/new-ui/components/TreeActionsToolbar/index.tsx
+++ b/lib/static/new-ui/components/TreeActionsToolbar/index.tsx
@@ -41,7 +41,7 @@ import {
 } from '@/static/new-ui/store/selectors';
 import {isAcceptable, isScreenRevertable} from '@/static/modules/utils';
 import {EditScreensFeature, RunTestsFeature} from '@/constants';
-import {getSuitesThreeViewData} from '@/static/new-ui/features/suites/components/SuitesPage/selectors';
+import {getSuitesTreeViewData} from '@/static/new-ui/features/suites/components/SuitesPage/selectors';
 import {GroupBySelect} from '@/static/new-ui/features/suites/components/GroupBySelect';
 import {SortBySelect} from '@/static/new-ui/features/suites/components/SortBySelect';
 import {thunkAcceptImages, thunkRevertImages} from '@/static/modules/actions/screenshots';
@@ -94,7 +94,7 @@ export function TreeActionsToolbar(props: TreeActionsToolbarProps): ReactNode {
 
     const treeViewMode = useSelector(state => state.ui.suitesPage.treeViewMode);
     const currentTreeNodeId = useSelector(state => state.app.suitesPage.currentTreeNodeId);
-    const {visibleTreeNodeIds} = useSelector(getSuitesThreeViewData);
+    const {visibleTreeNodeIds} = useSelector(getSuitesTreeViewData);
     const isFocusAvailable = isInitialized && currentTreeNodeId && visibleTreeNodeIds.includes(currentTreeNodeId);
 
     const isAtLeastOneAcceptable = activeImages.some(image => isAcceptable(image));

--- a/lib/static/new-ui/features/suites/components/ScreenshotsTreeViewItem/index.module.css
+++ b/lib/static/new-ui/features/suites/components/ScreenshotsTreeViewItem/index.module.css
@@ -16,19 +16,48 @@
     justify-content: center;
 }
 
-.accept-button {
+.accept-button, .go-to-visual {
     composes: regular-button from global, action-button from global;
 }
 
 .buttons-container {
     display: flex;
-    margin-left: auto;
+    overflow: hidden;
+    justify-content: flex-end;
+    container-name: buttons-container;
+    container-type: inline-size;
+    flex-grow: 1;
+
+    .go-to-visual {
+        flex-shrink: 1;
+        overflow: hidden;
+
+        :global(.g-button__icon) {
+            flex-shrink: 0;
+        }
+
+        :global(.g-button__text) {
+            display: block;
+            flex-shrink: 1;
+            word-break: break-all;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
+}
+
+@container buttons-container (max-width: 200px) {
+    .go-to-visual :global(.g-button__text) {
+        display: none !important;
+    }
 }
 
 .diff-mode-container {
     container-type: inline-size;
     flex-grow: 1;
     display: flex;
+    min-width: 100px;
 }
 
 .diff-mode-switcher {

--- a/lib/static/new-ui/features/suites/components/ScreenshotsTreeViewItem/index.tsx
+++ b/lib/static/new-ui/features/suites/components/ScreenshotsTreeViewItem/index.tsx
@@ -37,7 +37,7 @@ function getScrollParent(node: HTMLElement | null): HTMLElement | null {
     }
 }
 
-const MARGIN_TOP = 169; // --sticky-header-height + --gn-aside-header-size
+const MARGIN_TOP = 200; // enough for scroll below sticky header
 
 export function ScreenshotsTreeViewItem(props: ScreenshotsTreeViewItemProps): ReactNode {
     const dispatch = useDispatch();
@@ -128,9 +128,10 @@ export function ScreenshotsTreeViewItem(props: ScreenshotsTreeViewItemProps): Re
                     <Flex className={styles.buttonsContainer} gap={2}>
                         <Button
                             view="outlined"
-                            className={styles.acceptButton}
+                            className={styles.goToVisual}
                             disabled={isRunning || isProcessing}
                             onClick={onVisualChecks}
+                            qa="go-visual-button"
                         >
                             <Icon data={Eye}/>Go to Visual Checks
                         </Button>

--- a/lib/static/new-ui/features/suites/components/ScreenshotsTreeViewItem/index.tsx
+++ b/lib/static/new-ui/features/suites/components/ScreenshotsTreeViewItem/index.tsx
@@ -1,6 +1,6 @@
-import {ArrowUturnCcwLeft, Check} from '@gravity-ui/icons';
-import {Button, Icon, SegmentedRadioGroup as RadioButton, Select} from '@gravity-ui/uikit';
-import React, {ReactNode} from 'react';
+import {ArrowUturnCcwLeft, Check, Eye} from '@gravity-ui/icons';
+import {Button, Icon, SegmentedRadioGroup as RadioButton, Select, Flex} from '@gravity-ui/uikit';
+import React, {ReactNode, createRef, useEffect, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {AssertViewResult} from '@/static/new-ui/components/AssertViewResult';
@@ -18,15 +18,34 @@ import styles from './index.module.css';
 import {thunkAcceptImages, thunkRevertImages} from '@/static/modules/actions/screenshots';
 import {useAnalytics} from '@/static/new-ui/hooks/useAnalytics';
 import {ErrorHandler} from '../../../error-handling/components/ErrorHandling';
+import {useNavigate, useParams} from 'react-router-dom';
 
 interface ScreenshotsTreeViewItemProps {
     image: ImageEntity;
     style?: React.CSSProperties;
 }
 
+function getScrollParent(node: HTMLElement | null): HTMLElement | null {
+    if (node === null) {
+        return null;
+    }
+
+    if (node.scrollHeight > node.clientHeight) {
+        return node;
+    } else {
+        return getScrollParent(node.parentNode as HTMLElement);
+    }
+}
+
+const MARGIN_TOP = 169; // --sticky-header-height + --gn-aside-header-size
+
 export function ScreenshotsTreeViewItem(props: ScreenshotsTreeViewItemProps): ReactNode {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
+    const navigate = useNavigate();
+    const {suiteId, stateName} = useParams();
+    const ref = createRef<HTMLDivElement>();
+    const inited = useRef(false);
 
     const diffMode = useSelector(state => state.view.diffMode);
     const isEditScreensAvailable = useSelector(state => state.app.availableFeatures)
@@ -64,41 +83,88 @@ export function ScreenshotsTreeViewItem(props: ScreenshotsTreeViewItemProps): Re
         }
     };
 
-    return <div style={props.style} className={styles.container}>
-        {props.image.status !== TestStatus.SUCCESS && <div className={styles.toolbarContainer}>
-            {!isDiffModeSwitcherVisible &&
-                <AssertViewStatus image={props.image}/>}
-            {isDiffModeSwitcherVisible &&
-                <div className={styles.diffModeContainer}>
-                    <RadioButton onUpdate={onDiffModeChangeHandler} value={diffMode} className={styles.diffModeSwitcher}>
-                        {Object.values(DiffModes).map(diffMode =>
-                            <RadioButton.Option value={diffMode.id} content={diffMode.title} title={diffMode.description} key={diffMode.id}/>
-                        )}
-                    </RadioButton>
-                    <Select
-                        className={styles.diffModeSelect}
-                        label="Diff Mode" value={[diffMode]}
-                        onUpdate={([diffMode]): void => onDiffModeChangeHandler(diffMode as DiffModeId)}
-                        multiple={false}
-                    >
-                        {Object.values(DiffModes).map(diffMode =>
-                            <Select.Option value={diffMode.id} content={diffMode.title} title={diffMode.description} key={diffMode.id}/>
-                        )}
-                    </Select>
-                </div>
-            }
-            {isEditScreensAvailable && <div className={styles.buttonsContainer}>
-                {isUndoAvailable && <Button view={'action'} className={styles.acceptButton} disabled={isRunning || isProcessing} onClick={onScreenshotUndo}>
-                    <Icon data={ArrowUturnCcwLeft}/>Undo
-                </Button>}
-                {isAcceptable(props.image) && <Button view={'action'} className={styles.acceptButton} disabled={isRunning || isProcessing} onClick={onScreenshotAccept}>
-                    <Icon data={Check}/>Accept
-                </Button>}
-            </div>}
-        </div>}
+    const imageId = `${currentResult?.parentId} ${props.image.stateName}`;
 
-        <ErrorHandler.Boundary fallback={<ErrorHandler.FallbackDataCorruption />}>
-            <AssertViewResult result={props.image} />
-        </ErrorHandler.Boundary>
-    </div>;
+    const onVisualChecks = (): void => {
+        navigate(`/visual-checks/${encodeURIComponent(imageId)}/${currentResult?.attempt}`);
+    };
+
+    useEffect(() => {
+        if (ref && ref.current && `${suiteId} ${stateName}` === imageId && inited && inited.current === false) {
+            inited.current = true;
+            const scrollContainer = getScrollParent(ref.current as HTMLElement);
+            const topPosition = ref.current.getBoundingClientRect().top;
+
+            scrollContainer?.scrollTo(0, topPosition - MARGIN_TOP);
+        }
+    }, []);
+
+    return (
+        <div style={props.style} className={styles.container} ref={ref}>
+            {props.image.status !== TestStatus.SUCCESS && (
+                <div className={styles.toolbarContainer}>
+                    {!isDiffModeSwitcherVisible && (
+                        <AssertViewStatus image={props.image}/>
+                    )}
+                    {isDiffModeSwitcherVisible && (
+                        <div className={styles.diffModeContainer}>
+                            <RadioButton onUpdate={onDiffModeChangeHandler} value={diffMode} className={styles.diffModeSwitcher}>
+                                {Object.values(DiffModes).map(diffMode =>
+                                    <RadioButton.Option value={diffMode.id} content={diffMode.title} title={diffMode.description} key={diffMode.id}/>
+                                )}
+                            </RadioButton>
+                            <Select
+                                className={styles.diffModeSelect}
+                                label="Diff Mode" value={[diffMode]}
+                                onUpdate={([diffMode]): void => onDiffModeChangeHandler(diffMode as DiffModeId)}
+                                multiple={false}
+                            >
+                                {Object.values(DiffModes).map(diffMode =>
+                                    <Select.Option value={diffMode.id} content={diffMode.title} title={diffMode.description} key={diffMode.id}/>
+                                )}
+                            </Select>
+                        </div>
+                    )}
+                    <Flex className={styles.buttonsContainer} gap={2}>
+                        <Button
+                            view="outlined"
+                            className={styles.acceptButton}
+                            disabled={isRunning || isProcessing}
+                            onClick={onVisualChecks}
+                        >
+                            <Icon data={Eye}/>Go to Visual Checks
+                        </Button>
+                        {isEditScreensAvailable && (
+                            <>
+                                {isUndoAvailable && (
+                                    <Button
+                                        view="action"
+                                        className={styles.acceptButton}
+                                        disabled={isRunning || isProcessing}
+                                        onClick={onScreenshotUndo}
+                                    >
+                                        <Icon data={ArrowUturnCcwLeft}/>Undo
+                                    </Button>
+                                )}
+                                {isAcceptable(props.image) && (
+                                    <Button
+                                        view="action"
+                                        className={styles.acceptButton}
+                                        disabled={isRunning || isProcessing}
+                                        onClick={onScreenshotAccept}
+                                    >
+                                        <Icon data={Check}/>Accept
+                                    </Button>
+                                )}
+                            </>
+                        )}
+                    </Flex>
+                </div>
+            )}
+
+            <ErrorHandler.Boundary fallback={<ErrorHandler.FallbackDataCorruption />}>
+                <AssertViewResult result={props.image} />
+            </ErrorHandler.Boundary>
+        </div>
+    );
 }

--- a/lib/static/new-ui/features/suites/components/SuitesPage/selectors.ts
+++ b/lib/static/new-ui/features/suites/components/SuitesPage/selectors.ts
@@ -15,7 +15,7 @@ import {TestStatus} from '@/constants';
 import {TreeViewData} from '@/static/new-ui/components/TreeView';
 
 // Converts the existing store structure to the one that can be consumed by GravityUI
-export const getSuitesThreeViewData = createSelector(
+export const getSuitesTreeViewData = createSelector(
     [getGroups, getSuites, getAllRootGroupIds, getBrowsers, getBrowsersState, getResults, getImages, getTreeViewMode, getSortTestsData],
     (groups, suites, rootGroupIds, browsers, browsersState, results, images, treeViewMode, sortTestsData): TreeViewData => {
         const currentSortDirection = sortTestsData.currentDirection;

--- a/lib/static/new-ui/features/suites/components/TestSteps/index.tsx
+++ b/lib/static/new-ui/features/suites/components/TestSteps/index.tsx
@@ -14,7 +14,7 @@ import {TestStepArgs} from '@/static/new-ui/features/suites/components/TestStepA
 import {getIconByStatus} from '@/static/new-ui/utils';
 import {ErrorInfo} from '@/static/new-ui/components/ErrorInfo';
 import * as actions from '@/static/modules/actions';
-import {getCurrentResultId} from '@/static/new-ui/features/suites/selectors';
+import {getCurrentResult, getCurrentResultId} from '@/static/new-ui/features/suites/selectors';
 import {getStepsExpandedById, getTestSteps} from './selectors';
 import {Step, StepType} from './types';
 import {ListItemViewContentType, TreeViewItem} from '../../../../components/TreeViewItem';
@@ -26,6 +26,7 @@ import {ScreenshotsTreeViewItem} from '@/static/new-ui/features/suites/component
 import {ErrorHandler} from '../../../error-handling/components/ErrorHandling';
 import {goToTimeInSnapshotsPlayer, setCurrentPlayerHighlightTime} from '@/static/modules/actions/snapshots';
 import {setCurrentStep} from '@/static/modules/actions';
+import {useNavigate} from 'react-router-dom';
 
 type TestStepClickHandler = (item: {id: string}) => void
 
@@ -119,6 +120,8 @@ function TestStepsInternal(props: TestStepsProps): ReactNode {
     }
 
     const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const currentResult = useSelector(getCurrentResult);
 
     const currentStepId = useSelector(state => state.app.suitesPage.currentStepId);
     const currentHighlightStepId = useSelector(state => state.app.suitesPage.currentHighlightedStepId);
@@ -149,6 +152,15 @@ function TestStepsInternal(props: TestStepsProps): ReactNode {
             resultId: props.resultId,
             expandedById: Object.assign({}, props.stepsExpandedById, {[id]: !props.stepsExpandedById[id]})
         });
+
+        if (step.type === StepType.Action) {
+            navigate('/' + [
+                'suites',
+                currentResult?.parentId as string,
+                step.args[0] as string,
+                currentResult?.attempt?.toString() as string
+            ].map(encodeURIComponent).join('/'));
+        }
     }, [items, props.actions, props.stepsExpandedById]);
 
     const currentSnapshotsPlayerState = useSelector(state => state.app.snapshotsPlayer);

--- a/lib/static/new-ui/features/suites/selectors.ts
+++ b/lib/static/new-ui/features/suites/selectors.ts
@@ -71,3 +71,13 @@ export const isTimeTravelPlayerAvailable = (state: State): boolean => {
 
     return isSnapshotAvailable || (isRunning && isLiveStreamingAvailable);
 };
+
+export const getAttempt = (state: State): number | null => {
+    const browserId = state.app.suitesPage.currentBrowserId;
+
+    if (browserId) {
+        return state.tree.browsers.stateById[browserId].retryIndex;
+    }
+
+    return null;
+};

--- a/lib/static/new-ui/features/visual-checks/selectors.ts
+++ b/lib/static/new-ui/features/visual-checks/selectors.ts
@@ -129,3 +129,13 @@ export const getImagesByNamedImageIds = (state: State, names: string[]): ImageEn
 
     return results;
 };
+
+export const getAttempt = (state: State): number | null => {
+    const namedImage = getCurrentNamedImage(state);
+
+    if (namedImage) {
+        return state.tree.browsers.stateById[namedImage?.browserId].retryIndex;
+    }
+
+    return null;
+};

--- a/test/func/tests/common/new-ui/visual-checks-page/main-functionality.testplane.js
+++ b/test/func/tests/common/new-ui/visual-checks-page/main-functionality.testplane.js
@@ -14,6 +14,26 @@ if (process.env.TOOL === 'testplane') {
                         await expect(pageTitle).toHaveText('Visual Checks');
                     });
 
+                    it('move to suites and back', async ({browser}) => {
+                        const pageTitle = await browser.$('[data-qa="sidebar-title"]');
+                        const rightSideTitle = await browser.$('h2.text-display-1');
+
+                        const secondElement = await browser.$('[data-qa="tree-view-list"] > div + div');
+                        await secondElement.click();
+
+                        const goSuitesElement = await browser.$('[data-qa="go-suites-button"]');
+                        goSuitesElement.click();
+
+                        await expect(pageTitle).toHaveText('Suites');
+                        await expect(rightSideTitle).toHaveText('test with image comparison diff');
+
+                        const goVisualElement = await browser.$('[data-qa="go-visual-button"]');
+                        goVisualElement.click();
+
+                        await expect(pageTitle).toHaveText('Visual Checks');
+                        await expect(rightSideTitle).toHaveText('test with image comparison diff');
+                    });
+
                     it('change url after select screenshot', async ({browser}) => {
                         const secondElement = await browser.$('[data-qa="tree-view-list"] > div + div');
                         await secondElement.click();
@@ -21,11 +41,11 @@ if (process.env.TOOL === 'testplane') {
                         const currentUrl = await browser.getUrl();
                         const hash = currentUrl.split('#')[1];
 
-                        await expect(hash).toBe('/visual-checks/failed%20describe%20test%20with%20image%20comparison%20diff%20chrome%20header');
+                        await expect(hash).toBe('/visual-checks/failed%20describe%20test%20with%20image%20comparison%20diff%20chrome%20header/1');
                     });
 
                     it('open screenshot by url', async ({browser}) => {
-                        await browser.url('/fixtures/testplane/report/new-ui.html#/visual-checks/failed%20describe%20test%20with%20image%20comparison%20diff%20chrome%20header');
+                        await browser.url('/fixtures/testplane/report/new-ui.html#/visual-checks/failed%20describe%20test%20with%20image%20comparison%20diff%20chrome%20header/1');
                         await browser.execute(() => window.location.reload()); // need for catch data from changed hash
 
                         const rightSideTitle = await browser.$('h2.text-display-1');

--- a/test/unit/lib/static/new-ui/features/visual-checks/components/VisualChecksStickyHeader.jsx
+++ b/test/unit/lib/static/new-ui/features/visual-checks/components/VisualChecksStickyHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {addBrowserToTree, addImageToTree, addResultToTree, addSuiteToTree, mkBrowserEntity, mkEmptyTree, mkImageEntityFail, mkRealStore, mkResultEntity, mkSuiteEntityLeaf, renderWithStore} from '../../../../utils';
 import proxyquire from 'proxyquire';
 import {getNamedImages} from '@/static/new-ui/features/visual-checks/selectors';
+import {BrowserRouter} from 'react-router-dom';
 
 describe('<VisualChecksStickyHeader />', () => {
     const sandbox = sinon.sandbox.create();
@@ -48,7 +49,11 @@ describe('<VisualChecksStickyHeader />', () => {
             '../../../../../modules/utils/imageEntity': {preloadImageEntity: preloadImageEntityStub}
         }).VisualChecksStickyHeader;
 
-        renderWithStore(<VisualChecksStickyHeader visibleNamedImageIds={visibleNamedImageIds} />, store);
+        renderWithStore((
+            <BrowserRouter>
+                <VisualChecksStickyHeader visibleNamedImageIds={visibleNamedImageIds} />
+            </BrowserRouter>
+        ), store);
     });
 
     afterEach(() => {


### PR DESCRIPTION
Немного поменял урлы на страницах suites и visual checks теперь так
http://localhost:8000/new-ui#/visual-checks/:imageId/:attempt
http://localhost:8000/new-ui#/suites/:browserId/:stateName/:attempt

Теперь номер попытки и имя стейта сохраняется в урле
Вот примеры
http://localhost:8000/new-ui#/visual-checks/test%20example%20%230%20chrome%20main-element/2
http://localhost:8000/new-ui#/suites/test%20example%20%230%20chrome/main-element/2