### PR TITLE
fix: fix jitter during images load in tree view, enhance tree items visuals and fix scrollbar interfering with checkboxes

### DIFF
--- a/lib/static/new-ui/components/Card/UiCard.module.css
+++ b/lib/static/new-ui/components/Card/UiCard.module.css
@@ -2,6 +2,6 @@
     background-color: #fff;
     display: flex;
     flex-direction: column;
-    padding: 0 20px 20px 20px;
+    padding: 0 0 20px 20px;
     position: relative;
 }

--- a/lib/static/new-ui/components/ErrorInfo/index.module.css
+++ b/lib/static/new-ui/components/ErrorInfo/index.module.css
@@ -1,6 +1,8 @@
 .code {
     white-space: pre;
     font-family: monospace;
+    line-height: 1.2;
+    font-size: 14px;
     overflow-x: scroll;
     overflow-y: hidden;
     background: #101827;

--- a/lib/static/new-ui/components/ImageWithMagnifier/index.module.css
+++ b/lib/static/new-ui/components/ImageWithMagnifier/index.module.css
@@ -1,3 +1,7 @@
+.wrapper {
+    display: flex;
+}
+
 .magnifier {
     background-color: white;
     background-repeat: no-repeat;

--- a/lib/static/new-ui/components/ImageWithMagnifier/index.tsx
+++ b/lib/static/new-ui/components/ImageWithMagnifier/index.tsx
@@ -101,7 +101,7 @@ export function ImageWithMagnifier({
         });
     }, [showMagnifier, imgWidth, imgHeight, x, y]);
 
-    return <div>
+    return <div className={styles.wrapper}>
         <Screenshot
             image={image}
             style={style}

--- a/lib/static/new-ui/components/SideBar/index.module.css
+++ b/lib/static/new-ui/components/SideBar/index.module.css
@@ -3,9 +3,13 @@
 }
 
 .card__title {
-    margin: 20px 0 8px 0;
+    margin: 20px 20px 8px 0;
 }
 
 .tree-view-card {
     gap: 8px;
+}
+
+.filters-container, .tabs-container, .toolbar-container, .skeleton-container, .tree-view-container {
+    padding-right: 20px;
 }

--- a/lib/static/new-ui/components/SideBar/index.tsx
+++ b/lib/static/new-ui/components/SideBar/index.tsx
@@ -35,19 +35,20 @@ export function SideBar({
         <UiCard className={classNames(styles.card, styles.treeViewCard)} key='tree-view' qa='suites-tree-card'>
             <ErrorHandler.Boundary fallback={<ErrorHandler.FallbackCardCrash recommendedAction={'Try to reload page'}/>}>
                 <Text variant="header-2" className={styles['card__title']} qa="sidebar-title">{title}</Text>
-                <Flex gap={2}>
+                <Flex gap={2} className={styles['filters-container']}>
                     <NameFilter/>
                     <BrowsersSelect/>
                 </Flex>
                 <TabsSelect
+                    className={styles['tabs-container']}
                     list={statusList}
                     value={statusValue}
                     onChange={onStatusChange}
                     disabled={!isInitialized}
                 />
-                {onHighlightCurrentTest && <TreeActionsToolbar onHighlightCurrentTest={onHighlightCurrentTest} />}
-                {isInitialized && <TreeView ref={treeViewRef} {...props}/>}
-                {!isInitialized && <TreeViewSkeleton/>}
+                {onHighlightCurrentTest && <TreeActionsToolbar className={styles['toolbar-container']} onHighlightCurrentTest={onHighlightCurrentTest} />}
+                {isInitialized && <TreeView ref={treeViewRef} {...props} containerClassName={styles['tree-view-container']}/>}
+                {!isInitialized && <div className={styles['skeleton-container']}><TreeViewSkeleton/></div>}
             </ErrorHandler.Boundary>
         </UiCard>
     );

--- a/lib/static/new-ui/components/TabsSelect/index.tsx
+++ b/lib/static/new-ui/components/TabsSelect/index.tsx
@@ -1,5 +1,6 @@
 import {SegmentedRadioGroup as RadioButton} from '@gravity-ui/uikit';
 import React, {ReactNode} from 'react';
+import classNames from 'classnames';
 
 import {TestStatus, ViewMode} from '@/constants';
 import styles from './index.module.css';
@@ -29,13 +30,14 @@ export interface TabsSelectProps {
     value: string;
     onChange: (value: string) => void;
     disabled: boolean;
+    className?: string;
 }
 
-export function TabsSelect({list, value, onChange, disabled}: TabsSelectProps): ReactNode {
+export function TabsSelect({list, value, onChange, disabled, className}: TabsSelectProps): ReactNode {
     return (
         <RadioButton
             disabled={disabled}
-            className={styles.testStatusFilter}
+            className={classNames(styles.testStatusFilter, className)}
             width={'max'}
             value={value}
             onChange={(e): void => onChange(e.target.value)}

--- a/lib/static/new-ui/components/TreeActionsToolbar/index.module.css
+++ b/lib/static/new-ui/components/TreeActionsToolbar/index.module.css
@@ -2,7 +2,9 @@
     --g-color-text-info: #000;
     --divider-color: rgba(0, 0, 0, 0.1);
     --g-text-accent-font-weight: 500;
+}
 
+.inner-container {
     display: flex;
     gap: 4px;
     position: relative;

--- a/lib/static/new-ui/components/TreeActionsToolbar/index.tsx
+++ b/lib/static/new-ui/components/TreeActionsToolbar/index.tsx
@@ -50,11 +50,12 @@ import {useAnalytics} from '@/static/new-ui/hooks/useAnalytics';
 
 interface TreeActionsToolbarProps {
     onHighlightCurrentTest?: () => void;
+    className?: string;
 }
 
 const ANALYTICS_PREFIX = 'Tree actions toolbar:';
 
-export function TreeActionsToolbar(props: TreeActionsToolbarProps): ReactNode {
+export function TreeActionsToolbar({onHighlightCurrentTest, className}: TreeActionsToolbarProps): ReactNode {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
 
@@ -192,7 +193,7 @@ export function TreeActionsToolbar(props: TreeActionsToolbarProps): ReactNode {
             view={'flat'}
             onClick={handleToggleTreeView}
             disabled={!isInitialized} />
-        <IconButton icon={<Icon data={SquareDashed} height={14}/>} tooltip={'Focus on active test'} view={'flat'} onClick={props.onHighlightCurrentTest} disabled={!isFocusAvailable}/>
+        <IconButton icon={<Icon data={SquareDashed} height={14}/>} tooltip={'Focus on active test'} view={'flat'} onClick={onHighlightCurrentTest} disabled={!isFocusAvailable}/>
         <IconButton icon={<Icon data={ChevronsExpandVertical} height={14}/>} tooltip={'Expand all'} view={'flat'} onClick={handleExpandAll} disabled={!isInitialized}/>
         <IconButton icon={<Icon data={ChevronsCollapseVertical} height={14}/>} tooltip={'Collapse all'} view={'flat'} onClick={handleCollapseAll} disabled={!isInitialized}/>
         {areCheckboxesNeeded && <IconButton
@@ -206,7 +207,7 @@ export function TreeActionsToolbar(props: TreeActionsToolbarProps): ReactNode {
         />}
     </>;
 
-    return <div className={styles.container}>
+    return <div className={classNames(styles.container, className)}>
         <GroupBySelect />
         <SortBySelect />
         <div className={styles.buttonsContainer}>

--- a/lib/static/new-ui/components/TreeActionsToolbar/index.tsx
+++ b/lib/static/new-ui/components/TreeActionsToolbar/index.tsx
@@ -208,21 +208,24 @@ export function TreeActionsToolbar({onHighlightCurrentTest, className}: TreeActi
     </>;
 
     return <div className={classNames(styles.container, className)}>
-        <GroupBySelect />
-        <SortBySelect />
-        <div className={styles.buttonsContainer}>
-            {viewButtons}
-        </div>
-
-        <div
-            className={classNames(styles.selectedContainer, {[styles['selected-container--visible']]: isSelectedAtLeastOne})}>
-            <div className={styles.selectedTitle}>
-                <Icon data={CircleInfo}/>
-                <span data-qa="selected-tests-count">{selectedTestsCount} {selectedTestsCount > 1 ? 'tests' : 'test'} selected</span>
-            </div>
-
+        {/* This one is needed for paddings to work correctly for absolutely positioned selectedContainer */}
+        <div className={styles.innerContainer}>
+            <GroupBySelect />
+            <SortBySelect />
             <div className={styles.buttonsContainer}>
                 {viewButtons}
+            </div>
+
+            <div
+                className={classNames(styles.selectedContainer, {[styles['selected-container--visible']]: isSelectedAtLeastOne})}>
+                <div className={styles.selectedTitle}>
+                    <Icon data={CircleInfo}/>
+                    <span data-qa="selected-tests-count">{selectedTestsCount} {selectedTestsCount > 1 ? 'tests' : 'test'} selected</span>
+                </div>
+
+                <div className={styles.buttonsContainer}>
+                    {viewButtons}
+                </div>
             </div>
         </div>
     </div>;

--- a/lib/static/new-ui/components/TreeView/index.module.css
+++ b/lib/static/new-ui/components/TreeView/index.module.css
@@ -1,4 +1,6 @@
-.tree-view {}
+.tree-view {
+    --g-list-item-height: 34px;
+}
 
     .tree-view :global(.g-text_ellipsis) {
         white-space: normal;

--- a/lib/static/new-ui/components/TreeView/index.module.css
+++ b/lib/static/new-ui/components/TreeView/index.module.css
@@ -38,6 +38,7 @@
         font-size: 18px;
 
         user-select: none;
+        border-radius: 8px;
     }
 
         .tree-view__item > div {
@@ -95,6 +96,27 @@
 
         .tree-view__item--error svg {
             color: var(--g-color-private-red-600-solid);
+        }
+
+        /* Leaf sticking styles - only for browser items */
+        .tree-view__item--leaf-first.tree-view__item--browser {
+            border-radius: 8px 8px 0 0;
+            margin-bottom: 0 !important;
+        }
+
+        .tree-view__item--leaf-middle.tree-view__item--browser {
+            border-radius: 0;
+            margin-top: 0 !important;
+            margin-bottom: 0 !important;
+        }
+
+        .tree-view__item--leaf-last.tree-view__item--browser {
+            border-radius: 0 0 8px 8px;
+            margin-top: 0 !important;
+        }
+
+        .tree-view__item--leaf-single.tree-view__item--browser {
+            border-radius: 8px;
         }
 
 .empty-hint-container {

--- a/lib/static/new-ui/components/TreeView/index.tsx
+++ b/lib/static/new-ui/components/TreeView/index.tsx
@@ -212,6 +212,7 @@ export const TreeView = forwardRef<TreeViewHandle, TreeViewProps>(function TreeV
                             return (
                                 <ListItemView
                                     key={virtualRow.key}
+                                    data-qa="tree-view-item"
                                     data-index={virtualRow.index}
                                     ref={virtualizer.measureElement}
                                     height={0}

--- a/lib/static/new-ui/components/TreeView/index.tsx
+++ b/lib/static/new-ui/components/TreeView/index.tsx
@@ -33,6 +33,7 @@ export interface TreeViewProps {
     treeData: TreeViewData;
     treeViewExpandedById: Record<string, boolean>;
     onClick: (item: TreeViewItemData, expanded: boolean) => void;
+    containerClassName?: string;
 }
 
 export interface TreeViewHandle {
@@ -40,7 +41,7 @@ export interface TreeViewHandle {
 }
 
 export const TreeView = forwardRef<TreeViewHandle, TreeViewProps>(function TreeViewInternal(props, ref): ReactNode {
-    const {currentTreeNodeId, treeData, treeViewExpandedById, onClick} = props;
+    const {currentTreeNodeId, treeData, treeViewExpandedById, onClick, containerClassName} = props;
     const dispatch = useDispatch();
     const treeViewMode = useSelector(getTreeViewMode);
 
@@ -176,7 +177,7 @@ export const TreeView = forwardRef<TreeViewHandle, TreeViewProps>(function TreeV
 
     return (
         <ListContainerView className={styles.treeView}>
-            <div ref={parentRef} className={styles['tree-view__container']}>
+            <div ref={parentRef} className={classNames(styles['tree-view__container'], containerClassName)}>
                 <div
                     className={styles['tree-view__total-size-wrapper']}
                     style={{height: virtualizer.getTotalSize()}}

--- a/lib/static/new-ui/components/TreeView/index.tsx
+++ b/lib/static/new-ui/components/TreeView/index.tsx
@@ -140,11 +140,13 @@ export const TreeView = forwardRef<TreeViewHandle, TreeViewProps>(function TreeV
             const id = list.structure.visibleFlattenIds[index];
             const item = list.structure.itemsById[id];
 
-            // Groups on average take 3 lines: 2 lines of text (clamped) + 1 line for tags -> 68px in total
-            // Regular items on average take 1 line -> 34px
-            // Providing more precise estimates here greatly improves scrolling performance
-            const GROUP_ROW_HEIGHT = 68;
+            // Regular items on average take 1 line -> 34px. This is just a height of the tree view item, measured by hand via DevTools.
+            // We need to update this every time we change the tree view item height.
+            // Providing more precise estimates here greatly improves scrolling performance!
             const REGULAR_ROW_HEIGHT = 34;
+            // Group tree items on average take 3 lines: 2 lines of text (clamped) + 1 line for tags -> 68px in total
+            // We can measure this value by opening the report in browser, selecting group by error message and measuring the height of the group item.
+            const GROUP_ROW_HEIGHT = 68;
 
             return item.entityType === EntityType.Group ? GROUP_ROW_HEIGHT : REGULAR_ROW_HEIGHT;
         },

--- a/lib/static/new-ui/components/TreeViewItem/index.module.css
+++ b/lib/static/new-ui/components/TreeViewItem/index.module.css
@@ -11,8 +11,10 @@
 
     line-height: 20px;
 
-    padding: 4px 0;
+    padding: 6px 0;
     font-size: 18px;
+
+    border-radius: 8px;
 
     user-select: none;
     cursor: pointer;

--- a/lib/static/new-ui/components/TreeViewItem/index.module.css
+++ b/lib/static/new-ui/components/TreeViewItem/index.module.css
@@ -24,6 +24,10 @@
     transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
 }
 
+.tree-view-item > div > div {
+    align-items: baseline !important;
+}
+
 .tree-view-item--active {
     background: var(--g-color-base-brand);
     --g-color-base-simple-hover: var(--g-color-base-brand);

--- a/lib/static/new-ui/components/TreeViewItem/index.tsx
+++ b/lib/static/new-ui/components/TreeViewItem/index.tsx
@@ -1,4 +1,3 @@
-import {Box} from '@gravity-ui/uikit';
 import {
     unstable_getItemRenderState as getItemRenderState,
     unstable_ListItemView as ListItemView,
@@ -32,30 +31,26 @@ export function TreeViewItem<T>(props: TreeListItemProps<T>): ReactNode {
     const indent = props.list.structure.itemsState[props.id].indentation;
     const hasChildren = (props.list.structure.itemsById[props.id] as {hasChildren?: boolean}).hasChildren;
 
-    return <Box
-        spacing={{pt: 1}}
-    >
-        <ListItemView
-            onMouseMove={props.onMouseMove}
-            onMouseLeave={props.onMouseLeave}
-            className={classNames([props.className, styles.treeViewItem, {
-                [styles['tree-view-item--active']]: props.isActive,
-                [styles['tree-view-item--corrupted']]: !props.isActive && props.status === 'corrupted',
-                [styles['tree-view-item--error']]: !props.isActive && props.status === 'error'
-            }])}
-            activeOnHover={true}
-            style={{'--indent': indent + Number(!hasChildren)} as React.CSSProperties}
-            {...getItemRenderState({
-                id: props.id,
-                list: props.list,
-                onItemClick: props.onItemClick,
-                mapItemDataToContentProps: (item) => {
-                    return {
-                        indentation: 0,
-                        ...props.mapItemDataToContentProps(item)
-                    };
-                }
-            }).props}
-        />
-    </Box>;
+    return <ListItemView
+        onMouseMove={props.onMouseMove}
+        onMouseLeave={props.onMouseLeave}
+        className={classNames([props.className, styles.treeViewItem, {
+            [styles['tree-view-item--active']]: props.isActive,
+            [styles['tree-view-item--corrupted']]: !props.isActive && props.status === 'corrupted',
+            [styles['tree-view-item--error']]: !props.isActive && props.status === 'error'
+        }])}
+        activeOnHover={true}
+        style={{'--indent': indent + Number(!hasChildren)} as React.CSSProperties}
+        {...getItemRenderState({
+            id: props.id,
+            list: props.list,
+            onItemClick: props.onItemClick,
+            mapItemDataToContentProps: (item) => {
+                return {
+                    indentation: 0,
+                    ...props.mapItemDataToContentProps(item)
+                };
+            }
+        }).props}
+    />;
 }

--- a/lib/static/new-ui/components/TreeViewItemIcon/index.module.css
+++ b/lib/static/new-ui/components/TreeViewItemIcon/index.module.css
@@ -5,4 +5,5 @@
     height: 16px;
     width: 16px;
     flex-shrink: 0;
+    translate: 0 2px;
 }

--- a/lib/static/new-ui/components/TreeViewItemSubtitle/index.module.css
+++ b/lib/static/new-ui/components/TreeViewItemSubtitle/index.module.css
@@ -36,6 +36,8 @@
 .image-diff-item{
     img {
         max-height: 40vh;
+        max-width: calc(min(var(--natural-width) * 1px, 40vh * var(--natural-width) / var(--natural-height), 100%));
+        width: 100vw;
     }
 
     p {

--- a/lib/static/new-ui/components/TreeViewItemSubtitle/index.tsx
+++ b/lib/static/new-ui/components/TreeViewItemSubtitle/index.tsx
@@ -27,7 +27,7 @@ export function TreeViewItemSubtitle(props: TreeViewItemSubtitleProps): ReactNod
 
     if (props.item.images?.length) {
         return (
-            <div>
+            <div style={{overflow: 'hidden'}}>
                 {props.item.images.map((imageEntity) => {
                     const images = [];
 

--- a/lib/static/new-ui/features/suites/components/SuitesPage/index.module.css
+++ b/lib/static/new-ui/features/suites/components/SuitesPage/index.module.css
@@ -34,6 +34,7 @@
     gap: 12px;
     overflow: scroll;
     container-type: size;
+    padding-right: 20px;
 }
 
 .sticky-header {

--- a/lib/static/new-ui/features/visual-checks/components/VisualChecksPage/index.module.css
+++ b/lib/static/new-ui/features/visual-checks/components/VisualChecksPage/index.module.css
@@ -41,3 +41,7 @@
 .current-image {
     overflow: auto;
 }
+
+.test-view-card {
+    padding-right: 20px;
+}

--- a/test/func/tests/common/new-ui/visual-checks-page/main-functionality.testplane.js
+++ b/test/func/tests/common/new-ui/visual-checks-page/main-functionality.testplane.js
@@ -18,7 +18,8 @@ if (process.env.TOOL === 'testplane') {
                         const pageTitle = await browser.$('[data-qa="sidebar-title"]');
                         const rightSideTitle = await browser.$('h2.text-display-1');
 
-                        const secondElement = await browser.$('[data-qa="tree-view-list"] > div + div');
+                        const treeViewItems = await browser.$$('[data-qa="tree-view-item"]');
+                        const secondElement = treeViewItems[1];
                         await secondElement.click();
 
                         const goSuitesElement = await browser.$('[data-qa="go-suites-button"]');
@@ -35,7 +36,8 @@ if (process.env.TOOL === 'testplane') {
                     });
 
                     it('change url after select screenshot', async ({browser}) => {
-                        const secondElement = await browser.$('[data-qa="tree-view-list"] > div + div');
+                        const treeViewItems = await browser.$$('[data-qa="tree-view-item"]');
+                        const secondElement = treeViewItems[1];
                         await secondElement.click();
 
                         const currentUrl = await browser.getUrl();
@@ -54,7 +56,8 @@ if (process.env.TOOL === 'testplane') {
                     });
 
                     it('click to screenshot', async ({browser}) => {
-                        const secondElement = await browser.$('[data-qa="tree-view-list"] > div + div');
+                        const treeViewItems = await browser.$$('[data-qa="tree-view-item"]');
+                        const secondElement = treeViewItems[1];
                         await secondElement.click();
 
                         const rightSideTitle = await browser.$('h2.text-display-1');


### PR DESCRIPTION
### What's done?

- Tree view items now have more modern and sleek look, with slightly more rounded edges and similar items "sticking" to each other:
  <img width="835" height="660" alt="Screenshot 2025-08-23 at 12 55 38" src="https://github.com/user-attachments/assets/1af460c4-8936-4b48-95e1-a0b5cc958d09" />

- Scrollbar no longer interferes with checkboxes on MacOS:
  <img width="827" height="686" alt="Screenshot 2025-08-23 at 12 56 37" src="https://github.com/user-attachments/assets/503b983d-1dd1-4194-a7f9-abb4a1ef3146" />

- Tree view items no longer jump vertically when new images are being loaded. Scroll experience is now smooth and consistent.