### PR TITLE
fix: do not fail if GUI port is already occupied

### DIFF
--- a/lib/gui/index.ts
+++ b/lib/gui/index.ts
@@ -1,9 +1,7 @@
 import type {CommanderStatic} from '@gemini-testing/commander';
-import chalk from 'chalk';
 import opener from 'opener';
 
 import * as server from './server';
-import {logger} from '../common-utils';
 import * as utils from '../server-utils';
 
 import type {ToolAdapter} from '../adapters/tool';
@@ -29,7 +27,6 @@ export interface ServerArgs {
 export default (args: ServerArgs): void => {
     server.start(args)
         .then(({url}: { url: string }) => {
-            logger.log(`GUI is running at ${chalk.cyan(url)}`);
             args.cli.options.open && opener(url);
         })
         .catch((err: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/lib/gui/listen-with-fallback.ts
+++ b/lib/gui/listen-with-fallback.ts
@@ -1,0 +1,78 @@
+import type {Server as HttpServer} from 'http';
+import type {Express} from 'express';
+import {HEADERS_TIMEOUT, KEEP_ALIVE_TIMEOUT} from './constants';
+
+interface ListenOptions {
+    server: Express;
+    hostname?: string;
+    requestedPort?: number;
+}
+
+interface ListenResult {
+    actualPort: number;
+    hostnameForUrl: string;
+}
+
+const MAX_PORT_NUMBER = 65_535;
+const DEFAULT_PORT = 3000;
+
+const listenOnPort = (server: Express, portToTry: number, hostname?: string): Promise<void> => {
+    return new Promise((resolve, reject) => {
+        // eslint-disable-next-line prefer-const
+        let httpServer: HttpServer;
+
+        const handleError = (error: NodeJS.ErrnoException): void => {
+            httpServer.removeListener('error', handleError);
+            reject(error);
+        };
+
+        const onListen = (): void => {
+            resolve();
+        };
+
+        httpServer = hostname
+            ? server.listen(portToTry, hostname, onListen)
+            : server.listen(portToTry, onListen);
+        httpServer.keepAliveTimeout = KEEP_ALIVE_TIMEOUT;
+        httpServer.headersTimeout = HEADERS_TIMEOUT;
+
+        httpServer.once('error', handleError);
+    });
+};
+
+export const listenWithFallback = async ({server, hostname, requestedPort}: ListenOptions): Promise<ListenResult> => {
+    const hostnameForUrl = hostname ?? 'localhost';
+    const startPort = requestedPort ?? DEFAULT_PORT;
+
+    let currentPort = startPort;
+    let isSuccess = false;
+
+    while (currentPort <= MAX_PORT_NUMBER) {
+        try {
+            await listenOnPort(server, currentPort, hostname);
+            isSuccess = true;
+            break;
+        } catch (error) {
+            const err = error as NodeJS.ErrnoException;
+
+            if (err.code !== 'EADDRINUSE') {
+                throw err;
+            }
+
+            if (currentPort >= MAX_PORT_NUMBER) {
+                throw new Error(`Unable to find an available port to start GUI server: ${err.message}`);
+            }
+
+            currentPort += 1;
+        }
+    }
+
+    if (!isSuccess) {
+        throw new Error(`Unable to find an available port (tried all variants between ${startPort} and ${MAX_PORT_NUMBER})`);
+    }
+
+    return {
+        actualPort: currentPort,
+        hostnameForUrl
+    };
+};


### PR DESCRIPTION
[#710](https://github.com/gemini-testing/html-reporter/issues/710)