### PR TITLE
fix(pwt): ability to import config with using import attributes

### DIFF
--- a/lib/bundle/transformer.ts
+++ b/lib/bundle/transformer.ts
@@ -12,7 +12,8 @@ export const setupTransformHook = (): VoidFunction => {
         compact: false,
         presets: [require('@babel/preset-typescript')],
         plugins: [
-            require('@babel/plugin-transform-modules-commonjs')
+            require('@babel/plugin-transform-modules-commonjs'),
+            require('@babel/plugin-syntax-import-attributes')
         ]
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "html-reporter",
-      "version": "11.0.0",
+      "version": "11.0.3",
       "license": "MIT",
       "workspaces": [
         "test/func/fixtures/*",
@@ -53,6 +53,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.24.7",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
         "@babel/plugin-transform-modules-commonjs": "^7.24.7",
         "@babel/plugin-transform-runtime": "^7.22.5",
         "@babel/preset-env": "^7.22.5",
@@ -924,12 +925,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
+      "integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -34369,12 +34370,12 @@
       }
     },
     "@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
+      "integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.24.7"
       }
     },
     "@babel/plugin-syntax-import-meta": {

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",
+    "@babel/plugin-syntax-import-attributes": "^7.24.7",
     "@babel/plugin-transform-modules-commonjs": "^7.24.7",
     "@babel/plugin-transform-runtime": "^7.22.5",
     "@babel/preset-env": "^7.22.5",


### PR DESCRIPTION
In order to support read pwt config using import attributes, like:

```
// playwright.config.ts

import packageJson from './package.json' with { type: 'json' };
// ...
```