### PR TITLE
fix: correctly merge report even if request for databaseUrls.json failed

### DIFF
--- a/test/unit/lib/merge-reports/index.js
+++ b/test/unit/lib/merge-reports/index.js
@@ -226,6 +226,18 @@ describe('lib/merge-reports', () => {
         });
     });
 
+    it('should add json url to merged report even if request for it is failed', async () => {
+        const toolAdapter = stubToolAdapter({htmlReporter});
+        const paths = ['https://ci.ru'];
+        const destPath = 'dest-report/path';
+
+        axiosStub.get.withArgs('https://ci.ru/databaseUrls.json').rejects(new Error('o.O'));
+
+        await execMergeReports_({toolAdapter, paths, opts: {destPath, headers: []}});
+
+        assert.calledOnceWith(serverUtils.writeDatabaseUrlsFile, destPath, ['https://ci.ru/databaseUrls.json']);
+    });
+
     it('should merge reports with folder paths', async () => {
         const toolAdapter = stubToolAdapter({htmlReporter});
         const paths = ['https://ci.ru', 'src-report-1'];


### PR DESCRIPTION
In case when request for `databaseUrls.json` failed we write this URL into the merged report here - https://github.com/gemini-testing/html-reporter/blob/v11.0.3/lib/merge-reports/index.ts#L188, in the hope that when we open this report, it will resolved correctly (used in draft reports).

But this behaviour was broken here - https://github.com/gemini-testing/html-reporter/pull/647/files#diff-623c96dbab685eb30f70d730cffe6df5d73d79d71ff2c25aff1f67474ba82aafR34.

So in this PR I fixed it.