### PR TITLE
docs(ru): clarify static accepter static report wording

### DIFF
--- a/docs/en/html-reporter.md
+++ b/docs/en/html-reporter.md
@@ -6,3 +6,4 @@
 * [Customizing GUI](./html-reporter-custom-gui.md)
 * [API](./html-reporter-api.md)
 * [Events](./html-reporter-events.md)
+* [Accepting screenshots from reports in CI](./static-image-accepter.md)

--- a/docs/en/static-image-accepter.md
+++ b/docs/en/static-image-accepter.md
@@ -1,0 +1,242 @@
+# Accepting screenshots from reports in CI
+
+## Overview
+
+The static image accepter lets reviewers promote new screenshot baselines from a static HTML report that was published by CI (for example, on S3 or behind an internal web server). A typical flow looks like this:
+
+1. A CI job finishes running tests, generates the html-reporter bundle, and uploads the static report somewhere reviewers can reach it.
+2. A reviewer opens that static report, stages the screenshots that should become the new baselines, and presses **Commit**.
+3. html-reporter packages the staged screenshots together with repository metadata and sends them to a service that you operate. That service runs persistently (for example on your infrastructure or as a cloud function) and is responsible for updating the pull request with the new baselines.
+
+The static accepter is disabled in GUI mode. To expose it in the static bundle you must configure repository, pull request, and service URLs as shown below.
+
+## Configuration prerequisites
+
+Add the `staticImageAccepter` block to the reporter configuration used when building the static report:
+
+```js
+plugins: {
+    'html-reporter/hermione': {
+        enabled: true,
+        // ...other reporter options
+        staticImageAccepter: {
+            enabled: true,
+            repositoryUrl: 'https://github.com/org/project',
+            pullRequestUrl: 'https://github.com/org/project/pull/42',
+            serviceUrl: 'https://accepter.example.com/static-accepter',
+            meta: {
+                ciRunId: process.env.GITHUB_RUN_ID,
+                // any other contextual data required by your service
+            },
+            axiosRequestOptions: {
+                timeout: 120000
+            }
+        }
+    }
+}
+```
+
+* The accepter is ignored unless the `enabled` flag is set and the report is opened in static mode. `repositoryUrl`, `pullRequestUrl`, and `serviceUrl` are mandatory; missing values disable the feature inside the bundle.【F:lib/static/modules/static-image-accepter.ts†L36-L52】
+* Images collected for committing always reference the stored baseline path. The accepter throws if the underlying tool cannot provide a `refImg.relativePath`, because the service needs the final repository-relative destination for each file.【F:lib/static/modules/static-image-accepter.ts†L54-L82】
+* `axiosRequestOptions` (optional) are forwarded to the HTTP client used by the report UI so you can tweak timeouts, headers, or authentication parameters required by your service.【F:lib/static/modules/actions/static-accepter.ts†L58-L107】
+
+## High-level workflow
+
+1. Reviewers browse the static report, stage the screenshots they want to promote, and open the **Commit** dialog.
+2. html-reporter gathers the staged entries, fetches the binary data for each actual image, and builds a `multipart/form-data` payload that includes repository metadata, the chosen commit message, and every image file.【F:lib/static/modules/actions/static-accepter.ts†L69-L107】
+3. The payload is sent as an HTTP `POST` request to the configured `serviceUrl`. Upload progress is exposed in the UI so reviewers can monitor large batches.【F:lib/static/modules/actions/static-accepter.ts†L108-L115】
+4. Your accepter service performs authentication, verifies the request, stores the uploaded screenshots, and updates the PR branch (for example by creating a commit or opening a follow-up PR). It runs persistently so it can be reused across reports and CI runs.
+5. On any HTTP status between 200 (inclusive) and 400 (exclusive) the UI treats the operation as successful, marks images as committed, stores their identifiers in local storage to avoid duplicate work, and shows a success notification. Non-2xx responses bubble up as errors in the UI.【F:lib/static/modules/actions/static-accepter.ts†L116-L148】
+
+## HTTP API contract
+
+The html-reporter always sends a single HTTP `POST` request to `staticImageAccepter.serviceUrl`. The request body is `multipart/form-data`.
+
+### Form fields
+
+| Field name | Type | Description |
+|------------|------|-------------|
+| `repositoryUrl` | text part | Full URL of the Git repository that contains the baselines (usually the PR target repository).【F:lib/static/modules/actions/static-accepter.ts†L75-L90】|
+| `pullRequestUrl` | text part | Full URL of the PR that should receive the commit. Use it to discover branch/owner information inside your service.【F:lib/static/modules/actions/static-accepter.ts†L75-L90】|
+| `message` | text part | Commit message chosen by the reviewer. Defaults to `chore: update <tool> screenshot references` if left unchanged.【F:lib/static/components/modals/static-accepter-confirm/index.tsx†L19-L56】|
+| `meta` | text part (optional) | Arbitrary JSON string produced from the configured `staticImageAccepter.meta` object. Use it to pass CI context (run IDs, actor, custom flags).【F:lib/static/modules/actions/static-accepter.ts†L83-L90】|
+| `image` | file part (repeated) | Each staged screenshot is uploaded as a binary file. The browser fetches the actual image blob and attaches it with the filename set to the repository-relative destination path (for example `test/screens/page/diff.png`).【F:lib/static/modules/actions/static-accepter.ts†L91-L107】【F:lib/types.ts†L216-L233】|
+
+### Request semantics
+
+* Multiple `image` parts are added in parallel (up to 256 concurrent downloads) before the request is dispatched. Order is not guaranteed, so the server should rely on `file.originalname` (or equivalent) rather than the upload order.【F:lib/static/modules/actions/static-accepter.ts†L91-L107】
+* Each image corresponds to an `actual` screenshot that is meant to replace the `ref` baseline located at the given relative path. Your server is responsible for writing the file content to that path within the repository checkout or storage backend.
+* The client does not send a structured list of images in the body — the file parts themselves are authoritative. Use the multipart metadata to reconstruct the commit.
+* Authentication, authorization, and CSRF protections are entirely up to your implementation. Supply any additional headers through `axiosRequestOptions` (for example, bearer tokens) if you want the report to authenticate against the service.【F:lib/static/modules/actions/static-accepter.ts†L58-L107】
+
+### Response expectations
+
+* Any HTTP status in the range `[200, 400)` is treated as success. You may return a body (for example JSON with links to created commits), but the UI does not require it.
+* Any other status or thrown error results in a failure notification for the reviewer. Include descriptive error messages in the response body to simplify troubleshooting.【F:lib/static/modules/actions/static-accepter.ts†L116-L147】
+
+## Example: Express service backed by a GitHub App
+
+One straightforward way to let a persistent service update pull requests is to authenticate it as a GitHub App installation. The App holds the minimal permissions needed (`contents: write`, `pull_requests: read`) and GitHub rotates short-lived installation tokens for you. The service can then clone the PR branch, drop in the uploaded baselines, and push a commit on behalf of the App.
+
+### GitHub setup required beforehand
+
+1. **Create a GitHub App** (Settings → Developer settings → GitHub Apps) with the following repository permissions: `Contents: Read & Write` and `Pull requests: Read`. The App does not require any webhooks for this flow.
+2. **Generate a private key** for the App and store the PEM string in your secret manager. The server will use it to request installation tokens.
+3. **Install the App** on every repository where you intend to accept screenshots. During installation GitHub asks which repositories to authorize; select the relevant ones. Only repository or organization admins can perform this step.
+
+Once the App is installed, the service authenticates by exchanging the App credentials for an installation token every time it handles a request. That token is injected into the Git remote URL so all Git operations happen under the App’s robot account identity.
+
+Below is a minimal Express implementation that runs on your infrastructure (for example, in Kubernetes or on a small VM). It receives requests from html-reporter, authenticates as a GitHub App, clones the PR branch into a temporary directory, writes the uploaded files, commits them using the reviewer-provided message, and pushes the updated branch.
+
+```ts
+// server.ts
+import express from 'express';
+import multer from 'multer';
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import {randomUUID} from 'crypto';
+import simpleGit from 'simple-git';
+import {Octokit} from 'octokit';
+import {createAppAuth} from '@octokit/auth-app';
+
+const upload = multer({storage: multer.memoryStorage()});
+
+const appId = process.env.GITHUB_APP_ID!;
+const privateKey = process.env.GITHUB_APP_PRIVATE_KEY!; // PEM string
+
+app.post('/static-accepter', upload.any(), async (req, res) => {
+    const repositoryUrl = req.body.repositoryUrl as string;
+    const pullRequestUrl = req.body.pullRequestUrl as string;
+    const message = (req.body.message as string) || 'chore: update baselines';
+    const meta = req.body.meta ? JSON.parse(req.body.meta) : {};
+
+    if (!repositoryUrl || !pullRequestUrl) {
+        res.status(400).send('Missing repositoryUrl or pullRequestUrl');
+        return;
+    }
+
+    if (!req.files?.length) {
+        res.status(400).send('No images provided');
+        return;
+    }
+
+    const {owner, repo} = parseRepository(repositoryUrl);
+
+    const appOctokit = new Octokit({
+        authStrategy: createAppAuth,
+        auth: {appId, privateKey}
+    });
+
+    const installation = await appOctokit.rest.apps.getRepoInstallation({owner, repo});
+    const installationOctokit = new Octokit({
+        authStrategy: createAppAuth,
+        auth: {
+            appId,
+            privateKey,
+            installationId: installation.data.id
+        }
+    });
+
+    const prNumber = extractPullNumber(pullRequestUrl);
+    const {data: pull} = await installationOctokit.rest.pulls.get({owner, repo, pull_number: prNumber});
+    const branch = pull.head.ref;
+
+    const {token} = await installationOctokit.auth({type: 'installation'});
+    const remote = `https://x-access-token:${token}@github.com/${owner}/${repo}.git`;
+
+    const worktree = await fs.mkdtemp(path.join(os.tmpdir(), `accepter-${randomUUID()}-`));
+    const git = simpleGit();
+
+    try {
+        await git.clone(remote, worktree, ['--single-branch', '--branch', branch]);
+        const branchGit = simpleGit(worktree);
+
+        for (const file of req.files as Express.Multer.File[]) {
+            const destination = path.join(worktree, file.originalname);
+            await fs.mkdir(path.dirname(destination), {recursive: true});
+            await fs.writeFile(destination, file.buffer);
+        }
+
+        await branchGit.add('.');
+        await branchGit.commit(message, undefined, {
+            '--author': `${meta.actor ?? 'visual bot'} <${meta.actorEmail ?? 'bot@example.com'}>`
+        });
+        await branchGit.push('origin', branch);
+
+        res.status(204).end();
+    } catch (err) {
+        console.error(err);
+        res.status(500).send('Failed to update pull request');
+    } finally {
+        await fs.rm(worktree, {recursive: true, force: true});
+    }
+});
+
+function parseRepository(repositoryUrl: string) {
+    const match = repositoryUrl.match(/github\.com\/(.+?)\/(.+?)(\.git)?$/);
+    if (!match) {
+        throw new Error(`Unsupported repository URL: ${repositoryUrl}`);
+    }
+    return {owner: match[1], repo: match[2]};
+}
+
+function extractPullNumber(pullRequestUrl: string) {
+    const match = pullRequestUrl.match(/pull\/(\d+)/);
+    if (!match) {
+        throw new Error(`Unsupported pull request URL: ${pullRequestUrl}`);
+    }
+    return Number(match[1]);
+}
+
+const port = process.env.PORT ?? 3000;
+app.listen(port, () => {
+    console.log(`Static accepter listening on :${port}`);
+});
+```
+
+**Environment variables**
+
+* `GITHUB_APP_ID` – the numeric App ID.
+* `GITHUB_APP_PRIVATE_KEY` – the PEM-encoded private key generated for the App. Store it securely (for example in your secrets manager).
+* The App must be installed in every repository that should accept screenshots. It needs `Contents: Read & Write` and `Pull requests: Read` permissions.
+
+## Example: Integrating with GitHub Actions
+
+The accepter service is long-lived, but CI is still responsible for producing the static report and publishing it. The workflow below shows one possible setup:
+
+```yaml
+jobs:
+  visual-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx testplane --reporter=html-reporter --reporter-options path=testplane-report
+      - name: Upload static report to S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          SOURCE_DIR: testplane-report
+          DEST_DIR: "testplane-reports/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/"
+      - name: Publish report URL
+        run: |
+          echo "Report: https://reports.example.com/testplane-reports/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/index.html" >> "$GITHUB_STEP_SUMMARY"
+```
+
+Reviewers open the published report. When they approve new baselines, the static accepter UI POSTs the images to your persistent service. That service performs the GitHub App workflow described above and pushes the commit back to the PR branch.
+
+By implementing this contract you can let reviewers approve new baselines directly from static html-reporter builds while keeping full control over how screenshots are promoted inside your CI/CD system.

--- a/docs/ru/html-reporter.md
+++ b/docs/ru/html-reporter.md
@@ -6,3 +6,4 @@
 * [Кастомизация GUI](./html-reporter-custom-gui.md)
 * [API](./html-reporter-api.md)
 * [События](./html-reporter-events.md)
+* [Принятие скриншотов из отчётов в CI](./static-image-accepter.md)

--- a/docs/ru/static-image-accepter.md
+++ b/docs/ru/static-image-accepter.md
@@ -1,0 +1,242 @@
+# Принятие скриншотов из отчётов в CI
+
+## Обзор
+
+Данная функция позволяет ревьюерам принять новые эталонные скриншоты прямо из статического HTML-отчёта, опубликованного в CI (например, в S3 или на внутреннем веб-сервере). Типичный сценарий выглядит так:
+
+1. CI-прогон завершает тесты, генерирует сборку html-reporter и выкладывает статический отчёт в доступное ревьюерам место.
+2. Ревьюер открывает этот отчёт, помечает скриншоты, которые должны стать новыми эталонами, и нажимает **Commit**.
+3. html-reporter упаковывает выбранные скриншоты вместе с метаданными репозитория и отправляет их на принадлежащий вам сервис. Этот сервис работает постоянно (например, в вашем кластере или как облачная функция) и обновляет pull request новыми эталонами.
+
+В режиме GUI эта функция выключена, потому что локальный интерфейс уже умеет принимать скриншоты напрямую. Чтобы элементы UI принятия скриншотов появились в статическом отчёте, необходимо задать URL репозитория, pull request'а и сервиса, как показано ниже.
+
+## Предварительная настройка
+
+Добавьте блок `staticImageAccepter` в конфигурацию репортера, которая используется при сборке статического отчёта:
+
+```js
+plugins: {
+    'html-reporter/hermione': {
+        enabled: true,
+        // ...другие настройки репортера
+        staticImageAccepter: {
+            enabled: true,
+            repositoryUrl: 'https://github.com/org/project',
+            pullRequestUrl: 'https://github.com/org/project/pull/42',
+            serviceUrl: 'https://accepter.example.com/static-accepter',
+            meta: {
+                ciRunId: process.env.GITHUB_RUN_ID,
+                // дополнительные данные, которые нужны вашему сервису
+            },
+            axiosRequestOptions: {
+                timeout: 120000
+            }
+        }
+    }
+}
+```
+
+* Элементы для принятия скриншотов в статическом отчёте не появятся, если не задан `enabled` или отчёт открыт не в статическом режиме. `repositoryUrl`, `pullRequestUrl` и `serviceUrl` обязательны; без них кнопка «Accept» недоступна.【F:lib/static/modules/static-image-accepter.ts†L36-L52】
+* Сохраняемые изображения всегда ссылаются на путь эталона. html-reporter выбросит ошибку, если инструмент не предоставляет `refImg.relativePath`, потому что сервису нужен конечный относительный путь для каждого файла.【F:lib/static/modules/static-image-accepter.ts†L54-L82】
+* Параметр `axiosRequestOptions` (необязательный) прокидывается в HTTP-клиент интерфейса отчёта — так можно настроить таймауты, заголовки или авторизацию, требуемые вашим сервисом.【F:lib/static/modules/actions/static-accepter.ts†L58-L107】
+
+## Общая схема работы
+
+1. Ревьюер просматривает статический отчёт, отмечает скриншоты и открывает диалог **Commit**.
+2. html-reporter собирает выбранные элементы, загружает бинарные данные каждого «actual»-скриншота и формирует `multipart/form-data`, содержащий метаданные репозитория, сообщение коммита и файлы изображений.【F:lib/static/modules/actions/static-accepter.ts†L69-L107】
+3. Этот payload отправляется POST-запросом на `serviceUrl`. Прогресс загрузки отображается в интерфейсе.【F:lib/static/modules/actions/static-accepter.ts†L108-L115】
+4. Ваш сервис аутентифицирует запрос, проверяет его, сохраняет загруженные скриншоты и обновляет ветку PR (например, создаёт коммит или открывает follow-up PR). Он работает постоянно, поэтому его можно переиспользовать для разных отчётов и CI-запусков.
+5. Любой HTTP-статус в диапазоне `[200, 400)` считается успехом: интерфейс помечает изображения как принятые, запоминает их идентификаторы в `localStorage`, чтобы не отправлять повторно, и показывает уведомление. Ошибки приводят к отображению сообщения об ошибке.【F:lib/static/modules/actions/static-accepter.ts†L116-L148】
+
+## Контракт HTTP API
+
+html-reporter всегда отправляет один POST-запрос на `staticImageAccepter.serviceUrl`. Тело запроса имеет тип `multipart/form-data`.
+
+### Поля формы
+
+| Имя | Тип | Описание |
+|-----|-----|----------|
+| `repositoryUrl` | текст | Полный URL Git-репозитория с эталонами (обычно целевой репозиторий PR).【F:lib/static/modules/actions/static-accepter.ts†L75-L90】|
+| `pullRequestUrl` | текст | Полный URL pull request'а, который нужно обновить. Используйте его, чтобы определить ветку и владельца внутри сервиса.【F:lib/static/modules/actions/static-accepter.ts†L75-L90】|
+| `message` | текст | Сообщение коммита, выбранное ревьюером. По умолчанию `chore: update <tool> screenshot references`.【F:lib/static/components/modals/static-accepter-confirm/index.tsx†L19-L56】|
+| `meta` | текст (опционально) | Произвольная JSON-строка из `staticImageAccepter.meta`. Можно передавать контекст CI (ID прогона, автора, флаги).【F:lib/static/modules/actions/static-accepter.ts†L83-L90】|
+| `image` | файл (повторяется) | Каждый выбранный скриншот передаётся бинарным файлом. Имя файла равно относительному пути в репозитории (например, `test/screens/page/diff.png`).【F:lib/static/modules/actions/static-accepter.ts†L91-L107】【F:lib/types.ts†L216-L233】|
+
+### Семантика запроса
+
+* Файлы добавляются параллельно (до 256 одновременных загрузок), порядок не гарантируется — опирайтесь на `file.originalname` (или аналог) вместо позиции.【F:lib/static/modules/actions/static-accepter.ts†L91-L107】
+* Каждый файл заменяет соответствующий эталон (`ref`) по указанному относительному пути. Именно сервис отвечает за запись контента в репозиторий или хранилище.
+* Клиент не отправляет отдельный JSON-список изображений — достаточно данных `multipart`.
+* Механизмы аутентификации, авторизации и защиты от CSRF лежат на вашей стороне. Дополнительные заголовки можно задать через `axiosRequestOptions` (например, bearer-токен).【F:lib/static/modules/actions/static-accepter.ts†L58-L107】
+
+### Ожидаемый ответ
+
+* Любой статус в диапазоне `[200, 400)` считается успешным. Можно вернуть тело (например, JSON с ссылками на коммиты), но интерфейсу оно не требуется.
+* Остальные статусы или исключения приводят к ошибке в UI. Возвращайте развёрнутые сообщения, чтобы упрощать отладку.【F:lib/static/modules/actions/static-accepter.ts†L116-L147】
+
+## Пример: Express-сервис с GitHub App
+
+Один из удобных способов выдать постоянному сервису права на обновление PR — аутентифицировать его как установку GitHub App. Приложение получает минимальные разрешения (`contents: write`, `pull_requests: read`), а GitHub самостоятельно вращает краткоживущие токены установки. После этого сервис может клонировать ветку PR, подменять эталоны и пушить коммит от имени приложения.
+
+### Что нужно настроить в GitHub заранее
+
+1. **Создайте GitHub App** (Settings → Developer settings → GitHub Apps) со следующими правами на репозиторий: `Contents: Read & Write` и `Pull requests: Read`. Для этого сценария вебхуки не обязательны.
+2. **Сгенерируйте приватный ключ** для приложения и сохраните PEM-строку в менеджере секретов. Сервер будет использовать её для получения installation token’ов.
+3. **Установите приложение** во все репозитории, где планируете принимать скриншоты. Во время установки GitHub попросит выбрать репозитории — отметьте нужные. Выполнить установку могут только администраторы репозитория или организации.
+
+После установки приложение при каждом запросе обменивает свои учётные данные на installation token. Этот токен подставляется в URL удалённого репозитория, поэтому все Git-операции выполняются от имени сервисного аккаунта приложения.
+
+Ниже приведён упрощённый Express-сервер, который развёрнут на постоянной инфраструктуре (например, в Kubernetes или на отдельном сервере). Он принимает запросы из html-reporter, аутентифицируется как GitHub App, клонирует ветку PR во временную директорию, записывает файлы, делает коммит с указанным сообщением и пушит изменения.
+
+```ts
+// server.ts
+import express from 'express';
+import multer from 'multer';
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import {randomUUID} from 'crypto';
+import simpleGit from 'simple-git';
+import {Octokit} from 'octokit';
+import {createAppAuth} from '@octokit/auth-app';
+
+const upload = multer({storage: multer.memoryStorage()});
+
+const appId = process.env.GITHUB_APP_ID!;
+const privateKey = process.env.GITHUB_APP_PRIVATE_KEY!; // PEM-строка
+
+app.post('/static-accepter', upload.any(), async (req, res) => {
+    const repositoryUrl = req.body.repositoryUrl as string;
+    const pullRequestUrl = req.body.pullRequestUrl as string;
+    const message = (req.body.message as string) || 'chore: update baselines';
+    const meta = req.body.meta ? JSON.parse(req.body.meta) : {};
+
+    if (!repositoryUrl || !pullRequestUrl) {
+        res.status(400).send('Missing repositoryUrl or pullRequestUrl');
+        return;
+    }
+
+    if (!req.files?.length) {
+        res.status(400).send('No images provided');
+        return;
+    }
+
+    const {owner, repo} = parseRepository(repositoryUrl);
+
+    const appOctokit = new Octokit({
+        authStrategy: createAppAuth,
+        auth: {appId, privateKey}
+    });
+
+    const installation = await appOctokit.rest.apps.getRepoInstallation({owner, repo});
+    const installationOctokit = new Octokit({
+        authStrategy: createAppAuth,
+        auth: {
+            appId,
+            privateKey,
+            installationId: installation.data.id
+        }
+    });
+
+    const prNumber = extractPullNumber(pullRequestUrl);
+    const {data: pull} = await installationOctokit.rest.pulls.get({owner, repo, pull_number: prNumber});
+    const branch = pull.head.ref;
+
+    const {token} = await installationOctokit.auth({type: 'installation'});
+    const remote = `https://x-access-token:${token}@github.com/${owner}/${repo}.git`;
+
+    const worktree = await fs.mkdtemp(path.join(os.tmpdir(), `accepter-${randomUUID()}-`));
+    const git = simpleGit();
+
+    try {
+        await git.clone(remote, worktree, ['--single-branch', '--branch', branch]);
+        const branchGit = simpleGit(worktree);
+
+        for (const file of req.files as Express.Multer.File[]) {
+            const destination = path.join(worktree, file.originalname);
+            await fs.mkdir(path.dirname(destination), {recursive: true});
+            await fs.writeFile(destination, file.buffer);
+        }
+
+        await branchGit.add('.');
+        await branchGit.commit(message, undefined, {
+            '--author': `${meta.actor ?? 'visual bot'} <${meta.actorEmail ?? 'bot@example.com'}>`
+        });
+        await branchGit.push('origin', branch);
+
+        res.status(204).end();
+    } catch (err) {
+        console.error(err);
+        res.status(500).send('Failed to update pull request');
+    } finally {
+        await fs.rm(worktree, {recursive: true, force: true});
+    }
+});
+
+function parseRepository(repositoryUrl: string) {
+    const match = repositoryUrl.match(/github\.com\/(.+?)\/(.+?)(\.git)?$/);
+    if (!match) {
+        throw new Error(`Unsupported repository URL: ${repositoryUrl}`);
+    }
+    return {owner: match[1], repo: match[2]};
+}
+
+function extractPullNumber(pullRequestUrl: string) {
+    const match = pullRequestUrl.match(/pull\/(\d+)/);
+    if (!match) {
+        throw new Error(`Unsupported pull request URL: ${pullRequestUrl}`);
+    }
+    return Number(match[1]);
+}
+
+const port = process.env.PORT ?? 3000;
+app.listen(port, () => {
+    console.log(`Static accepter listening on :${port}`);
+});
+```
+
+**Переменные окружения**
+
+* `GITHUB_APP_ID` — числовой идентификатор приложения.
+* `GITHUB_APP_PRIVATE_KEY` — приватный ключ в PEM-формате. Храните его в защищённом хранилище.
+* Приложение должно быть установлено во всех репозиториях, где нужно принимать скриншоты из статических отчётов. Ему нужны права `Contents: Read & Write` и `Pull requests: Read`.
+
+## Пример интеграции с GitHub Actions
+
+Сам сервис живёт отдельно, а CI продолжает генерировать и публиковать статический отчёт. Ниже пример workflow:
+
+```yaml
+jobs:
+  visual-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx testplane --reporter=html-reporter --reporter-options path=testplane-report
+      - name: Upload static report to S3
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          SOURCE_DIR: testplane-report
+          DEST_DIR: "testplane-reports/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/"
+      - name: Publish report URL
+        run: |
+          echo "Report: https://reports.example.com/testplane-reports/${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}/index.html" >> "$GITHUB_STEP_SUMMARY"
+```
+
+Ревьюеры открывают опубликованный отчёт. Когда они подтверждают новые эталоны, html-reporter отправляет изображения на ваш постоянный сервис. Тот выполняет описанные выше действия GitHub App и пушит коммит в ветку PR.
+
+Следуя этому контракту, вы позволяете ревьюерам принимать новые эталоны прямо из статических сборок html-reporter и при этом полностью контролируете процесс их публикации.


### PR DESCRIPTION
## Summary
- update the Russian static accepter guide to describe UI availability in the static report instead of the bundle wording

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd2275257483338e10ad4718c28af9