### PR TITLE
fix: ErrorInfo string diff background

### DIFF
--- a/lib/static/new-ui/components/ErrorInfo/index.tsx
+++ b/lib/static/new-ui/components/ErrorInfo/index.tsx
@@ -22,6 +22,11 @@ export function ErrorInfo(props: ErrorInfoProps): ReactNode {
         reset: ['eee', '00000000']
     });
 
+    // ANSI "inverse" (code 7) is used to highlight the differing characters in a diff. Its default
+    // rendering (transparent text on a light background) is unreadable on the dark report background,
+    // so we make the differing part inherit the surrounding color and just render it bold instead.
+    ansiHtml.tags.open['7'] = 'font-weight:bold';
+
     let errorName = props.name;
 
     if (typeof errorName !== 'string') {

--- a/lib/static/new-ui/types/typings.d.ts
+++ b/lib/static/new-ui/types/typings.d.ts
@@ -12,6 +12,10 @@ declare module 'ansi-html-community' {
     interface AnsiHtmlCommunity {
         (value: string): string;
         setColors: (colors: Record<string, unknown>) => void;
+        tags: {
+            open: Record<string, string>;
+            close: Record<string, string>;
+        };
     }
     const f: AnsiHtmlCommunity;
 


### PR DESCRIPTION
Issue:

https://github.com/mahdyar/ansi-html-community/blob/master/index.js#L162-L163

Before

<img width="915" height="307" alt="image" src="https://github.com/user-attachments/assets/06e3680f-2502-4f9d-a5ca-56d8645feda8" />

After

<img width="919" height="311" alt="image" src="https://github.com/user-attachments/assets/25a9a805-a576-4709-91b8-52b1ce26dba1" />
