### PR TITLE
fix: fix unclosed string errors by updating rrweb package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "html-reporter",
-      "version": "11.8.3",
+      "version": "11.14.1",
       "license": "MIT",
       "workspaces": [
         "test/func/fixtures/*",
@@ -66,7 +66,7 @@
         "@jest/reporters": "^29.7.0",
         "@playwright/test": "^1.44.1",
         "@react-hook/resize-observer": "^2.0.1",
-        "@rrweb/replay": "^2.0.0-alpha.18",
+        "@rrweb/replay": "^2.1.1",
         "@swc/core": "^1.3.64",
         "@tanstack/react-virtual": "^3.8.3",
         "@testing-library/react": "^16.0.0",
@@ -5318,26 +5318,29 @@
       ]
     },
     "node_modules/@rrweb/replay": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/replay/-/replay-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-EGCdydiQHCEbh1j+EF7OupwRHD1/EnAYYF4ENBz4CReoH+jGsLKu0LT2962CWPnQttMvpxwzhmD5gFGf63Gm0g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/replay/-/replay-2.1.1.tgz",
+      "integrity": "sha512-jq64eyJvrh/ioBS1MpDrs/Lj+7QY2TW4xGxp4g4LJKdltSkqMjMbUmhTDcpzaEDZt66S0gasGcgqCulsksSXnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.18",
-        "rrweb": "^2.0.0-alpha.18"
+        "@rrweb/types": "^2.1.1",
+        "rrweb": "^2.1.1"
       }
     },
     "node_modules/@rrweb/types": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.1.1.tgz",
+      "integrity": "sha512-g0I3nCNL1S7slDXwhunxOuOoswkY8WVZJQrPFiwixOc6xoD514d1JLTuyAzCKIox8g/PaLKtV5g31Uk42inQSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rrweb/utils": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-qV8azQYo9RuwW4NGRtOiQfTBdHNL1B0Q//uRLMbCSjbaKqJYd88Js17Bdskj65a0Vgp2dwTLPIZ0gK47dfjfaA==",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.1.1.tgz",
+      "integrity": "sha512-x2SgJAD3YJ9eVcLZ5l6OqWMtczdA3VfS5XqPeqpZdQgV9oh6Id5GK2cDN4bimnkqryOcIJdz8cTvV0yNvqQ+nA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@semantic-ui-react/event-stack": {
       "version": "3.1.3",
@@ -6521,7 +6524,8 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
       "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -7828,7 +7832,8 @@
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
       "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -9137,6 +9142,7 @@
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -27024,28 +27030,30 @@
       }
     },
     "node_modules/rrdom": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-fSFzFFxbqAViITyYVA4Z0o5G6p1nEqEr/N8vdgSKie9Rn0FJxDSNJgjV0yiCIzcDs0QR+hpvgFhpbdZ6JIr5Nw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.1.1.tgz",
+      "integrity": "sha512-VBkTF3bGNqcZjqnbo/gKi9GVQPIxiG0dofw7CQdAZQFQ2juJdt2YKIf3oS9QudL8HTpGh9bz5TUN+3amBn1Geg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "rrweb-snapshot": "^2.0.0-alpha.18"
+        "rrweb-snapshot": "^2.1.1"
       }
     },
     "node_modules/rrweb": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-1mjZcB+LVoGSx1+i9E2ZdAP90fS3MghYVix2wvGlZvrgRuLCbTCCOZMztFCkKpgp7/EeCdYM4nIHJkKX5J1Nmg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.1.1.tgz",
+      "integrity": "sha512-ToxhJg3SsrAhw+/DPhI/2iiwZQIrGK5BGkZ0kHn4qUExcvQYRaolkciD1FWX2+r6vf1IxFyhsoRY18h3D+XoCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.18",
-        "@rrweb/utils": "^2.0.0-alpha.18",
+        "@rrweb/types": "^2.1.1",
+        "@rrweb/utils": "^2.1.1",
         "@types/css-font-loading-module": "0.0.7",
         "@xstate/fsm": "^1.4.0",
         "base64-arraybuffer": "^1.0.1",
         "mitt": "^3.0.0",
-        "rrdom": "^2.0.0-alpha.18",
-        "rrweb-snapshot": "^2.0.0-alpha.18"
+        "rrdom": "^2.1.1",
+        "rrweb-snapshot": "^2.1.1"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -27055,10 +27063,11 @@
       "dev": true
     },
     "node_modules/rrweb-snapshot": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.1.1.tgz",
+      "integrity": "sha512-al4Kx7Am7YlIn/5Yb2EMr7cdmjGiK+cLhdilJEXqkFXgpnys8t/yMJumXy2Ormgirpg3MBnFha0GTgny+iIL2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "postcss": "^8.4.38"
       }
@@ -37602,25 +37611,25 @@
       "optional": true
     },
     "@rrweb/replay": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/replay/-/replay-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-EGCdydiQHCEbh1j+EF7OupwRHD1/EnAYYF4ENBz4CReoH+jGsLKu0LT2962CWPnQttMvpxwzhmD5gFGf63Gm0g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/replay/-/replay-2.1.1.tgz",
+      "integrity": "sha512-jq64eyJvrh/ioBS1MpDrs/Lj+7QY2TW4xGxp4g4LJKdltSkqMjMbUmhTDcpzaEDZt66S0gasGcgqCulsksSXnw==",
       "dev": true,
       "requires": {
-        "@rrweb/types": "^2.0.0-alpha.18",
-        "rrweb": "^2.0.0-alpha.18"
+        "@rrweb/types": "^2.1.1",
+        "rrweb": "^2.1.1"
       }
     },
     "@rrweb/types": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.1.1.tgz",
+      "integrity": "sha512-g0I3nCNL1S7slDXwhunxOuOoswkY8WVZJQrPFiwixOc6xoD514d1JLTuyAzCKIox8g/PaLKtV5g31Uk42inQSQ==",
       "dev": true
     },
     "@rrweb/utils": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-qV8azQYo9RuwW4NGRtOiQfTBdHNL1B0Q//uRLMbCSjbaKqJYd88Js17Bdskj65a0Vgp2dwTLPIZ0gK47dfjfaA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.1.1.tgz",
+      "integrity": "sha512-x2SgJAD3YJ9eVcLZ5l6OqWMtczdA3VfS5XqPeqpZdQgV9oh6Id5GK2cDN4bimnkqryOcIJdz8cTvV0yNvqQ+nA==",
       "dev": true
     },
     "@semantic-ui-react/event-stack": {
@@ -53983,28 +53992,28 @@
       }
     },
     "rrdom": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-fSFzFFxbqAViITyYVA4Z0o5G6p1nEqEr/N8vdgSKie9Rn0FJxDSNJgjV0yiCIzcDs0QR+hpvgFhpbdZ6JIr5Nw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.1.1.tgz",
+      "integrity": "sha512-VBkTF3bGNqcZjqnbo/gKi9GVQPIxiG0dofw7CQdAZQFQ2juJdt2YKIf3oS9QudL8HTpGh9bz5TUN+3amBn1Geg==",
       "dev": true,
       "requires": {
-        "rrweb-snapshot": "^2.0.0-alpha.18"
+        "rrweb-snapshot": "^2.1.1"
       }
     },
     "rrweb": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-1mjZcB+LVoGSx1+i9E2ZdAP90fS3MghYVix2wvGlZvrgRuLCbTCCOZMztFCkKpgp7/EeCdYM4nIHJkKX5J1Nmg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.1.1.tgz",
+      "integrity": "sha512-ToxhJg3SsrAhw+/DPhI/2iiwZQIrGK5BGkZ0kHn4qUExcvQYRaolkciD1FWX2+r6vf1IxFyhsoRY18h3D+XoCg==",
       "dev": true,
       "requires": {
-        "@rrweb/types": "^2.0.0-alpha.18",
-        "@rrweb/utils": "^2.0.0-alpha.18",
+        "@rrweb/types": "^2.1.1",
+        "@rrweb/utils": "^2.1.1",
         "@types/css-font-loading-module": "0.0.7",
         "@xstate/fsm": "^1.4.0",
         "base64-arraybuffer": "^1.0.1",
         "mitt": "^3.0.0",
-        "rrdom": "^2.0.0-alpha.18",
-        "rrweb-snapshot": "^2.0.0-alpha.18"
+        "rrdom": "^2.1.1",
+        "rrweb-snapshot": "^2.1.1"
       }
     },
     "rrweb-cssom": {
@@ -54014,9 +54023,9 @@
       "dev": true
     },
     "rrweb-snapshot": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.1.1.tgz",
+      "integrity": "sha512-al4Kx7Am7YlIn/5Yb2EMr7cdmjGiK+cLhdilJEXqkFXgpnys8t/yMJumXy2Ormgirpg3MBnFha0GTgny+iIL2w==",
       "dev": true,
       "requires": {
         "postcss": "^8.4.38"

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@jest/reporters": "^29.7.0",
     "@playwright/test": "^1.44.1",
     "@react-hook/resize-observer": "^2.0.1",
-    "@rrweb/replay": "^2.0.0-alpha.18",
+    "@rrweb/replay": "^2.1.1",
     "@swc/core": "^1.3.64",
     "@tanstack/react-virtual": "^3.8.3",
     "@testing-library/react": "^16.0.0",


### PR DESCRIPTION
### What's done?

On some pages, the `Unclosed block.` occurred due to `rr_split` markers. Later versions of rrweb fixed this by correctly rejoining css before parsing it.