### PR TITLE
fix: avoid tmp package for temp paths

### DIFF
--- a/lib/reporter-helpers.ts
+++ b/lib/reporter-helpers.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import os from 'node:os';
 import fs from 'fs-extra';
 import {pipeline} from 'stream/promises';
 import _ from 'lodash';
@@ -30,8 +31,6 @@ const copyImageFromUrl = async (imageUrl: string, destinationPath: string): Prom
 };
 
 export const updateReferenceImages = async (testResult: ReporterTestResult, reportPath: string, onReferenceUpdateCb: OnReferenceUpdateCb): Promise<ReporterTestResult> => {
-    const {default: tmp} = await import('tmp');
-
     const newImagesInfo: ImageInfoFull[] = await Promise.all(testResult.imagesInfo.map(async (imageInfo) => {
         const newImageInfo = _.clone(imageInfo);
 
@@ -50,7 +49,7 @@ export const updateReferenceImages = async (testResult: ReporterTestResult, repo
 
         if (utils.fileExists(referencePath)) {
             const referenceId = mkReferenceHash(testResult.id, stateName);
-            const oldReferencePath = path.resolve(tmp.tmpdir, referenceId);
+            const oldReferencePath = path.resolve(os.tmpdir(), referenceId);
             await utils.copyFileAsync(referencePath, oldReferencePath);
         }
 
@@ -79,11 +78,9 @@ export const updateReferenceImages = async (testResult: ReporterTestResult, repo
 };
 
 export const revertReferenceImage = async (removedResult: ReporterTestResult, newResult: ReporterTestResult, stateName: string): Promise<void> => {
-    const {default: tmp} = await import('tmp');
-
     const referenceId = removedResult.id;
     const referenceHash = mkReferenceHash(referenceId, stateName);
-    const oldReferencePath = path.resolve(tmp.tmpdir, referenceHash);
+    const oldReferencePath = path.resolve(os.tmpdir(), referenceHash);
     const referencePath = getImagesInfoByStateName(newResult.imagesInfo, stateName)?.refImg?.path;
 
     if (!referencePath) {

--- a/lib/server-utils.ts
+++ b/lib/server-utils.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import os from 'node:os';
 import path from 'path';
 import url from 'url';
 
@@ -67,9 +68,7 @@ export function createPath({attempt: attemptInput, imageDir: imageDirInput, time
 }
 
 export const getTempPath = async (destPath: string): Promise<string> => {
-    const {default: tmp} = await import('tmp');
-
-    return path.resolve(tmp.tmpdir, destPath);
+    return path.resolve(os.tmpdir(), destPath);
 };
 
 export function createHash(buffer: Buffer): string {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,10 +7,6 @@ import {ImageDiffError, NoRefImageError} from './errors';
 import {UiMode} from './constants/local-storage';
 import {ReporterTestResult} from './adapters/test-result';
 
-declare module 'tmp' {
-    export const tmpdir: string;
-}
-
 export type {Suite as TestplaneSuite} from 'testplane';
 
 export interface HermioneTestResult extends TestResult {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "html-reporter",
-      "version": "11.14.1",
+      "version": "11.16.1",
       "license": "MIT",
       "workspaces": [
         "test/func/fixtures/*",
@@ -44,7 +44,6 @@
         "qs": "^6.9.1",
         "signal-exit": "^4.1.0",
         "strip-ansi": "^6.0.1",
-        "tmp": "^0.1.0",
         "url-join": "^4.0.1",
         "worker-farm": "^1.7.0",
         "yazl": "^3.3.1"
@@ -96,7 +95,6 @@
         "@types/redux-mock-store": "^1.0.6",
         "@types/sinon": "^4.3.3",
         "@types/strftime": "^0.9.8",
-        "@types/tmp": "^0.1.0",
         "@types/urijs": "^1.19.19",
         "@types/yazl": "^2.4.6",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
@@ -7137,12 +7135,6 @@
       "integrity": "sha512-QIvDlGAKyF3YJbT3QZnfC+RIvV5noyDbi+ZJ5rkaSRqxCGrYJefgXm3leZAjtoQOutZe1hCXbAg+p89/Vj4HlQ==",
       "dev": true
     },
-    "node_modules/@types/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==",
-      "dev": true
-    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -9028,7 +9020,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/bare-events": {
       "version": "2.5.4",
@@ -9380,6 +9373,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10606,7 +10600,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -15876,7 +15871,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -16524,6 +16520,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17844,6 +17841,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -22364,6 +22362,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -24005,6 +24004,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -24422,6 +24422,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26977,6 +26978,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -30876,17 +30878,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -33604,7 +33595,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "2.4.3",
@@ -39021,12 +39013,6 @@
       "integrity": "sha512-QIvDlGAKyF3YJbT3QZnfC+RIvV5noyDbi+ZJ5rkaSRqxCGrYJefgXm3leZAjtoQOutZe1hCXbAg+p89/Vj4HlQ==",
       "dev": true
     },
-    "@types/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==",
-      "dev": true
-    },
     "@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -40403,7 +40389,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "bare-events": {
       "version": "2.5.4",
@@ -40658,6 +40645,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -41588,7 +41576,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -45633,7 +45622,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -46097,6 +46087,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -47100,6 +47091,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -50453,6 +50445,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -51692,6 +51685,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -52013,7 +52007,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -53951,6 +53946,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -56817,14 +56813,6 @@
       "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
       "dev": true
     },
-    "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "requires": {
-        "rimraf": "^2.6.3"
-      }
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -58707,7 +58695,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "qs": "^6.9.1",
     "signal-exit": "^4.1.0",
     "strip-ansi": "^6.0.1",
-    "tmp": "^0.1.0",
     "url-join": "^4.0.1",
     "worker-farm": "^1.7.0",
     "yazl": "^3.3.1"
@@ -191,7 +190,6 @@
     "@types/redux-mock-store": "^1.0.6",
     "@types/sinon": "^4.3.3",
     "@types/strftime": "^0.9.8",
-    "@types/tmp": "^0.1.0",
     "@types/urijs": "^1.19.19",
     "@types/yazl": "^2.4.6",
     "@typescript-eslint/eslint-plugin": "^5.60.0",

--- a/test/unit/lib/adapters/test-result/testplane/index.ts
+++ b/test/unit/lib/adapters/test-result/testplane/index.ts
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import * as fsOriginal from 'fs-extra';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
-import tmpOriginal from 'tmp';
 
 import {TestStatus} from 'lib/constants/test-statuses';
 import {ERROR_DETAILS_PATH} from 'lib/constants/paths';
@@ -39,7 +38,6 @@ describe('TestplaneTestResultAdapter', () => {
     let utils: sinon.SinonStubbedInstance<typeof originalUtils>;
     let commonUtils: sinon.SinonStubbedInstance<typeof originalCommonUtils>;
     let fs: sinon.SinonStubbedInstance<typeof fsOriginal>;
-    let tmp: typeof tmpOriginal;
     let testAdapterUtils: sinon.SinonStubbedInstance<typeof originalTestAdapterUtils>;
 
     const mkTestplaneTestResultAdapter = (
@@ -55,7 +53,6 @@ describe('TestplaneTestResultAdapter', () => {
     }) as TestplaneTestResult;
 
     beforeEach(() => {
-        tmp = {tmpdir: 'default/dir'} as typeof tmpOriginal;
         fs = sinon.stub(_.clone(fsOriginal));
         getSuitePath = sandbox.stub();
 
@@ -73,7 +70,6 @@ describe('TestplaneTestResultAdapter', () => {
         testAdapterUtils = _.clone(originalTestAdapterUtils);
 
         TestplaneTestResultAdapter = proxyquire('lib/adapters/test-result/testplane', {
-            tmp,
             'fs-extra': fs,
             '../../../plugin-utils': {getSuitePath},
             '../../server-utils': utils,

--- a/test/unit/lib/reporter-helpers.js
+++ b/test/unit/lib/reporter-helpers.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const path = require('path');
 const _ = require('lodash');
 const proxyquire = require('proxyquire');
 const {UPDATED} = require('lib/constants');
 const commonUtilsOriginal = require('lib/common-utils');
+const osOriginal = require('node:os');
 
 describe('lib/reporter-helpers', () => {
     const sandbox = sinon.sandbox.create();
@@ -13,6 +15,7 @@ describe('lib/reporter-helpers', () => {
     let fs;
     let streamPipeline;
     let imageStream;
+    let os;
 
     const mkImageInfo_ = (actualImgPath) => ({
         status: UPDATED,
@@ -31,7 +34,10 @@ describe('lib/reporter-helpers', () => {
         commonUtils = _.clone(commonUtilsOriginal);
         imageStream = {};
         sandbox.stub(commonUtils, 'fetchFile').resolves({data: imageStream, status: 200});
+        sandbox.stub(commonUtils, 'getShortMD5').returns('reference-id');
         streamPipeline = sandbox.stub().resolves();
+        os = _.clone(osOriginal);
+        sandbox.stub(os, 'tmpdir').returns('/temp-dir');
 
         fs = {
             createWriteStream: sandbox.stub().returns({})
@@ -42,6 +48,7 @@ describe('lib/reporter-helpers', () => {
             getReferencePath: sandbox.stub().returns('images/plain/reference.png'),
             copyFileAsync: sandbox.stub().resolves(),
             fileExists: sandbox.stub().returns(false),
+            getImagesInfoByStateName: sandbox.stub(),
             makeDirFor: sandbox.stub().resolves()
         };
 
@@ -52,6 +59,7 @@ describe('lib/reporter-helpers', () => {
                 copyAndUpdate: sandbox.stub().callsFake((source, data) => _.assign(source, data))
             },
             'fs-extra': fs,
+            'node:os': os,
             'stream/promises': {pipeline: streamPipeline}
         });
     });
@@ -78,5 +86,31 @@ describe('lib/reporter-helpers', () => {
         assert.calledOnceWith(fs.createWriteStream, '/ref/path/plain.png');
         assert.calledOnceWith(streamPipeline, imageStream, fs.createWriteStream.firstCall.returnValue);
         assert.calledWith(utils.copyFileAsync, '/ref/path/plain.png', '/report/images/plain/reference.png');
+    });
+
+    it('should save the previous reference image in the OS temporary directory', async () => {
+        const onReferenceUpdateCb = sandbox.stub();
+        const testResult = mkTestResult_('images/plain/current.png');
+        utils.fileExists.returns(true);
+
+        await reporterHelpers.updateReferenceImages(testResult, '/report', onReferenceUpdateCb);
+
+        assert.calledWith(
+            utils.copyFileAsync.firstCall,
+            '/ref/path/plain.png',
+            path.resolve('/temp-dir', 'reference-id')
+        );
+    });
+
+    it('should restore a reference image from the OS temporary directory', async () => {
+        utils.getImagesInfoByStateName.returns({refImg: {path: '/ref/path/plain.png'}});
+
+        await reporterHelpers.revertReferenceImage({id: 'test-id'}, {imagesInfo: []}, 'plain');
+
+        assert.calledOnceWith(
+            utils.copyFileAsync,
+            path.resolve('/temp-dir', 'reference-id'),
+            '/ref/path/plain.png'
+        );
     });
 });

--- a/test/unit/lib/server-utils.js
+++ b/test/unit/lib/server-utils.js
@@ -12,9 +12,12 @@ describe('server-utils', () => {
 
     const fsOriginal = require('fs-extra');
     const fs = _.clone(fsOriginal);
+    const osOriginal = require('node:os');
+    const os = _.clone(osOriginal);
 
     const utils = proxyquire('lib/server-utils', {
-        'fs-extra': fs
+        'fs-extra': fs,
+        'node:os': os
     });
 
     afterEach(() => sandbox.restore());
@@ -92,6 +95,16 @@ describe('server-utils', () => {
 
                 assert.equal(resultPath, path.join('/root', 'reportPath', IMAGES_PATH, 'some', 'dir', 'plain', `bro~${testData.prefix}_${test.timestamp}_0.png`));
             });
+        });
+    });
+
+    describe('getTempPath', () => {
+        it('should resolve destination inside the OS temporary directory', async () => {
+            sandbox.stub(os, 'tmpdir').returns('/temp-dir');
+
+            const result = await utils.getTempPath('image.png');
+
+            assert.equal(result, path.resolve('/temp-dir', 'image.png'));
         });
     });
 


### PR DESCRIPTION
Use node:os directly to avoid loading tmp and its transitive dependency chain from a non-canonical pnpm path.