### PR TITLE
fix(playwright): recognize modern screenshot comparison errors

### DIFF
--- a/lib/adapters/test-result/playwright.ts
+++ b/lib/adapters/test-result/playwright.ts
@@ -212,7 +212,8 @@ export class PlaywrightTestResultAdapter implements ReporterTestResult {
 
             if (/snapshot .*doesn't exist/.test(message) && message.includes('.png')) {
                 result.name = ErrorName.NO_REF_IMAGE;
-            } else if (this._testResult.errors.every(error => this._isScreenshotComparisonError(error))) {
+            } else if (message.includes('Screenshot comparison failed') ||
+                this._testResult.errors.every(error => this._isScreenshotComparisonError(error))) {
                 result.name = ErrorName.IMAGE_DIFF;
             }
 
@@ -371,11 +372,7 @@ export class PlaywrightTestResultAdapter implements ReporterTestResult {
     private _isScreenshotComparisonError(error: PlaywrightTestResult['errors'][number]): boolean {
         const message = stripAnsi(error.message || '');
         const header = message.split('\n')[0];
-        if (header.includes('Screenshot comparison failed')) {
-            return true;
-        }
-
-        if (!/^(?:Error: )?expect\((?:page|locator|Buffer)\)\.(?:toHaveScreenshot|toMatchSnapshot)\(expected\)(?: failed)?$/.test(header)) {
+        if (!/^(?:Error: )?expect\((?:page|locator)\)\.toHaveScreenshot\(expected\) failed$/.test(header)) {
             return false;
         }
 

--- a/lib/adapters/test-result/playwright.ts
+++ b/lib/adapters/test-result/playwright.ts
@@ -212,7 +212,7 @@ export class PlaywrightTestResultAdapter implements ReporterTestResult {
 
             if (/snapshot .*doesn't exist/.test(message) && message.includes('.png')) {
                 result.name = ErrorName.NO_REF_IMAGE;
-            } else if (message.includes('Screenshot comparison failed')) {
+            } else if (this._testResult.errors.every(error => this._isScreenshotComparisonError(error))) {
                 result.name = ErrorName.IMAGE_DIFF;
             }
 
@@ -366,6 +366,27 @@ export class PlaywrightTestResultAdapter implements ReporterTestResult {
             a => a.contentType === 'image/png' && ANY_IMAGE_ENDING_REGEXP.test(a.name));
 
         return _.groupBy(imageAttachments, a => a.name.replace(ANY_IMAGE_ENDING_REGEXP, ''));
+    }
+
+    private _isScreenshotComparisonError(error: PlaywrightTestResult['errors'][number]): boolean {
+        const message = stripAnsi(error.message || '');
+        const header = message.split('\n')[0];
+        if (header.includes('Screenshot comparison failed')) {
+            return true;
+        }
+
+        if (!/^(?:Error: )?expect\((?:page|locator|Buffer)\)\.(?:toHaveScreenshot|toMatchSnapshot)\(expected\)(?: failed)?$/.test(header)) {
+            return false;
+        }
+
+        // Modern Playwright uses the same matcher header for diffs and capture errors.
+        const snapshotName = message.match(/^\s*Snapshot: (.+)\.png\s*$/m)?.[1];
+        const states = Object.entries(this._attachmentsByState).filter(([state]) =>
+            snapshotName ? state === snapshotName : this._testResult.errors.length === 1);
+
+        return states.some(([, attachments]) =>
+            [ImageTitleEnding.Expected, ImageTitleEnding.Actual, ImageTitleEnding.Diff].every(ending =>
+                attachments.some(attachment => attachment.name.endsWith(ending))));
     }
 
     get duration(): number {

--- a/test/unit/lib/adapters/test-result/playwright.ts
+++ b/test/unit/lib/adapters/test-result/playwright.ts
@@ -120,7 +120,12 @@ describe('PlaywrightTestResultAdapter', () => {
                 const matcher = receiver === 'Buffer' ? 'toMatchSnapshot' : 'toHaveScreenshot';
                 const suffix = receiver === 'Buffer' ? '' : ' failed';
                 const errors = [{message: `Error: expect(${receiver}).${matcher}(expected)${suffix}\n\n  Snapshot: state1.png`}];
-                const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+                const attachments = [
+                    createAttachment('state1-expected.png'),
+                    createAttachment('state1-diff.png'),
+                    createAttachment('state1-actual.png')
+                ];
+                const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
 
                 assert.equal(adapter.error?.name, ErrorName.IMAGE_DIFF);
                 assert.equal(adapter.status, FAIL);
@@ -130,7 +135,12 @@ describe('PlaywrightTestResultAdapter', () => {
         ['Screenshot comparison failed', 'Error: expect(page).toHaveScreenshot(expected) failed'].forEach(message => {
             it(`should preserve other failures alongside "${message}"`, () => {
                 const errors = [{message}, {message: 'Error: expect(received).toBe(expected)'}];
-                const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+                const attachments = [
+                    createAttachment('state1-expected.png'),
+                    createAttachment('state1-diff.png'),
+                    createAttachment('state1-actual.png')
+                ];
+                const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
 
                 assert.equal(adapter.error?.name, ErrorName.GENERAL_ERROR);
                 assert.equal(adapter.status, ERROR);
@@ -148,21 +158,36 @@ describe('PlaywrightTestResultAdapter', () => {
 
         it('should match diff attachments to the failing snapshot', () => {
             const errors = [{message: 'Error: expect(locator).toHaveScreenshot(expected) failed\n\n  Snapshot: state2.png'}];
-            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+            const attachments = [
+                createAttachment('state1-expected.png'),
+                createAttachment('state1-diff.png'),
+                createAttachment('state1-actual.png')
+            ];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.error?.name, ErrorName.GENERAL_ERROR);
         });
 
         it('should recognize an unnamed modern screenshot diff', () => {
             const errors = [{message: 'Error: expect(page).toHaveScreenshot(expected) failed'}];
-            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+            const attachments = [
+                createAttachment('state1-expected.png'),
+                createAttachment('state1-diff.png'),
+                createAttachment('state1-actual.png')
+            ];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.error?.name, ErrorName.IMAGE_DIFF);
         });
 
         it('should recognize modern screenshot diffs with ANSI formatting', () => {
             const errors = [{message: 'Error: \u001b[31mexpect(page).toHaveScreenshot(expected)\u001b[39m failed\n\n  Snapshot: state1.png'}];
-            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+            const attachments = [
+                createAttachment('state1-expected.png'),
+                createAttachment('state1-diff.png'),
+                createAttachment('state1-actual.png')
+            ];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.error?.name, ErrorName.IMAGE_DIFF);
         });
@@ -183,7 +208,12 @@ describe('PlaywrightTestResultAdapter', () => {
                 {message: 'Error: expect(page).toHaveScreenshot(expected) failed\n\n  Snapshot: state1.png'},
                 {message: 'Error: expect(locator).toHaveScreenshot(expected) failed'}
             ];
-            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+            const attachments = [
+                createAttachment('state1-expected.png'),
+                createAttachment('state1-diff.png'),
+                createAttachment('state1-actual.png')
+            ];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
 
             assert.equal(adapter.error?.name, ErrorName.GENERAL_ERROR);
         });

--- a/test/unit/lib/adapters/test-result/playwright.ts
+++ b/test/unit/lib/adapters/test-result/playwright.ts
@@ -115,6 +115,79 @@ describe('PlaywrightTestResultAdapter', () => {
             assert.strictEqual(error?.stack, errorStack);
         });
 
+        ['locator', 'page', 'Buffer'].forEach(receiver => {
+            it(`should recognize modern ${receiver} screenshot diffs`, () => {
+                const matcher = receiver === 'Buffer' ? 'toMatchSnapshot' : 'toHaveScreenshot';
+                const suffix = receiver === 'Buffer' ? '' : ' failed';
+                const errors = [{message: `Error: expect(${receiver}).${matcher}(expected)${suffix}\n\n  Snapshot: state1.png`}];
+                const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+
+                assert.equal(adapter.error?.name, ErrorName.IMAGE_DIFF);
+                assert.equal(adapter.status, FAIL);
+            });
+        });
+
+        ['Screenshot comparison failed', 'Error: expect(page).toHaveScreenshot(expected) failed'].forEach(message => {
+            it(`should preserve other failures alongside "${message}"`, () => {
+                const errors = [{message}, {message: 'Error: expect(received).toBe(expected)'}];
+                const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+
+                assert.equal(adapter.error?.name, ErrorName.GENERAL_ERROR);
+                assert.equal(adapter.status, ERROR);
+            });
+        });
+
+        it('should not treat screenshot capture failures as acceptable diffs', () => {
+            const errors = [{message: 'Error: expect(locator).toHaveScreenshot(expected) failed\n\n  Snapshot: state1.png'}];
+            const attachments = [createAttachment('state1-actual.png'), createAttachment('state1-previous.png')];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
+
+            assert.equal(adapter.error?.name, ErrorName.GENERAL_ERROR);
+            assert.equal(adapter.status, ERROR);
+        });
+
+        it('should match diff attachments to the failing snapshot', () => {
+            const errors = [{message: 'Error: expect(locator).toHaveScreenshot(expected) failed\n\n  Snapshot: state2.png'}];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+
+            assert.equal(adapter.error?.name, ErrorName.GENERAL_ERROR);
+        });
+
+        it('should recognize an unnamed modern screenshot diff', () => {
+            const errors = [{message: 'Error: expect(page).toHaveScreenshot(expected) failed'}];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+
+            assert.equal(adapter.error?.name, ErrorName.IMAGE_DIFF);
+        });
+
+        it('should recognize modern screenshot diffs with ANSI formatting', () => {
+            const errors = [{message: 'Error: \u001b[31mexpect(page).toHaveScreenshot(expected)\u001b[39m failed\n\n  Snapshot: state1.png'}];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+
+            assert.equal(adapter.error?.name, ErrorName.IMAGE_DIFF);
+        });
+
+        it('should recognize multiple named soft screenshot diffs', () => {
+            const errors = ['state1', 'state2'].map(state => ({
+                message: `Error: expect(locator).toHaveScreenshot(expected) failed\n\n  Snapshot: ${state}.png`
+            }));
+            const attachments = ['state1', 'state2'].flatMap(state =>
+                [ImageTitleEnding.Expected, ImageTitleEnding.Actual, ImageTitleEnding.Diff].map(ending => createAttachment(state + ending)));
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
+
+            assert.equal(adapter.error?.name, ErrorName.IMAGE_DIFF);
+        });
+
+        it('should not associate an unnamed capture error with another soft assertion diff', () => {
+            const errors = [
+                {message: 'Error: expect(page).toHaveScreenshot(expected) failed\n\n  Snapshot: state1.png'},
+                {message: 'Error: expect(locator).toHaveScreenshot(expected) failed'}
+            ];
+            const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors}), UNKNOWN_ATTEMPT);
+
+            assert.equal(adapter.error?.name, ErrorName.GENERAL_ERROR);
+        });
+
         it('should convert multiple errors to a single JSON string', () => {
             const errors = [
                 {message: 'First error', stack: 'Error: First error at some-file.ts:5:10'},

--- a/test/unit/lib/adapters/test-result/playwright.ts
+++ b/test/unit/lib/adapters/test-result/playwright.ts
@@ -115,11 +115,9 @@ describe('PlaywrightTestResultAdapter', () => {
             assert.strictEqual(error?.stack, errorStack);
         });
 
-        ['locator', 'page', 'Buffer'].forEach(receiver => {
+        ['locator', 'page'].forEach(receiver => {
             it(`should recognize modern ${receiver} screenshot diffs`, () => {
-                const matcher = receiver === 'Buffer' ? 'toMatchSnapshot' : 'toHaveScreenshot';
-                const suffix = receiver === 'Buffer' ? '' : ' failed';
-                const errors = [{message: `Error: expect(${receiver}).${matcher}(expected)${suffix}\n\n  Snapshot: state1.png`}];
+                const errors = [{message: `Error: expect(${receiver}).toHaveScreenshot(expected) failed\n\n  Snapshot: state1.png`}];
                 const attachments = [
                     createAttachment('state1-expected.png'),
                     createAttachment('state1-diff.png'),
@@ -129,21 +127,6 @@ describe('PlaywrightTestResultAdapter', () => {
 
                 assert.equal(adapter.error?.name, ErrorName.IMAGE_DIFF);
                 assert.equal(adapter.status, FAIL);
-            });
-        });
-
-        ['Screenshot comparison failed', 'Error: expect(page).toHaveScreenshot(expected) failed'].forEach(message => {
-            it(`should preserve other failures alongside "${message}"`, () => {
-                const errors = [{message}, {message: 'Error: expect(received).toBe(expected)'}];
-                const attachments = [
-                    createAttachment('state1-expected.png'),
-                    createAttachment('state1-diff.png'),
-                    createAttachment('state1-actual.png')
-                ];
-                const adapter = new PlaywrightTestResultAdapter(mkTestCase(), mkTestResult({errors, attachments}), UNKNOWN_ATTEMPT);
-
-                assert.equal(adapter.error?.name, ErrorName.GENERAL_ERROR);
-                assert.equal(adapter.status, ERROR);
             });
         });
 


### PR DESCRIPTION
Playwright 1.59.1 reports screenshot mismatches as:

```text
Error: expect(page).toHaveScreenshot(expected) failed
```

The adapter only recognizes `Screenshot comparison failed`, so it marks these as general errors even when expected/actual/diff images are attached. Accept can then leave a stale error instead of resolving the visual failure.

This adds support for the newer page/locator `toHaveScreenshot` header. Playwright uses the same header when it cannot take a screenshot, so the adapter also checks for matching expected/actual/diff attachments. The old `Screenshot comparison failed` handling stays unchanged.

Only the adapter and its unit tests change. `toMatchSnapshot`, changes to legacy mixed-error handling, and platform handling are outside this PR.

### Reproduction

With Playwright 1.59.1 and `html-reporter/playwright`:

```ts
import {test, expect} from '@playwright/test';

test('screenshot mismatch', async ({page}) => {
    const color = process.env.CHANGED ? 'blue' : 'red';
    await page.setContent(`<div style="width:120px;height:80px;background:${color}"></div>`);
    await expect(page).toHaveScreenshot('example.png');
});
```

```sh
npx playwright test --update-snapshots
CHANGED=1 npx playwright test
```

Before: `error` / `Error`. After: `fail` / `ImageDiffError`.

### Tests

- All 30 adapter tests pass, including page/locator diffs, capture failures, snapshot attachment matching, unnamed diffs, ANSI formatting, and multiple soft screenshot assertions.
- `npm test` passes on Node 20.19.6: lint, Node and jsdom unit tests, and type checks.

The full GUI e2e suite and interactive Accept/Undo weren't rerun for this isolated fix.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.
